### PR TITLE
readme update to use host container n8n

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Add to Claude Desktop config:
 
 >💡 Tip: If you’re running n8n locally on the same machine (e.g., via Docker), use http://host.docker.internal:5678 as the N8N_API_URL.
 
-
 > **Note**: The n8n API credentials are optional. Without them, you'll have access to all documentation and validation tools. With them, you'll additionally get workflow management capabilities (create, update, execute workflows).
 
 **Important:** The `-i` flag is required for MCP stdio communication.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Add to Claude Desktop config:
 }
 ```
 
+>💡 Tip: If you’re running n8n locally on the same machine (e.g., via Docker), use http://host.docker.internal:5678 as the N8N_API_URL.
+
+
 > **Note**: The n8n API credentials are optional. Without them, you'll have access to all documentation and validation tools. With them, you'll additionally get workflow management capabilities (create, update, execute workflows).
 
 **Important:** The `-i` flag is required for MCP stdio communication.
@@ -188,6 +191,8 @@ Add to Claude Desktop config:
 ```
 
 > **Note**: The n8n API credentials can be configured either in a `.env` file (create from `.env.example`) or directly in the Claude config as shown above.
+
+> 💡 Tip: If you’re running n8n locally on the same machine (e.g., via Docker), use http://host.docker.internal:5678 as the N8N_API_URL.
 
 ## 🤖 Claude Project Setup
 


### PR DESCRIPTION
I noticed some confusion around how to correctly configure the N8N_API_URL when n8n is running locally, https://youtu.be/xf2i6Acs1mI?t=510

This PR adds a helpful note to clarify that when n8n is running on the host machine (e.g., via Docker or a local instance), the correct value for N8N_API_URL is:

```
http://host.docker.internal:5678
```

This is a commonly supported hostname that allows a containerized MCP server to communicate with a service on the host machine.