### PR TITLE
Fix MCP schema validation: Add additionalProperties to workflow nodes array

### DIFF
--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -140,7 +140,11 @@ export const n8nManagementTools: ToolDefinition[] = [
         },
         nodes: { 
           type: 'array', 
-          description: 'Complete array of workflow nodes (required if modifying workflow structure)' 
+          description: 'Complete array of workflow nodes (required if modifying workflow structure)',
+          items: {
+            type: 'object',
+            additionalProperties: true
+          }
         },
         connections: { 
           type: 'object', 


### PR DESCRIPTION
## 🐛 Problem
This fix resolves MCP schema validation conflicts with dynamic node properties.

**Root cause:** n8n workflow nodes contain dynamic properties that vary by node type, which requires `additionalProperties: true` for proper MCP validation.

The `n8n_update_full_workflow` MCP tool was failing validation in VSCode Desktop with the error:
```
"additional properties not allowed" 
```

This occurred when the tool attempted to validate workflow node objects against the MCP schema, causing workflow management operations to fail.

## 🔧 Solution
Added `additionalProperties: true` to the `nodes` array schema in the `n8n_update_full_workflow` tool definition.

**File changed:** `src/mcp/tools-n8n-manager.ts`

**Specific change:**
```typescript
nodes: { 
  type: 'array', 
  description: 'Complete array of workflow nodes (required if modifying workflow structure)',
  items: {
-   type: 'object'
+   type: 'object',
+   additionalProperties: true
  }
}
```

## 🎯 Impact
- ✅ **Fixes VSCode Desktop compatibility** - MCP tools now validate correctly
- ✅ **Improves tool reliability** - Prevents validation failures during workflow operations  
- ✅ **No breaking changes** - Only adds permissive schema validation
- ✅ **Affects 1 tool** - `n8n_update_full_workflow` in the n8n management suite