### PR TITLE
Add isArchived field to workflow responses and types

### DIFF
--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -282,6 +282,7 @@ export async function handleGetWorkflowStructure(args: unknown): Promise<McpTool
         id: workflow.id,
         name: workflow.name,
         active: workflow.active,
+        isArchived: workflow.isArchived,
         nodes: simplifiedNodes,
         connections: workflow.connections,
         nodeCount: workflow.nodes.length,
@@ -325,6 +326,7 @@ export async function handleGetWorkflowMinimal(args: unknown): Promise<McpToolRe
         id: workflow.id,
         name: workflow.name,
         active: workflow.active,
+        isArchived: workflow.isArchived,
         tags: workflow.tags || [],
         createdAt: workflow.createdAt,
         updatedAt: workflow.updatedAt
@@ -470,6 +472,7 @@ export async function handleListWorkflows(args: unknown): Promise<McpToolRespons
       id: workflow.id,
       name: workflow.name,
       active: workflow.active,
+      isArchived: workflow.isArchived,
       createdAt: workflow.createdAt,
       updatedAt: workflow.updatedAt,
       tags: workflow.tags || [],

--- a/src/types/n8n-api.ts
+++ b/src/types/n8n-api.ts
@@ -49,6 +49,7 @@ export interface Workflow {
   nodes: WorkflowNode[];
   connections: WorkflowConnection;
   active?: boolean; // Optional for creation as it's read-only
+  isArchived?: boolean; // Optional, available in newer n8n versions
   settings?: WorkflowSettings;
   staticData?: Record<string, unknown>;
   tags?: string[];


### PR DESCRIPTION
# Add `isArchived` Property Support to Workflow Objects

## Summary

This PR adds support for the `isArchived` property in n8n workflow objects throughout the MCP server. The `isArchived` property was introduced in newer n8n versions as part of the soft-deletion functionality, allowing workflows to be archived rather than permanently deleted.

## Changes Made

### 1. Type System Updates
- **`src/types/n8n-api.ts`**: Added `isArchived?: boolean` property to the `Workflow` interface
- Properly typed as optional to maintain backward compatibility with older n8n versions

### 2. MCP Tool Response Enhancements
Updated the following handlers in **`src/mcp/handlers-n8n-manager.ts`**:
- **`handleListWorkflows()`**: Now includes `isArchived` in minimal workflow objects returned by `n8n_list_workflows`
- **`handleGetWorkflowMinimal()`**: Now includes `isArchived` in response data for `n8n_get_workflow_minimal`
- **`handleGetWorkflowStructure()`**: Now includes `isArchived` in simplified workflow data for `n8n_get_workflow_structure`
- **`handleGetWorkflowDetails()`**: Already includes `isArchived` automatically via the complete workflow object

## Key Benefits

1. **Complete Workflow Status Information**: AI agents now receive both `active` and `isArchived` properties when available, providing comprehensive workflow status.
2. **Better Decision Making**: AI agents can distinguish between active, inactive, and archived workflows for more intelligent workflow management
3. **Future-Proof**: Supports the n8n roadmap direction toward soft-deletion of workflows

## Backward Compatibility

- ✅ **Fully backward compatible**: Uses optional TypeScript property (`isArchived?`)
- ✅ **Graceful degradation**: Works with both newer n8n versions (returns `isArchived` value) and older versions (property is `undefined`)
- ✅ **No breaking changes**: Existing functionality remains unchanged
- ✅ **API compliance**: The `isArchived` property remains properly excluded from update operations in `cleanWorkflowForUpdate()`

## Testing

- ✅ **Build**: Successful TypeScript compilation
- ✅ **Type Safety**: All TypeScript type checks pass
- ✅ **Unit Tests**: All 1,416 unit tests pass
- ✅ **Integration Tests**: Compatible with existing test suite

## Context

This change addresses the evolution of n8n's workflow management system, which now allows workflows to be archived (soft-deleted) rather than permanently removed. The `isArchived` property allows:

- Workflows to be hidden from the main interface while preserving functionality
- Existing Execute Workflow nodes to continue working with archived workflows  
- Users to restore archived workflows via the UI
- The execution engine to process archived workflows normally (it ignores the `isArchived` flag)

The feature was introduced in  [n8n/14894](https://github.com/n8n-io/n8n/pull/14894).

## Version Support

This enhancement supports n8n version `^1.107.4` and is designed to work seamlessly with both current and future n8n versions that implement the `isArchived` property.