### PR TITLE
Use wget since n8n image goes not have curl

### DIFF
--- a/docker-compose.n8n.yml
+++ b/docker-compose.n8n.yml
@@ -22,7 +22,7 @@ services:
     networks:
       - n8n-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5678/healthz"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:5678/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.n8n.yml` file. The change updates the `healthcheck` configuration to use `wget` instead of `curl` for testing the health of the service.