### PR TITLE
Support self-signed SSL certificates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,3 +216,10 @@ ENABLE_MULTI_TENANT=false
 N8N_TEST_CLEANUP_ENABLED=true         # Enable automatic cleanup of test workflows
 N8N_TEST_TAG=mcp-integration-test     # Tag applied to all test workflows
 N8N_TEST_NAME_PREFIX=[MCP-TEST]       # Name prefix for test workflows
+
+# Custom SSL certificate for self-signed n8n instances
+# Path to the server's .crt file (absolute or relative)
+# Supports both CA certificates and self-signed server certificates
+# Example: N8N_CERT_PATH=/path/to/n8n-server.crt
+# Docker: Mount certificate and use container path (e.g., /app/certs/n8n.crt)
+# N8N_CERT_PATH=

--- a/README.md
+++ b/README.md
@@ -474,6 +474,125 @@ Deploy n8n-MCP to Railway's cloud platform with zero configuration:
 
 **Restart Claude Desktop after updating configuration** - That's it! 🎉
 
+## 🔐 SSL/TLS Configuration
+
+### Using Custom CA Certificates (Recommended)
+
+If your n8n instance uses a custom or self-signed SSL certificate, configure the `N8N_CERT_PATH` environment variable to point to your certificate file (PEM format):
+
+- For self-signed certificates: provide the server's certificate itself
+- For custom CA: provide the CA certificate that signed the server's certificate
+
+This approach maintains full SSL verification while trusting your specific certificate.
+
+### Using with npx
+
+Add the certificate path to your Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "n8n-mcp": {
+      "command": "npx",
+      "args": ["n8n-mcp"],
+      "env": {
+        "MCP_MODE": "stdio",
+        "LOG_LEVEL": "error",
+        "DISABLE_CONSOLE_OUTPUT": "true",
+        "N8N_API_URL": "https://your-n8n-instance.com",
+        "N8N_API_KEY": "your-api-key",
+        "N8N_CERT_PATH": "/path/to/your/certificate.crt"
+      }
+    }
+  }
+}
+```
+
+### Using with Docker
+
+Mount your certificate file as a volume and set the environment variable:
+
+```bash
+docker run -i --rm --init \
+  -v /path/to/your/certificate.crt:/app/certs/n8n.crt:ro \
+  -e MCP_MODE=stdio \
+  -e LOG_LEVEL=error \
+  -e DISABLE_CONSOLE_OUTPUT=true \
+  -e N8N_API_URL=https://your-n8n-instance.com \
+  -e N8N_API_KEY=your-api-key \
+  -e N8N_CERT_PATH=/app/certs/n8n.crt \
+  ghcr.io/czlonkowski/n8n-mcp:latest
+```
+
+For Claude Desktop configuration with Docker:
+
+```json
+{
+  "mcpServers": {
+    "n8n-mcp": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm", "--init",
+        "-v", "/path/to/your/certificate.crt:/app/certs/n8n.crt:ro",
+        "-e", "MCP_MODE=stdio",
+        "-e", "LOG_LEVEL=error",
+        "-e", "DISABLE_CONSOLE_OUTPUT=true",
+        "-e", "N8N_API_URL=https://your-n8n-instance.com",
+        "-e", "N8N_API_KEY=your-api-key",
+        "-e", "N8N_CERT_PATH=/app/certs/n8n.crt",
+        "ghcr.io/czlonkowski/n8n-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+### Using with docker-compose
+
+See the commented certificate configuration in `docker-compose.yml` and `docker-compose.n8n.yml`. Uncomment the relevant sections and adjust the certificate path.
+
+### Troubleshooting Certificate Issues
+
+Common issues and quick fixes:
+- **UNABLE_TO_VERIFY_LEAF_SIGNATURE** → Missing root certificate in your bundle
+- **SELF_SIGNED_CERT_IN_CHAIN** → Configure certificate as trusted CA or skip verification
+- **ERR_TLS_CERT_ALTNAME_INVALID** → Domain name doesn't match certificate
+
+📚 **For detailed solutions, see our [SSL Troubleshooting Guide](./docs/SSL_TROUBLESHOOTING.md)** which covers:
+- Complete error messages and solutions
+- How to create proper certificate bundles
+- Diagnostic commands and debugging tips
+- Solutions for Let's Encrypt, self-signed, and corporate certificates
+
+### Disabling SSL Verification (Development Only)
+
+⚠️ **WARNING**: This option completely disables SSL certificate verification and should ONLY be used for local development or testing environments.
+
+If you're unable to provide a valid certificate and need to connect to a development server, you can disable SSL verification:
+
+```json
+{
+  "mcpServers": {
+    "n8n-mcp": {
+      "command": "npx",
+      "args": ["n8n-mcp"],
+      "env": {
+        "MCP_MODE": "stdio",
+        "N8N_API_URL": "https://your-n8n-instance.com",
+        "N8N_API_KEY": "your-api-key",
+        "N8N_SKIP_SSL_VERIFICATION": "true"
+      }
+    }
+  }
+}
+```
+
+**Important Security Notes**:
+- Never use `N8N_SKIP_SSL_VERIFICATION` in production environments
+- This disables protection against man-in-the-middle attacks
+- Always prefer providing the correct certificate via `N8N_CERT_PATH`
+- The server will log warnings when SSL verification is disabled
+
 ## 🔧 n8n Integration
 
 Want to use n8n-MCP with your n8n instance? Check out our comprehensive [n8n Deployment Guide](./docs/N8N_DEPLOYMENT.md) for:

--- a/docker-compose.n8n.yml
+++ b/docker-compose.n8n.yml
@@ -48,9 +48,18 @@ services:
       - MCP_AUTH_TOKEN=${MCP_AUTH_TOKEN}
       - AUTH_TOKEN=${MCP_AUTH_TOKEN}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+
+      # Optional: Self-signed certificate support
+      # Uncomment if your n8n instance uses a self-signed SSL certificate
+      # Note: Also uncomment the corresponding volume mount below
+      # - N8N_CERT_PATH=/app/certs/n8n.crt
     volumes:
       - ./data:/app/data:ro
       - mcp_logs:/app/logs
+
+      # Optional: Mount certificate file for self-signed n8n instances
+      # Uncomment and adjust the path to your certificate file
+      # - /path/to/your/certificate.crt:/app/certs/n8n.crt:ro
     networks:
       - n8n-network
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,10 +34,19 @@ services:
       # N8N_API_KEY: ${N8N_API_KEY}
       # N8N_API_TIMEOUT: ${N8N_API_TIMEOUT:-30000}
       # N8N_API_MAX_RETRIES: ${N8N_API_MAX_RETRIES:-3}
+
+      # Optional: Self-signed certificate support
+      # Uncomment if your n8n instance uses a self-signed SSL certificate
+      # N8N_CERT_PATH: /app/certs/n8n.crt
     
     # Volumes for persistence
     volumes:
       - n8n-mcp-data:/app/data
+
+      # Optional: Mount certificate file for self-signed n8n instances
+      # Uncomment and adjust the path to your certificate file
+      # Example: ./certs/n8n.crt:/app/certs/n8n.crt:ro
+      # - /path/to/your/certificate.crt:/app/certs/n8n.crt:ro
     
     # Port mapping
     ports:

--- a/docs/DOCKER_README.md
+++ b/docs/DOCKER_README.md
@@ -68,6 +68,7 @@ docker run -d \
 | `AUTH_RATE_LIMIT_WINDOW` | Rate limit window in ms (v2.16.3+) | `900000` (15 min) | No |
 | `AUTH_RATE_LIMIT_MAX` | Max auth attempts per window (v2.16.3+) | `20` | No |
 | `WEBHOOK_SECURITY_MODE` | SSRF protection: `strict`/`moderate`/`permissive` (v2.16.3+) | `strict` | No |
+| `N8N_CERT_PATH` | Path to SSL certificate for self-signed n8n instances | - | No |
 
 *Either `AUTH_TOKEN` or `AUTH_TOKEN_FILE` must be set for HTTP mode. If both are set, `AUTH_TOKEN` takes precedence.
 
@@ -286,6 +287,7 @@ docker ps --format "table {{.Names}}\t{{.Status}}"
 docker inspect n8n-mcp | jq '.[0].State.Health'
 ```
 
+<<<<<<< HEAD
 ## 🔒 Security Features (v2.16.3+)
 
 ### Rate Limiting
@@ -377,6 +379,76 @@ your-domain.com {
 - Read-only root filesystem compatible
 - No unnecessary packages installed
 - Regular security updates via GitHub Actions
+
+## 🔐 SSL Certificate Configuration
+
+### Self-Signed Certificates
+
+If your n8n instance uses a self-signed SSL certificate, you need to mount the certificate file and configure the `N8N_CERT_PATH` environment variable:
+
+#### Basic Docker Run
+
+```bash
+# Run with mounted certificate
+docker run -d \
+  --name n8n-mcp \
+  -e MCP_MODE=http \
+  -e AUTH_TOKEN=your-secure-token \
+  -e N8N_API_URL=https://your-n8n-instance.com \
+  -e N8N_API_KEY=your-api-key \
+  -e N8N_CERT_PATH=/app/certs/n8n.crt \
+  -v /path/to/your/certificate.crt:/app/certs/n8n.crt:ro \
+  -p 3000:3000 \
+  ghcr.io/czlonkowski/n8n-mcp:latest
+```
+
+#### Docker Compose Configuration
+
+Add certificate configuration to your `docker-compose.yml`:
+
+```yaml
+services:
+  n8n-mcp:
+    image: ghcr.io/czlonkowski/n8n-mcp:latest
+    environment:
+      MCP_MODE: http
+      AUTH_TOKEN: ${AUTH_TOKEN}
+      N8N_API_URL: https://your-n8n-instance.com
+      N8N_API_KEY: ${N8N_API_KEY}
+      N8N_CERT_PATH: /app/certs/n8n.crt
+    volumes:
+      - n8n-mcp-data:/app/data
+      - /path/to/your/certificate.crt:/app/certs/n8n.crt:ro
+    ports:
+      - "3000:3000"
+```
+
+#### Certificate Troubleshooting
+
+**Common Issues:**
+
+1. **Certificate not found error:**
+   ```bash
+   # Verify the certificate is properly mounted
+   docker exec n8n-mcp ls -la /app/certs/
+   ```
+
+2. **Permission denied:**
+   ```bash
+   # Ensure certificate is readable
+   chmod 644 /path/to/your/certificate.crt
+   ```
+
+3. **Invalid certificate format:**
+   - Certificate must be in PEM format (.crt or .pem)
+   - Check with: `openssl x509 -in certificate.crt -text -noout`
+
+4. **Still can't connect:**
+   ```bash
+   # Test certificate directly
+   openssl s_client -connect your-n8n-instance.com:443 \
+     -CAfile /path/to/your/certificate.crt -showcerts
+   ```
 
 ## 📊 Resource Management
 

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -137,6 +137,69 @@ Skip HTTP entirely and use stdio mode directly:
 
 💡 **Save your AUTH_TOKEN** - clients will need it to connect!
 
+### Self-Signed Certificates
+
+If your n8n instance uses a self-signed SSL certificate, you need to configure the `N8N_CERT_PATH` environment variable:
+
+#### Docker with Certificate
+
+```bash
+# 1. Create environment file with certificate path
+cat > .env << EOF
+AUTH_TOKEN=$(openssl rand -base64 32)
+USE_FIXED_HTTP=true
+MCP_MODE=http
+PORT=3000
+N8N_CERT_PATH=/app/certs/n8n.crt
+N8N_API_URL=https://your-n8n-instance.com
+N8N_API_KEY=your-api-key-here
+EOF
+
+# 2. Deploy with Docker and mount certificate
+docker run -d \
+  --name n8n-mcp \
+  --restart unless-stopped \
+  --env-file .env \
+  -v /path/to/your/certificate.crt:/app/certs/n8n.crt:ro \
+  -p 3000:3000 \
+  ghcr.io/czlonkowski/n8n-mcp:latest
+```
+
+#### Docker Compose with Certificate
+
+Add the following to your `docker-compose.yml`:
+
+```yaml
+services:
+  n8n-mcp:
+    image: ghcr.io/czlonkowski/n8n-mcp:latest
+    environment:
+      # ... other environment variables ...
+      N8N_CERT_PATH: /app/certs/n8n.crt
+    volumes:
+      - n8n-mcp-data:/app/data
+      - /path/to/your/certificate.crt:/app/certs/n8n.crt:ro
+```
+
+#### Local Development with Certificate
+
+```bash
+# Set the certificate path
+export N8N_CERT_PATH=/path/to/your/certificate.crt
+export N8N_API_URL=https://your-n8n-instance.com
+export N8N_API_KEY=your-api-key
+
+# Start the server
+npm run start:http
+```
+
+#### Certificate Troubleshooting
+
+- **Format**: Certificate must be in PEM format (.crt or .pem file)
+- **Permissions**: Ensure the certificate file is readable by the process
+- **Path**: Use absolute paths to avoid resolution issues
+- **Testing**: You can test the certificate with `openssl s_client -connect your-n8n-instance.com:443 -showcerts`
+
 ## ⚙️ Configuration
 
 ### Required Environment Variables

--- a/docs/SSL_TROUBLESHOOTING.md
+++ b/docs/SSL_TROUBLESHOOTING.md
@@ -1,0 +1,345 @@
+# SSL/TLS Certificate Troubleshooting Guide
+
+This guide helps you resolve SSL certificate issues when connecting n8n-MCP to your n8n instance.
+
+## 📋 Table of Contents
+- [Quick Solutions](#quick-solutions)
+- [Understanding the Problem](#understanding-the-problem)
+- [Common Errors and Solutions](#common-errors-and-solutions)
+- [Creating a Complete Certificate Bundle](#creating-a-complete-certificate-bundle)
+- [Diagnostic Commands](#diagnostic-commands)
+- [Solutions by Certificate Type](#solutions-by-certificate-type)
+- [Best Practices](#best-practices)
+
+## Quick Solutions
+
+| Problem | Quick Fix |
+|---------|-----------|
+| **UNABLE_TO_VERIFY_LEAF_SIGNATURE** | Add root certificate to your bundle |
+| **SELF_SIGNED_CERT_IN_CHAIN** | Use the self-signed cert as CA |
+| **Certificate verification failed** | Ensure complete certificate chain |
+| **Works with curl but not Node.js** | Node.js needs the full chain including root |
+
+## Understanding the Problem
+
+### Node.js vs curl Behavior
+
+**Important:** Node.js has stricter certificate validation than curl:
+- **curl**: Often works with just intermediate certificates
+- **Node.js**: Requires the complete certificate chain including the root CA
+
+This is why your n8n instance might work fine in a browser or with curl, but fail with n8n-MCP.
+
+### Certificate Chain Structure
+
+A complete certificate chain consists of:
+```
+1. Server Certificate (your domain)
+   ↓
+2. Intermediate Certificate(s) (optional)
+   ↓  
+3. Root Certificate (trusted CA)
+```
+
+Node.js needs ALL three levels to validate the connection.
+
+## Common Errors and Solutions
+
+### 1. UNABLE_TO_VERIFY_LEAF_SIGNATURE
+
+**Error Message:**
+```
+Error: unable to verify the first certificate
+```
+
+**Cause:** Missing root certificate in the chain.
+
+**Solution:**
+```bash
+# Create a complete bundle with root certificate
+cat fullchain.pem root.pem > complete-bundle.pem
+
+# Use the complete bundle
+export N8N_CERT_PATH=/path/to/complete-bundle.pem
+```
+
+### 2. SELF_SIGNED_CERT_IN_CHAIN
+
+**Error Message:**
+```
+Error: self signed certificate in certificate chain
+```
+
+**Cause:** Using a self-signed certificate without proper configuration.
+
+**Solution:**
+```bash
+# For self-signed certificates, use the certificate itself as CA
+export N8N_CERT_PATH=/path/to/self-signed-cert.pem
+
+# Or if you must, disable verification (development only!)
+export N8N_SKIP_SSL_VERIFICATION=true
+```
+
+### 3. CERT_HAS_EXPIRED
+
+**Error Message:**
+```
+Error: certificate has expired
+```
+
+**Cause:** The SSL certificate has passed its expiration date.
+
+**Solution:**
+```bash
+# Check certificate expiration
+openssl x509 -in cert.pem -noout -dates
+
+# Renew your certificate through your certificate provider:
+# - Let's Encrypt: certbot renew
+# - Commercial CA: Contact your provider or use their portal
+# - Self-signed: Generate a new certificate
+```
+
+### 4. ERR_TLS_CERT_ALTNAME_INVALID
+
+**Error Message:**
+```
+Error: Hostname/IP does not match certificate's altnames
+```
+
+**Cause:** The certificate doesn't match the domain you're connecting to.
+
+**Solution:**
+```bash
+# Check certificate domains
+openssl x509 -in cert.pem -noout -text | grep -A1 "Subject Alternative Name"
+
+# Ensure N8N_API_URL matches the certificate domain
+export N8N_API_URL=https://correct-domain.com
+```
+
+### 5. Incomplete Certificate Chain
+
+**Error Message:**
+```
+Error: unable to get local issuer certificate
+```
+
+**Cause:** Missing intermediate or root certificates.
+
+**Solution:** Create a complete certificate bundle (see next section).
+
+## Creating a Complete Certificate Bundle
+
+### For Let's Encrypt Certificates
+
+Let's Encrypt certificates often need the ISRG Root X1 certificate:
+
+```bash
+# 1. Download ISRG Root X1 (Let's Encrypt root)
+wget https://letsencrypt.org/certs/isrgrootx1.pem
+
+# 2. Create complete bundle (order matters!)
+cat /etc/letsencrypt/live/yourdomain/fullchain.pem isrgrootx1.pem > complete-bundle.pem
+
+# 3. Use the complete bundle
+export N8N_CERT_PATH=/path/to/complete-bundle.pem
+```
+
+### Certificate Bundle Order
+
+The correct order in your PEM file should be:
+```
+-----BEGIN CERTIFICATE-----
+[Your server certificate]
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+[Intermediate certificate]
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+[Root certificate]
+-----END CERTIFICATE-----
+```
+
+### Verify Your Bundle
+
+```bash
+# Verify the certificate chain
+openssl verify -CAfile complete-bundle.pem complete-bundle.pem
+
+# Should output: complete-bundle.pem: OK
+```
+
+## Diagnostic Commands
+
+### 1. Test SSL Connection
+
+```bash
+# Test with openssl
+openssl s_client -connect your-n8n-instance.com:443 -showcerts
+
+# Test with Node.js (same as n8n-MCP)
+node -e "
+const https = require('https');
+const fs = require('fs');
+const ca = fs.readFileSync('complete-bundle.pem');
+https.get('https://your-n8n-instance.com', {ca}, (res) => {
+  console.log('Success! Status:', res.statusCode);
+}).on('error', (e) => {
+  console.error('Error:', e.message);
+});
+"
+```
+
+### 2. Debug TLS Issues
+
+```bash
+# Enable Node.js TLS debugging
+NODE_DEBUG=tls node your-script.js
+
+# This will show detailed TLS handshake information
+```
+
+### 3. Inspect Certificate Details
+
+```bash
+# View certificate information
+openssl x509 -in cert.pem -text -noout
+
+# Check certificate chain
+openssl crl2pkcs7 -nocrl -certfile fullchain.pem | \
+  openssl pkcs7 -print_certs -text -noout | \
+  grep -E "Subject:|Issuer:"
+```
+
+### 4. Compare curl vs Node.js
+
+```bash
+# Test with curl (often works)
+curl -v https://your-n8n-instance.com
+
+# Test with Node.js (might fail without root cert)
+node -e "require('https').get('https://your-n8n-instance.com', r => console.log('OK')).on('error', e => console.error(e.message))"
+```
+
+## Solutions by Certificate Type
+
+### Let's Encrypt / Certbot
+
+```bash
+# Standard setup
+export N8N_CERT_PATH=/etc/letsencrypt/live/yourdomain/fullchain.pem
+
+# If that fails, create bundle with root
+cat /etc/letsencrypt/live/yourdomain/fullchain.pem \
+    <(wget -qO- https://letsencrypt.org/certs/isrgrootx1.pem) \
+    > /tmp/complete-bundle.pem
+export N8N_CERT_PATH=/tmp/complete-bundle.pem
+```
+
+### Self-Signed Certificates
+
+```bash
+# Generate self-signed certificate
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes
+
+# Use the certificate itself as CA
+export N8N_CERT_PATH=/path/to/cert.pem
+```
+
+### Corporate/Custom CA
+
+```bash
+# Get your CA certificate from IT department
+# Combine if necessary
+cat server-cert.pem intermediate-ca.pem root-ca.pem > bundle.pem
+export N8N_CERT_PATH=/path/to/bundle.pem
+```
+
+### CloudFlare Origin Certificates
+
+```bash
+# Download CloudFlare's origin CA
+wget https://developers.cloudflare.com/ssl/static/origin_ca_rsa_root.pem
+
+# Use as CA
+export N8N_CERT_PATH=/path/to/origin_ca_rsa_root.pem
+```
+
+## Best Practices
+
+### 1. Always Test Your Configuration
+
+```bash
+# Create a test script
+cat > test-ssl.js << 'EOF'
+const https = require('https');
+const fs = require('fs');
+
+const ca = fs.readFileSync(process.env.N8N_CERT_PATH);
+const url = process.env.N8N_API_URL;
+
+https.get(url, {ca}, (res) => {
+  console.log('✅ SSL connection successful!');
+  console.log('Status:', res.statusCode);
+  process.exit(0);
+}).on('error', (e) => {
+  console.error('❌ SSL connection failed:', e.message);
+  process.exit(1);
+});
+EOF
+
+node test-ssl.js
+```
+
+### 2. Security Recommendations
+
+1. **Never use `N8N_SKIP_SSL_VERIFICATION` in production**
+2. **Keep certificates up to date** - Set up auto-renewal
+3. **Use proper certificate storage** - Secure file permissions (600 or 400)
+4. **Monitor expiration dates** - Set up alerts
+
+### 3. Certificate File Permissions
+
+```bash
+# Secure your certificate files
+chmod 600 /path/to/cert.pem
+chown $USER:$USER /path/to/cert.pem
+```
+
+## Still Having Issues?
+
+If you're still experiencing problems:
+
+1. **Verify the basics:**
+   ```bash
+   # Check file exists and is readable
+   ls -la $N8N_CERT_PATH
+   
+   # Check it's valid PEM format
+   openssl x509 -in $N8N_CERT_PATH -text -noout
+   ```
+
+2. **Try the nuclear option (development only!):**
+   ```bash
+   export N8N_SKIP_SSL_VERIFICATION=true
+   ```
+   ⚠️ **WARNING**: This completely disables SSL verification and should NEVER be used in production.
+
+3. **Get help:**
+   - Check the [main troubleshooting guide](../README.md#troubleshooting)
+   - Open an issue on [GitHub](https://github.com/czlonkowski/n8n-mcp/issues)
+   - Include your error message and `NODE_DEBUG=tls` output
+
+## Summary
+
+The key points to remember:
+
+1. **Node.js needs the complete certificate chain** including the root certificate
+2. **Certificate order matters**: Server → Intermediate → Root
+3. **Test with Node.js**, not just curl or browsers
+4. **Use `openssl verify`** to validate your certificate bundle
+5. **Enable `NODE_DEBUG=tls`** for detailed debugging information
+
+When in doubt, create a complete bundle with all certificates and use that with `N8N_CERT_PATH`.


### PR DESCRIPTION
This PR introduces support for self-signed SSL certificates when connecting to an n8n instance. Users can now specify a certificate path using the new N8N_CERT_PATH environment variable. Key changes include:

- Extended environment configuration (.env.example) to include N8N_CERT_PATH.
- Enhanced API client to load and use a custom certificate.
- Updated Docker-related docs and compose files with instructions and examples.
- README and deployment docs now include detailed usage and troubleshooting for self-signed certs.