### PR TITLE
fix: Ensure error.message is a string before checking for specific messages in workflow validator

### DIFF
--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -964,9 +964,9 @@ export class WorkflowValidator {
     }
 
     // Suggest proper connection structure for workflows with connection errors
-    const hasConnectionErrors = result.errors.some(e => 
-      e.message && (
-        e.message.includes('connection') || 
+    const hasConnectionErrors = result.errors.some(e =>
+      typeof e.message === 'string' && (
+        e.message.includes('connection') ||
         e.message.includes('Connection') ||
         e.message.includes('Multi-node workflow has no connections')
       )


### PR DESCRIPTION
## Summary

Fix "Workflow validation failed: e.message.includes is not a function" error by ensuring `e.message` is a string before calling `.includes`. This issue occurs during workflow validation, but it's unclear whether the root cause is in [n8n](https://github.com/n8n-io/n8n) or [n8n-mcp](https://github.com/czlonkowski/n8n-mcp) ([workflow-validator.ts](https://github.com/czlonkowski/n8n-mcp/blob/main/src/services/workflow-validator.ts)).

Added a defensive type check to avoid runtime failures.

## Related Github issues

https://github.com/n8n-io/n8n/issues/17413