### PR TITLE
fix: exclude documentation changes from Docker builds and fix tag generation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,9 +7,25 @@ on:
       - main
     tags:
       - 'v*'
+    paths-ignore:
+      - '**.md'
+      - '.github/FUNDING.yml'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - 'LICENSE'
+      - 'ATTRIBUTION.md'
+      - 'docs/**'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - '.github/FUNDING.yml'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/pull_request_template.md'
+      - 'LICENSE'
+      - 'ATTRIBUTION.md'
+      - 'docs/**'
   workflow_dispatch:
 
 env:
@@ -56,7 +72,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix={{branch}}-,format=short
+            type=sha,format=short
             type=raw,value=latest,enable={{is_default_branch}}
             
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary
- Add paths-ignore to skip Docker builds for documentation-only changes
- Fix invalid Docker tag format that was causing build failures

## Problem
The Docker workflow was:
1. Running unnecessarily for documentation-only changes (like FUNDING.yml)
2. Generating invalid tags like `ghcr.io/czlonkowski/n8n-mcp:-b5e0797` due to the branch prefix in SHA tags

## Solution
- Added `paths-ignore` configuration to exclude common documentation files
- Removed the problematic `prefix={{branch}}-` from the SHA tag generation
- This prevents unnecessary builds and fixes the tag format error

## Test plan
- [x] Documentation-only PRs (like #48) will no longer trigger Docker builds
- [x] SHA tags will be generated without branch prefix, avoiding invalid formats
- [x] Regular code changes will still trigger Docker builds as expected

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>