### PR TITLE
Fix MCP protocol version compatibility

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -188,7 +188,7 @@ export async function startFixedHTTPServer() {
               response = {
                 jsonrpc: '2.0',
                 result: {
-                  protocolVersion: '1.0',
+                  protocolVersion: '2024-11-05',
                   capabilities: {
                     tools: {},
                     resources: {}


### PR DESCRIPTION
Updates MCP protocol version from '1.0' to '2024-11-05' to resolve compatibility issues with modern MCP clients and ensure proper protocol negotiation.