### PR TITLE
Update CLAUDE_CODE_SETUP.md

### DIFF
--- a/docs/CLAUDE_CODE_SETUP.md
+++ b/docs/CLAUDE_CODE_SETUP.md
@@ -42,7 +42,7 @@ claude mcp add-from-claude-desktop
 For team sharing, add to `.mcp.json` in your project root:
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "n8n-mcp": {
       "command": "npx",
       "args": ["n8n-mcp"],


### PR DESCRIPTION
fix .mcp.json file for Claude code setup Project configuration

Claude Code expects the key `"mcpServers"` instead of `"servers"`