### PR TITLE
chore: update n8n dependencies to 1.110.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub stars](https://img.shields.io/github/stars/czlonkowski/n8n-mcp?style=social)](https://github.com/czlonkowski/n8n-mcp)
-[![Version](https://img.shields.io/badge/version-2.10.8-blue.svg)](https://github.com/czlonkowski/n8n-mcp)
+[![Version](https://img.shields.io/badge/version-2.10.9-blue.svg)](https://github.com/czlonkowski/n8n-mcp)
 [![npm version](https://img.shields.io/npm/v/n8n-mcp.svg)](https://www.npmjs.com/package/n8n-mcp)
 [![codecov](https://codecov.io/gh/czlonkowski/n8n-mcp/graph/badge.svg?token=YOUR_TOKEN)](https://codecov.io/gh/czlonkowski/n8n-mcp)
 [![Tests](https://img.shields.io/badge/tests-1728%20passing-brightgreen.svg)](https://github.com/czlonkowski/n8n-mcp/actions)
-[![n8n version](https://img.shields.io/badge/n8n-^1.109.2-orange.svg)](https://github.com/n8n-io/n8n)
+[![n8n version](https://img.shields.io/badge/n8n-^1.110.1-orange.svg)](https://github.com/n8n-io/n8n)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io%2Fczlonkowski%2Fn8n--mcp-green.svg)](https://github.com/czlonkowski/n8n-mcp/pkgs/container/n8n-mcp)
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/n8n-mcp?referralCode=n8n-mcp)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.9] - 2025-01-09
+
+### Changed
+- **Dependencies**: Updated n8n packages to 1.110.1
+  - n8n: 1.109.2 → 1.110.1
+  - n8n-core: 1.108.0 → 1.109.0
+  - n8n-workflow: 1.106.0 → 1.107.0
+  - @n8n/n8n-nodes-langchain: 1.108.1 → 1.109.1
+
+### Updated
+- **Node Database**: Rebuilt with 536 nodes from updated n8n packages
+- **Templates**: Refreshed workflow templates database with latest 499 templates from n8n.io
+
 ## [2.10.8] - 2025-09-04
 
 ### Updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,21 @@
 {
   "name": "n8n-mcp",
-  "version": "2.10.5",
+  "version": "2.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.10.5",
+      "version": "2.10.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",
-        "@n8n/n8n-nodes-langchain": "^1.108.1",
-        "@rollup/rollup-darwin-arm64": "*",
-        "@rollup/rollup-linux-x64-gnu": "*",
+        "@n8n/n8n-nodes-langchain": "^1.109.1",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
-        "n8n": "^1.109.2",
-        "n8n-core": "^1.108.0",
-        "n8n-workflow": "^1.106.0",
+        "n8n": "^1.110.1",
+        "n8n-core": "^1.109.0",
+        "n8n-workflow": "^1.107.0",
         "sql.js": "^1.13.0",
         "uuid": "^10.0.0"
       },
@@ -68,6 +66,7 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -5219,6 +5218,8 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5232,11 +5233,15 @@
     },
     "node_modules/@babel/code-frame/node_modules/js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -5244,20 +5249,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.3",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.3",
-        "@babel/parser": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -5274,6 +5281,8 @@
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "peer": true,
       "bin": {
@@ -5282,6 +5291,8 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5297,6 +5308,8 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5312,6 +5325,8 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -5320,6 +5335,8 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "peer": true,
       "bin": {
@@ -5328,11 +5345,15 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC",
       "peer": true
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -5341,6 +5362,8 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5353,6 +5376,8 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5369,6 +5394,8 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -5391,6 +5418,8 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -5398,22 +5427,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.3",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.3",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -5424,6 +5457,8 @@
     },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5435,6 +5470,8 @@
     },
     "node_modules/@babel/plugin-syntax-bigint": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5446,6 +5483,8 @@
     },
     "node_modules/@babel/plugin-syntax-class-properties": {
       "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5457,6 +5496,8 @@
     },
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5471,6 +5512,8 @@
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5485,6 +5528,8 @@
     },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5496,6 +5541,8 @@
     },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5507,6 +5554,8 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5521,6 +5570,8 @@
     },
     "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
       "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5532,6 +5583,8 @@
     },
     "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5543,6 +5596,8 @@
     },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5554,6 +5609,8 @@
     },
     "node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5565,6 +5622,8 @@
     },
     "node_modules/@babel/plugin-syntax-optional-catch-binding": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5576,6 +5635,8 @@
     },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5587,6 +5648,8 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5601,6 +5664,8 @@
     },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5615,6 +5680,8 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5636,6 +5703,8 @@
     },
     "node_modules/@babel/template": {
       "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5648,16 +5717,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.3",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.3",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2",
+        "@babel/types": "^7.28.4",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -5665,7 +5736,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -6290,6 +6363,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6305,6 +6380,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6313,6 +6390,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
       "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -6321,6 +6400,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
       "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6333,6 +6414,8 @@
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause",
       "peer": true
     },
@@ -6345,6 +6428,8 @@
     },
     "node_modules/@jest/console": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6361,6 +6446,8 @@
     },
     "node_modules/@jest/core": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6407,6 +6494,8 @@
     },
     "node_modules/@jest/core/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -6415,6 +6504,8 @@
     },
     "node_modules/@jest/core/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6426,6 +6517,8 @@
     },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6440,6 +6533,8 @@
     },
     "node_modules/@jest/expect": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6452,6 +6547,8 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6463,6 +6560,8 @@
     },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6479,6 +6578,8 @@
     },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6493,6 +6594,8 @@
     },
     "node_modules/@jest/reporters": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6535,11 +6638,15 @@
     },
     "node_modules/@jest/reporters/node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@jest/reporters/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -6548,6 +6655,8 @@
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
       "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6557,6 +6666,9 @@
     },
     "node_modules/@jest/reporters/node_modules/glob": {
       "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6576,6 +6688,8 @@
     },
     "node_modules/@jest/reporters/node_modules/istanbul-lib-source-maps": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -6589,6 +6703,8 @@
     },
     "node_modules/@jest/reporters/node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6600,6 +6716,8 @@
     },
     "node_modules/@jest/reporters/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6611,6 +6729,8 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6622,6 +6742,8 @@
     },
     "node_modules/@jest/source-map": {
       "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6635,6 +6757,8 @@
     },
     "node_modules/@jest/test-result": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6649,6 +6773,8 @@
     },
     "node_modules/@jest/test-sequencer": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6663,6 +6789,8 @@
     },
     "node_modules/@jest/transform": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6688,6 +6816,8 @@
     },
     "node_modules/@jest/types": {
       "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6707,6 +6837,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -7466,6 +7607,8 @@
     },
     "node_modules/@langchain/langgraph": {
       "version": "0.2.74",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-0.2.74.tgz",
+      "integrity": "sha512-oHpEi5sTZTPaeZX1UnzfM2OAJ21QGQrwReTV6+QnX7h8nDCBzhtipAw1cK616S+X8zpcVOjgOtJuaJhXa4mN8w==",
       "license": "MIT",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "~0.0.17",
@@ -7488,6 +7631,8 @@
     },
     "node_modules/@langchain/langgraph-checkpoint": {
       "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-0.0.18.tgz",
+      "integrity": "sha512-IS7zJj36VgY+4pf8ZjsVuUWef7oTwt1y9ylvwu0aLuOn1d0fg05Om9DLm3v2GZ2Df6bhLV1kfWAM0IAl9O5rQQ==",
       "license": "MIT",
       "dependencies": {
         "uuid": "^10.0.0"
@@ -7501,6 +7646,8 @@
     },
     "node_modules/@langchain/langgraph-sdk": {
       "version": "0.0.112",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.0.112.tgz",
+      "integrity": "sha512-/9W5HSWCqYgwma6EoOspL4BGYxGxeJP6lIquPSF4FA0JlKopaUv58ucZC3vAgdJyCgg6sorCIV/qg7SGpEcCLw==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.15",
@@ -7527,6 +7674,8 @@
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7799,6 +7948,8 @@
     },
     "node_modules/@n8n_io/ai-assistant-sdk": {
       "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@n8n_io/ai-assistant-sdk/-/ai-assistant-sdk-1.15.0.tgz",
+      "integrity": "sha512-M/bNnxyVGxwLGU/mzQrZOkZK4NkR9x8cUMZHfVJlv1z6YTlHX56BYH+0jSlb2c15DEwPkku9l0RFVLTTt0ExQQ==",
       "license": "UNLICENSED",
       "engines": {
         "node": ">=20.15",
@@ -7833,7 +7984,9 @@
       }
     },
     "node_modules/@n8n/ai-workflow-builder": {
-      "version": "0.19.0",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@n8n/ai-workflow-builder/-/ai-workflow-builder-0.20.0.tgz",
+      "integrity": "sha512-hUcCZatSlkSwqE85mQL0O8T+UjG1Sk0f8MhOsUck975H3ND2ei23U8qFbPBP55dMJQ/oxHYbTIogjXz0A8QO8g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@langchain/anthropic": "0.3.26",
@@ -7841,114 +7994,65 @@
         "@langchain/langgraph": "0.2.74",
         "@langchain/openai": "0.6.7",
         "@n8n_io/ai-assistant-sdk": "1.15.0",
-        "@n8n/backend-common": "^0.19.0",
-        "@n8n/config": "1.52.0",
+        "@n8n/backend-common": "^0.20.0",
+        "@n8n/config": "1.53.0",
         "@n8n/di": "0.9.0",
         "langsmith": "^0.3.45",
-        "n8n-workflow": "1.106.0",
-        "picocolors": "1.0.1",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/ai-workflow-builder/node_modules/@n8n/errors": {
-      "version": "0.4.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "callsites": "3.1.0"
-      }
-    },
-    "node_modules/@n8n/ai-workflow-builder/node_modules/n8n-workflow": {
-      "version": "1.106.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "^0.4.0",
-        "@n8n/tournament": "1.0.6",
-        "ast-types": "0.15.2",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.0",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.2",
-        "jssha": "3.3.1",
         "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "xml2js": "0.6.2",
+        "n8n-workflow": "1.107.0",
+        "picocolors": "1.0.1",
         "zod": "3.25.67"
       }
     },
     "node_modules/@n8n/ai-workflow-builder/node_modules/picocolors": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "license": "ISC"
     },
     "node_modules/@n8n/ai-workflow-builder/node_modules/zod": {
       "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@n8n/api-types": {
-      "version": "0.43.0",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-0.44.0.tgz",
+      "integrity": "sha512-tysoanoCLklncWIZz36VThmKontgtiEZZgR2pubUems3Z21yZ2/Yo9LFYFTdFfc3A1cKQjmeoEtx+8xu3IkOUQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/permissions": "0.32.0",
-        "n8n-workflow": "1.106.0",
+        "@n8n/permissions": "0.33.0",
+        "n8n-workflow": "1.107.0",
         "xss": "1.0.15",
         "zod": "3.25.67",
         "zod-class": "0.0.16"
       }
     },
-    "node_modules/@n8n/api-types/node_modules/@n8n/errors": {
-      "version": "0.4.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "callsites": "3.1.0"
-      }
-    },
-    "node_modules/@n8n/api-types/node_modules/n8n-workflow": {
-      "version": "1.106.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "^0.4.0",
-        "@n8n/tournament": "1.0.6",
-        "ast-types": "0.15.2",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.0",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.2",
-        "jssha": "3.3.1",
-        "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
-      }
-    },
     "node_modules/@n8n/api-types/node_modules/zod": {
       "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@n8n/backend-common": {
-      "version": "0.19.0",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-0.20.0.tgz",
+      "integrity": "sha512-Gy7thkXhGvQ5tEnyiatruy1YBwCCL/agub1WUe4MCysCQtbOD1rB9FHrno9+yX8/O6fMLNNW0fsIirxvHc4bcA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/config": "^1.52.0",
+        "@n8n/config": "^1.53.0",
         "@n8n/constants": "^0.11.0",
-        "@n8n/decorators": "^0.19.0",
+        "@n8n/decorators": "^0.20.0",
         "@n8n/di": "^0.9.0",
         "callsites": "3.1.0",
-        "n8n-workflow": "^1.106.0",
+        "n8n-workflow": "^1.107.0",
         "picocolors": "1.0.1",
         "reflect-metadata": "0.2.2",
         "winston": "3.14.2",
@@ -7957,10 +8061,14 @@
     },
     "node_modules/@n8n/backend-common/node_modules/picocolors": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "license": "ISC"
     },
     "node_modules/@n8n/backend-common/node_modules/readable-stream": {
       "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -7973,6 +8081,8 @@
     },
     "node_modules/@n8n/backend-common/node_modules/winston": {
       "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
+      "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
@@ -7992,24 +8102,28 @@
       }
     },
     "node_modules/@n8n/backend-test-utils": {
-      "version": "0.12.0",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@n8n/backend-test-utils/-/backend-test-utils-0.13.0.tgz",
+      "integrity": "sha512-OnAXq1vY0b8NtSCEmAazDc4Ng8vB+Se4Ey9+UDHVcXOaG8xsBA5QzU01g3Cac7D5U/DQuW8s+9VCjfVrGiGB6Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/backend-common": "^0.19.0",
-        "@n8n/config": "^1.52.0",
+        "@n8n/backend-common": "^0.20.0",
+        "@n8n/config": "^1.53.0",
         "@n8n/constants": "^0.11.0",
-        "@n8n/db": "^0.20.0",
+        "@n8n/db": "^0.21.0",
         "@n8n/di": "^0.9.0",
-        "@n8n/permissions": "^0.32.0",
+        "@n8n/permissions": "^0.33.0",
         "@n8n/typeorm": "0.3.20-12",
         "jest-mock-extended": "^3.0.4",
-        "n8n-workflow": "^1.106.0",
+        "n8n-workflow": "^1.107.0",
         "reflect-metadata": "0.2.2",
         "uuid": "10.0.0"
       }
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@n8n/typeorm": {
       "version": "0.3.20-12",
+      "resolved": "https://registry.npmjs.org/@n8n/typeorm/-/typeorm-0.3.20-12.tgz",
+      "integrity": "sha512-Jc+Uys9HXTRq+u2XTqnAqjZVvAPwYH4qy4wRcizN0u7sfBvRGRpeF8ZAoplOGjXPRBG278QKcfVAJ64j/bj+uQ==",
       "license": "MIT",
       "dependencies": {
         "@n8n/p-retry": "6.2.0-2",
@@ -8124,6 +8238,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@n8n/typeorm/node_modules/uuid": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -8135,6 +8251,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/api-logs": {
       "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.1.tgz",
+      "integrity": "sha512-I4PHczeujhQAQv6ZBzqHYEUiggZL4IdSMixtVD3EYqbdrjujE7kRfI5QohjlPoJm8BvenoW5YaTMWRrbpot6tg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8147,6 +8265,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation": {
       "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.1.tgz",
+      "integrity": "sha512-SgHEKXoVxOjc20ZYusPG3Fh+RLIZTSa4x8QtD3NfgAUDyqdFFS9W1F2ZVbZkqDCdyMcQG02Ok4duUGLHJXHgbA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8167,6 +8287,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-connect": {
       "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.0.tgz",
+      "integrity": "sha512-Q57JGpH6T4dkYHo9tKXONgLtxzsh1ZEW5M9A/OwKrZFyEpLqWgjhcZ3hIuVvDlhb426iDF1f9FPToV/mi5rpeA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8185,6 +8307,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-dataloader": {
       "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.0.tgz",
+      "integrity": "sha512-88+qCHZC02up8PwKHk0UQKLLqGGURzS3hFQBZC7PnGwReuoKjHXS1o29H58S+QkXJpkTr2GACbx8j6mUoGjNPA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8200,6 +8324,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-express": {
       "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.0.tgz",
+      "integrity": "sha512-XFWVx6k0XlU8lu6cBlCa29ONtVt6ADEjmxtyAyeF2+rifk8uBJbk1La0yIVfI0DoKURGbaEDTNelaXG9l/lNNQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8217,6 +8343,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-fs": {
       "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.0.tgz",
+      "integrity": "sha512-JGwmHhBkRT2G/BYNV1aGI+bBjJu4fJUD/5/Jat0EWZa2ftrLV3YE8z84Fiij/wK32oMZ88eS8DI4ecLGZhpqsQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8233,6 +8361,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-generic-pool": {
       "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.0.tgz",
+      "integrity": "sha512-at8GceTtNxD1NfFKGAuwtqM41ot/TpcLh+YsGe4dhf7gvv1HW/ZWdq6nfRtS6UjIvZJOokViqLPJ3GVtZItAnQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8248,6 +8378,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-graphql": {
       "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.0.tgz",
+      "integrity": "sha512-Cc8SMf+nLqp0fi8oAnooNEfwZWFnzMiBHCGmDFYqmgjPylyLmi83b+NiTns/rKGwlErpW0AGPt0sMpkbNlzn8w==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8263,6 +8395,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-hapi": {
       "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.1.tgz",
+      "integrity": "sha512-VH6mU3YqAKTePPfUPwfq4/xr049774qWtfTuJqVHoVspCLiT3bW+fCQ1toZxt6cxRPYASoYaBsMA3CWo8B8rcw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8280,6 +8414,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-http": {
       "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.1.tgz",
+      "integrity": "sha512-ThLmzAQDs7b/tdKI3BV2+yawuF09jF111OFsovqT1Qj3D8vjwKBwhi/rDE5xethwn4tSXtZcJ9hBsVAlWFQZ7g==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8299,6 +8435,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-ioredis": {
       "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.0.tgz",
+      "integrity": "sha512-4HqP9IBC8e7pW9p90P3q4ox0XlbLGme65YTrA3UTLvqvo4Z6b0puqZQP203YFu8m9rE/luLfaG7/xrwwqMUpJw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8316,6 +8454,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-kafkajs": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.0.tgz",
+      "integrity": "sha512-LB+3xiNzc034zHfCtgs4ITWhq6Xvdo8bsq7amR058jZlf2aXXDrN9SV4si4z2ya9QX4tz6r4eZJwDkXOp14/AQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8332,6 +8472,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-knex": {
       "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.0.tgz",
+      "integrity": "sha512-SlT0+bLA0Lg3VthGje+bSZatlGHw/vwgQywx0R/5u9QC59FddTQSPJeWNw29M6f8ScORMeUOOTwihlQAn4GkJQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8348,6 +8490,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-koa": {
       "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.0.tgz",
+      "integrity": "sha512-HFdvqf2+w8sWOuwtEXayGzdZ2vWpCKEQv5F7+2DSA74Te/Cv4rvb2E5So5/lh+ok4/RAIPuvCbCb/SHQFzMmbw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8365,6 +8509,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-lru-memoizer": {
       "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.0.tgz",
+      "integrity": "sha512-Tn7emHAlvYDFik3vGU0mdwvWJDwtITtkJ+5eT2cUquct6nIs+H8M47sqMJkCpyPe5QIBJoTOHxmc6mj9lz6zDw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8380,6 +8526,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-mongodb": {
       "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.51.0.tgz",
+      "integrity": "sha512-cMKASxCX4aFxesoj3WK8uoQ0YUrRvnfxaO72QWI2xLu5ZtgX/QvdGBlU3Ehdond5eb74c2s1cqRQUIptBnKz1g==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8396,6 +8544,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-mongoose": {
       "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.0.tgz",
+      "integrity": "sha512-mtVv6UeaaSaWTeZtLo4cx4P5/ING2obSqfWGItIFSunQBrYROfhuVe7wdIrFUs2RH1tn2YYpAJyMaRe/bnTTIQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8413,6 +8563,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-mysql": {
       "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.0.tgz",
+      "integrity": "sha512-tWWyymgwYcTwZ4t8/rLDfPYbOTF3oYB8SxnYMtIQ1zEf5uDm90Ku3i6U/vhaMyfHNlIHvDhvJh+qx5Nc4Z3Acg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8430,6 +8582,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-mysql2": {
       "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.0.tgz",
+      "integrity": "sha512-qLslv/EPuLj0IXFvcE3b0EqhWI8LKmrgRPIa4gUd8DllbBpqJAvLNJSv3cC6vWwovpbSI3bagNO/3Q2SuXv2xA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8447,6 +8601,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-pg": {
       "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.50.0.tgz",
+      "integrity": "sha512-TtLxDdYZmBhFswm8UIsrDjh/HFBeDXd4BLmE8h2MxirNHewLJ0VS9UUddKKEverb5Sm2qFVjqRjcU+8Iw4FJ3w==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8467,6 +8623,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8476,6 +8634,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-redis-4": {
       "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.0.tgz",
+      "integrity": "sha512-aTUWbzbFMFeRODn3720TZO0tsh/49T8H3h8vVnVKJ+yE36AeW38Uj/8zykQ/9nO8Vrtjr5yKuX3uMiG/W8FKNw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8493,6 +8653,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-tedious": {
       "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.0.tgz",
+      "integrity": "sha512-9zhjDpUDOtD+coeADnYEJQ0IeLVCj7w/hqzIutdp5NqS1VqTAanaEfsEcSypyvYv5DX3YOsTUoF+nr2wDXPETA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8510,6 +8672,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/instrumentation-undici": {
       "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.0.tgz",
+      "integrity": "sha512-vm+V255NGw9gaSsPD6CP0oGo8L55BffBc8KnxqsMuc6XiAD1L8SFNzsW0RHhxJFqy9CJaJh+YiJ5EHXuZ5rZBw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8526,6 +8690,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8535,6 +8701,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@prisma/instrumentation": {
       "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.22.0.tgz",
+      "integrity": "sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8546,6 +8714,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
       "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8558,6 +8728,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
       "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
+      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8578,6 +8750,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@sentry/core": {
       "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.0.tgz",
+      "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -8587,6 +8761,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@sentry/node": {
       "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.55.0.tgz",
+      "integrity": "sha512-h10LJLDTRAzYgay60Oy7moMookqqSZSviCWkkmHZyaDn+4WURnPp5SKhhfrzPRQcXKrweiOwDSHBgn1tweDssg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -8633,6 +8809,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@sentry/opentelemetry": {
       "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.55.0.tgz",
+      "integrity": "sha512-UvatdmSr3Xf+4PLBzJNLZ2JjG1yAPWGe/VrJlJAqyTJ2gKeTzgXJJw8rp4pbvNZO8NaTGEYhhO+scLUj0UtLAQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -8653,6 +8831,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@types/connect": {
       "version": "3.4.36",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
+      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -8662,6 +8842,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/@types/whatwg-url": {
       "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -8672,6 +8854,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/better-sqlite3": {
       "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8683,6 +8867,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/bson": {
       "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8692,6 +8878,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/glob": {
       "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -8710,6 +8898,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/jackspeak": {
       "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -8723,10 +8913,14 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/lru-cache": {
       "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
     "node_modules/@n8n/backend-test-utils/node_modules/mkdirp": {
       "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
       "license": "MIT",
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
@@ -8740,6 +8934,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/mongodb": {
       "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8781,6 +8977,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/mongodb-connection-string-url": {
       "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -8791,6 +8989,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/path-scurry": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -8805,6 +9005,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/tr46": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -8817,6 +9019,8 @@
     },
     "node_modules/@n8n/backend-test-utils/node_modules/whatwg-url": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -8845,7 +9049,9 @@
       }
     },
     "node_modules/@n8n/config": {
-      "version": "1.52.0",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-1.53.0.tgz",
+      "integrity": "sha512-0EkIG1tTy6M8EOQLIm6diKekGc9j98fXzFp22qI2R4JX9ZcIS2qaC6GjMq2Ud7KuMwoNYFM3eM9syrDd22d7IA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@n8n/di": "0.9.0",
@@ -8855,6 +9061,8 @@
     },
     "node_modules/@n8n/config/node_modules/zod": {
       "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -8865,22 +9073,24 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@n8n/db": {
-      "version": "0.20.0",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@n8n/db/-/db-0.21.0.tgz",
+      "integrity": "sha512-PZcPuMJBsi70sysugocFptAcLahsk7tQVKsjx50D0WroBNEJnke4eEtzFuxEFTBv2A7ryNyqO78+PmpMWos2rg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/api-types": "^0.43.0",
-        "@n8n/backend-common": "^0.19.0",
-        "@n8n/config": "^1.52.0",
+        "@n8n/api-types": "^0.44.0",
+        "@n8n/backend-common": "^0.20.0",
+        "@n8n/config": "^1.53.0",
         "@n8n/constants": "^0.11.0",
-        "@n8n/decorators": "^0.19.0",
+        "@n8n/decorators": "^0.20.0",
         "@n8n/di": "^0.9.0",
-        "@n8n/permissions": "^0.32.0",
+        "@n8n/permissions": "^0.33.0",
         "@n8n/typeorm": "0.3.20-12",
         "class-validator": "0.14.0",
         "flatted": "3.2.7",
         "lodash": "4.17.21",
-        "n8n-core": "^1.108.0",
-        "n8n-workflow": "^1.106.0",
+        "n8n-core": "^1.109.0",
+        "n8n-workflow": "^1.107.0",
         "nanoid": "3.3.8",
         "p-lazy": "3.1.0",
         "reflect-metadata": "0.2.2",
@@ -8891,6 +9101,8 @@
     },
     "node_modules/@n8n/db/node_modules/@n8n/typeorm": {
       "version": "0.3.20-12",
+      "resolved": "https://registry.npmjs.org/@n8n/typeorm/-/typeorm-0.3.20-12.tgz",
+      "integrity": "sha512-Jc+Uys9HXTRq+u2XTqnAqjZVvAPwYH4qy4wRcizN0u7sfBvRGRpeF8ZAoplOGjXPRBG278QKcfVAJ64j/bj+uQ==",
       "license": "MIT",
       "dependencies": {
         "@n8n/p-retry": "6.2.0-2",
@@ -9005,6 +9217,8 @@
     },
     "node_modules/@n8n/db/node_modules/@n8n/typeorm/node_modules/uuid": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -9016,6 +9230,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/api-logs": {
       "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.1.tgz",
+      "integrity": "sha512-I4PHczeujhQAQv6ZBzqHYEUiggZL4IdSMixtVD3EYqbdrjujE7kRfI5QohjlPoJm8BvenoW5YaTMWRrbpot6tg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9028,6 +9244,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation": {
       "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.1.tgz",
+      "integrity": "sha512-SgHEKXoVxOjc20ZYusPG3Fh+RLIZTSa4x8QtD3NfgAUDyqdFFS9W1F2ZVbZkqDCdyMcQG02Ok4duUGLHJXHgbA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9048,6 +9266,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-connect": {
       "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.0.tgz",
+      "integrity": "sha512-Q57JGpH6T4dkYHo9tKXONgLtxzsh1ZEW5M9A/OwKrZFyEpLqWgjhcZ3hIuVvDlhb426iDF1f9FPToV/mi5rpeA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9066,6 +9286,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-dataloader": {
       "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.0.tgz",
+      "integrity": "sha512-88+qCHZC02up8PwKHk0UQKLLqGGURzS3hFQBZC7PnGwReuoKjHXS1o29H58S+QkXJpkTr2GACbx8j6mUoGjNPA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9081,6 +9303,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-express": {
       "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.0.tgz",
+      "integrity": "sha512-XFWVx6k0XlU8lu6cBlCa29ONtVt6ADEjmxtyAyeF2+rifk8uBJbk1La0yIVfI0DoKURGbaEDTNelaXG9l/lNNQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9098,6 +9322,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-fs": {
       "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.0.tgz",
+      "integrity": "sha512-JGwmHhBkRT2G/BYNV1aGI+bBjJu4fJUD/5/Jat0EWZa2ftrLV3YE8z84Fiij/wK32oMZ88eS8DI4ecLGZhpqsQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9114,6 +9340,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-generic-pool": {
       "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.0.tgz",
+      "integrity": "sha512-at8GceTtNxD1NfFKGAuwtqM41ot/TpcLh+YsGe4dhf7gvv1HW/ZWdq6nfRtS6UjIvZJOokViqLPJ3GVtZItAnQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9129,6 +9357,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-graphql": {
       "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.0.tgz",
+      "integrity": "sha512-Cc8SMf+nLqp0fi8oAnooNEfwZWFnzMiBHCGmDFYqmgjPylyLmi83b+NiTns/rKGwlErpW0AGPt0sMpkbNlzn8w==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9144,6 +9374,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-hapi": {
       "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.1.tgz",
+      "integrity": "sha512-VH6mU3YqAKTePPfUPwfq4/xr049774qWtfTuJqVHoVspCLiT3bW+fCQ1toZxt6cxRPYASoYaBsMA3CWo8B8rcw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9161,6 +9393,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-http": {
       "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.1.tgz",
+      "integrity": "sha512-ThLmzAQDs7b/tdKI3BV2+yawuF09jF111OFsovqT1Qj3D8vjwKBwhi/rDE5xethwn4tSXtZcJ9hBsVAlWFQZ7g==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9180,6 +9414,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-ioredis": {
       "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.0.tgz",
+      "integrity": "sha512-4HqP9IBC8e7pW9p90P3q4ox0XlbLGme65YTrA3UTLvqvo4Z6b0puqZQP203YFu8m9rE/luLfaG7/xrwwqMUpJw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9197,6 +9433,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-kafkajs": {
       "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.0.tgz",
+      "integrity": "sha512-LB+3xiNzc034zHfCtgs4ITWhq6Xvdo8bsq7amR058jZlf2aXXDrN9SV4si4z2ya9QX4tz6r4eZJwDkXOp14/AQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9213,6 +9451,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-knex": {
       "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.0.tgz",
+      "integrity": "sha512-SlT0+bLA0Lg3VthGje+bSZatlGHw/vwgQywx0R/5u9QC59FddTQSPJeWNw29M6f8ScORMeUOOTwihlQAn4GkJQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9229,6 +9469,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-koa": {
       "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.0.tgz",
+      "integrity": "sha512-HFdvqf2+w8sWOuwtEXayGzdZ2vWpCKEQv5F7+2DSA74Te/Cv4rvb2E5So5/lh+ok4/RAIPuvCbCb/SHQFzMmbw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9246,6 +9488,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-lru-memoizer": {
       "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.0.tgz",
+      "integrity": "sha512-Tn7emHAlvYDFik3vGU0mdwvWJDwtITtkJ+5eT2cUquct6nIs+H8M47sqMJkCpyPe5QIBJoTOHxmc6mj9lz6zDw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9261,6 +9505,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-mongodb": {
       "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.51.0.tgz",
+      "integrity": "sha512-cMKASxCX4aFxesoj3WK8uoQ0YUrRvnfxaO72QWI2xLu5ZtgX/QvdGBlU3Ehdond5eb74c2s1cqRQUIptBnKz1g==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9277,6 +9523,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-mongoose": {
       "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.0.tgz",
+      "integrity": "sha512-mtVv6UeaaSaWTeZtLo4cx4P5/ING2obSqfWGItIFSunQBrYROfhuVe7wdIrFUs2RH1tn2YYpAJyMaRe/bnTTIQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9294,6 +9542,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-mysql": {
       "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.0.tgz",
+      "integrity": "sha512-tWWyymgwYcTwZ4t8/rLDfPYbOTF3oYB8SxnYMtIQ1zEf5uDm90Ku3i6U/vhaMyfHNlIHvDhvJh+qx5Nc4Z3Acg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9311,6 +9561,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-mysql2": {
       "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.0.tgz",
+      "integrity": "sha512-qLslv/EPuLj0IXFvcE3b0EqhWI8LKmrgRPIa4gUd8DllbBpqJAvLNJSv3cC6vWwovpbSI3bagNO/3Q2SuXv2xA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9328,6 +9580,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-pg": {
       "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.50.0.tgz",
+      "integrity": "sha512-TtLxDdYZmBhFswm8UIsrDjh/HFBeDXd4BLmE8h2MxirNHewLJ0VS9UUddKKEverb5Sm2qFVjqRjcU+8Iw4FJ3w==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9348,6 +9602,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9357,6 +9613,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-redis-4": {
       "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.0.tgz",
+      "integrity": "sha512-aTUWbzbFMFeRODn3720TZO0tsh/49T8H3h8vVnVKJ+yE36AeW38Uj/8zykQ/9nO8Vrtjr5yKuX3uMiG/W8FKNw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9374,6 +9632,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-tedious": {
       "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.0.tgz",
+      "integrity": "sha512-9zhjDpUDOtD+coeADnYEJQ0IeLVCj7w/hqzIutdp5NqS1VqTAanaEfsEcSypyvYv5DX3YOsTUoF+nr2wDXPETA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9391,6 +9651,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/instrumentation-undici": {
       "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.0.tgz",
+      "integrity": "sha512-vm+V255NGw9gaSsPD6CP0oGo8L55BffBc8KnxqsMuc6XiAD1L8SFNzsW0RHhxJFqy9CJaJh+YiJ5EHXuZ5rZBw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9407,6 +9669,8 @@
     },
     "node_modules/@n8n/db/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9416,6 +9680,8 @@
     },
     "node_modules/@n8n/db/node_modules/@prisma/instrumentation": {
       "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.22.0.tgz",
+      "integrity": "sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9427,6 +9693,8 @@
     },
     "node_modules/@n8n/db/node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
       "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9439,6 +9707,8 @@
     },
     "node_modules/@n8n/db/node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
       "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
+      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9459,6 +9729,8 @@
     },
     "node_modules/@n8n/db/node_modules/@sentry/core": {
       "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.0.tgz",
+      "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9468,6 +9740,8 @@
     },
     "node_modules/@n8n/db/node_modules/@sentry/node": {
       "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.55.0.tgz",
+      "integrity": "sha512-h10LJLDTRAzYgay60Oy7moMookqqSZSviCWkkmHZyaDn+4WURnPp5SKhhfrzPRQcXKrweiOwDSHBgn1tweDssg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9514,6 +9788,8 @@
     },
     "node_modules/@n8n/db/node_modules/@sentry/opentelemetry": {
       "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.55.0.tgz",
+      "integrity": "sha512-UvatdmSr3Xf+4PLBzJNLZ2JjG1yAPWGe/VrJlJAqyTJ2gKeTzgXJJw8rp4pbvNZO8NaTGEYhhO+scLUj0UtLAQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9534,6 +9810,8 @@
     },
     "node_modules/@n8n/db/node_modules/@types/connect": {
       "version": "3.4.36",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
+      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9543,6 +9821,8 @@
     },
     "node_modules/@n8n/db/node_modules/@types/whatwg-url": {
       "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9553,6 +9833,8 @@
     },
     "node_modules/@n8n/db/node_modules/better-sqlite3": {
       "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9564,6 +9846,8 @@
     },
     "node_modules/@n8n/db/node_modules/bson": {
       "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9573,10 +9857,14 @@
     },
     "node_modules/@n8n/db/node_modules/flatted": {
       "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "license": "ISC"
     },
     "node_modules/@n8n/db/node_modules/glob": {
       "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -9595,6 +9883,8 @@
     },
     "node_modules/@n8n/db/node_modules/jackspeak": {
       "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -9608,10 +9898,14 @@
     },
     "node_modules/@n8n/db/node_modules/lru-cache": {
       "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
     "node_modules/@n8n/db/node_modules/mkdirp": {
       "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
       "license": "MIT",
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
@@ -9625,6 +9919,8 @@
     },
     "node_modules/@n8n/db/node_modules/mongodb": {
       "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9666,6 +9962,8 @@
     },
     "node_modules/@n8n/db/node_modules/mongodb-connection-string-url": {
       "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -9676,6 +9974,8 @@
     },
     "node_modules/@n8n/db/node_modules/path-scurry": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -9690,6 +9990,8 @@
     },
     "node_modules/@n8n/db/node_modules/tr46": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9702,6 +10004,8 @@
     },
     "node_modules/@n8n/db/node_modules/whatwg-url": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -9715,20 +10019,24 @@
     },
     "node_modules/@n8n/db/node_modules/zod": {
       "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@n8n/decorators": {
-      "version": "0.19.0",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-0.20.0.tgz",
+      "integrity": "sha512-HYdYjePe8dhwkLUVG7HHjGTHnKg2agHg3XojMO1njcdOI8bT4/XcBmFQ4690TwPl9HcU1XOWYXk8j+iN+cYc4w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@n8n/constants": "^0.11.0",
         "@n8n/di": "^0.9.0",
-        "@n8n/permissions": "^0.32.0",
+        "@n8n/permissions": "^0.33.0",
         "lodash": "4.17.21",
-        "n8n-workflow": "^1.106.0"
+        "n8n-workflow": "^1.107.0"
       }
     },
     "node_modules/@n8n/di": {
@@ -10725,7 +11033,9 @@
       "license": "MIT"
     },
     "node_modules/@n8n/permissions": {
-      "version": "0.32.0",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.33.0.tgz",
+      "integrity": "sha512-VKra7dKglfJ4+jbryqip7PcCtAyZ1MId/WP3ZVcEhogNGVhrdbuhjHHv/bdjcHUyQQ41Vq+QJAmCnizzE8KzzQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "zod": "3.25.67"
@@ -10733,225 +11043,43 @@
     },
     "node_modules/@n8n/permissions/node_modules/zod": {
       "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@n8n/task-runner": {
-      "version": "1.45.0",
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/@n8n/task-runner/-/task-runner-1.46.0.tgz",
+      "integrity": "sha512-GEb3M8pUmugEQgs5usVp9wfeYyHhnix/vv7IpvIrg4WL8WYt/LQ3nJWwQeth5RgjFLNQN3E3gnkqkGp2g6pqMQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/config": "1.52.0",
+        "@n8n/config": "1.53.0",
         "@n8n/di": "0.9.0",
-        "@n8n/errors": "^0.4.0",
+        "@n8n/errors": "^0.5.0",
         "@sentry/node": "^9.42.1",
         "acorn": "8.14.0",
         "acorn-walk": "8.3.4",
         "lodash": "4.17.21",
         "luxon": "3.4.4",
-        "n8n-core": "1.108.0",
-        "n8n-workflow": "1.106.0",
+        "n8n-core": "1.109.0",
+        "n8n-workflow": "1.107.0",
         "nanoid": "3.3.8",
         "ws": "^8.18.0"
       }
     },
-    "node_modules/@n8n/task-runner/node_modules/@n8n/client-oauth2": {
-      "version": "0.28.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "axios": "1.8.3"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/@n8n/errors": {
-      "version": "0.4.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "callsites": "3.1.0"
-      }
-    },
     "node_modules/@n8n/task-runner/node_modules/acorn": {
       "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/axios": {
-      "version": "1.8.3",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/entities": {
-      "version": "6.0.1",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/n8n-core": {
-      "version": "1.108.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@aws-sdk/client-s3": "3.808.0",
-        "@langchain/core": "0.3.68",
-        "@n8n/backend-common": "^0.19.0",
-        "@n8n/client-oauth2": "0.28.0",
-        "@n8n/config": "1.52.0",
-        "@n8n/constants": "0.11.0",
-        "@n8n/decorators": "0.19.0",
-        "@n8n/di": "0.9.0",
-        "@sentry/node": "^9.42.1",
-        "@sentry/node-native": "^9.42.1",
-        "axios": "1.8.3",
-        "callsites": "3.1.0",
-        "chardet": "2.0.0",
-        "cron": "3.1.7",
-        "fast-glob": "3.2.12",
-        "file-type": "16.5.4",
-        "form-data": "4.0.0",
-        "htmlparser2": "^10.0.0",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "iconv-lite": "0.6.3",
-        "jsonwebtoken": "9.0.2",
-        "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "mime-types": "2.1.35",
-        "n8n-workflow": "1.106.0",
-        "nanoid": "3.3.8",
-        "oauth-1.0a": "2.2.6",
-        "p-cancelable": "2.1.1",
-        "picocolors": "1.0.1",
-        "pretty-bytes": "5.6.0",
-        "proxy-from-env": "^1.1.0",
-        "qs": "6.11.0",
-        "ssh2": "1.15.0",
-        "uuid": "10.0.0",
-        "winston": "3.14.2",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
-      },
-      "bin": {
-        "n8n-copy-static-files": "bin/copy-static-files",
-        "n8n-generate-metadata": "bin/generate-metadata",
-        "n8n-generate-translations": "bin/generate-translations"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/n8n-workflow": {
-      "version": "1.106.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "^0.4.0",
-        "@n8n/tournament": "1.0.6",
-        "ast-types": "0.15.2",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.0",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.2",
-        "jssha": "3.3.1",
-        "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/picocolors": {
-      "version": "1.0.1",
-      "license": "ISC"
-    },
-    "node_modules/@n8n/task-runner/node_modules/qs": {
-      "version": "6.11.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/winston": {
-      "version": "3.14.2",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/zod": {
-      "version": "3.25.67",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@n8n/tournament": {
@@ -12139,11 +12267,15 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -12152,6 +12284,8 @@
     },
     "node_modules/@sinonjs/commons/node_modules/type-detect": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -12160,6 +12294,8 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -13231,6 +13367,8 @@
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13243,6 +13381,8 @@
     },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13251,6 +13391,8 @@
     },
     "node_modules/@types/babel__template": {
       "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13260,6 +13402,8 @@
     },
     "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13345,6 +13489,8 @@
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13364,11 +13510,15 @@
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13377,6 +13527,8 @@
     },
     "node_modules/@types/istanbul-reports": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13556,6 +13708,8 @@
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "license": "MIT",
       "peer": true
     },
@@ -13585,6 +13739,8 @@
     },
     "node_modules/@types/validator": {
       "version": "13.15.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.3.tgz",
+      "integrity": "sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==",
       "license": "MIT"
     },
     "node_modules/@types/webidl-conversions": {
@@ -13607,6 +13763,8 @@
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13615,6 +13773,8 @@
     },
     "node_modules/@types/yargs-parser": {
       "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT",
       "peer": true
     },
@@ -14475,6 +14635,8 @@
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14495,6 +14657,8 @@
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -14510,6 +14674,8 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/brace-expansion": {
       "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14519,6 +14685,9 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/glob": {
       "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -14538,6 +14707,8 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -14553,6 +14724,8 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -14564,6 +14737,8 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "peer": true,
       "bin": {
@@ -14572,6 +14747,8 @@
     },
     "node_modules/babel-plugin-istanbul/node_modules/test-exclude": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -14585,6 +14762,8 @@
     },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14599,6 +14778,8 @@
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14624,6 +14805,8 @@
     },
     "node_modules/babel-preset-jest": {
       "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14824,6 +15007,8 @@
     },
     "node_modules/browserslist": {
       "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
+      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -14855,6 +15040,8 @@
     },
     "node_modules/bser": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -15131,7 +15318,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001739",
+      "version": "1.0.30001741",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+      "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -15242,6 +15431,8 @@
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -15327,6 +15518,8 @@
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "funding": [
         {
           "type": "github",
@@ -15349,6 +15542,8 @@
     },
     "node_modules/class-validator": {
       "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
+      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
       "license": "MIT",
       "dependencies": {
         "@types/validator": "^13.7.10",
@@ -15468,6 +15663,8 @@
     },
     "node_modules/co": {
       "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -15508,6 +15705,8 @@
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "license": "MIT",
       "peer": true
     },
@@ -15738,6 +15937,8 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT",
       "peer": true
     },
@@ -15817,6 +16018,8 @@
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -15938,6 +16141,8 @@
     },
     "node_modules/cssfilter": {
       "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
       "license": "MIT"
     },
     "node_modules/cssstyle": {
@@ -16143,6 +16348,8 @@
     },
     "node_modules/dedent": {
       "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
+      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
@@ -16250,6 +16457,8 @@
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -16274,6 +16483,8 @@
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -16428,12 +16639,16 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.214",
+      "version": "1.5.215",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.215.tgz",
+      "integrity": "sha512-TIvGp57UpeNetj/wV/xpFNpWGb0b/ROw372lHPx5Aafx02gjTBtWnEEcaSX3W2dLM3OSdGGyHX/cHl01JQsLaQ==",
       "license": "ISC",
       "peer": true
     },
     "node_modules/emittery": {
       "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -16549,6 +16764,8 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -17259,6 +17476,8 @@
     },
     "node_modules/execa": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -17281,11 +17500,15 @@
     },
     "node_modules/execa/node_modules/signal-exit": {
       "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC",
       "peer": true
     },
     "node_modules/exit": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
       "peer": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -17310,6 +17533,8 @@
     },
     "node_modules/expect": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -17606,6 +17831,8 @@
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -17695,6 +17922,8 @@
     },
     "node_modules/find-up": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -18087,6 +18316,8 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -18124,6 +18355,8 @@
     },
     "node_modules/get-package-type": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -18153,6 +18386,8 @@
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -18779,6 +19014,8 @@
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
@@ -18937,6 +19174,8 @@
     },
     "node_modules/import-local": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19086,6 +19325,8 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT",
       "peer": true
     },
@@ -19260,6 +19501,8 @@
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -19560,6 +19803,8 @@
     },
     "node_modules/istanbul-lib-instrument": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -19624,6 +19869,8 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19649,6 +19896,8 @@
     },
     "node_modules/jest-changed-files": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19662,6 +19911,8 @@
     },
     "node_modules/jest-circus": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19692,6 +19943,8 @@
     },
     "node_modules/jest-cli": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19724,6 +19977,8 @@
     },
     "node_modules/jest-config": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19768,6 +20023,8 @@
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
       "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19777,6 +20034,9 @@
     },
     "node_modules/jest-config/node_modules/glob": {
       "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -19796,6 +20056,8 @@
     },
     "node_modules/jest-config/node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -19807,6 +20069,8 @@
     },
     "node_modules/jest-diff": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19821,6 +20085,8 @@
     },
     "node_modules/jest-docblock": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19832,6 +20098,8 @@
     },
     "node_modules/jest-each": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19847,6 +20115,8 @@
     },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19863,6 +20133,8 @@
     },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -19871,6 +20143,8 @@
     },
     "node_modules/jest-haste-map": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19895,6 +20169,8 @@
     },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19907,6 +20183,8 @@
     },
     "node_modules/jest-matcher-utils": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19921,6 +20199,8 @@
     },
     "node_modules/jest-message-util": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19940,6 +20220,8 @@
     },
     "node_modules/jest-mock": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -19953,6 +20235,8 @@
     },
     "node_modules/jest-mock-extended": {
       "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-3.0.7.tgz",
+      "integrity": "sha512-7lsKdLFcW9B9l5NzZ66S/yTQ9k8rFtnwYdCNuRU/81fqDWicNDVhitTSPnrGmNeNm0xyw0JHexEOShrIKRCIRQ==",
       "license": "MIT",
       "dependencies": {
         "ts-essentials": "^10.0.0"
@@ -19964,6 +20248,8 @@
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -19980,6 +20266,8 @@
     },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -19988,6 +20276,8 @@
     },
     "node_modules/jest-resolve": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20007,6 +20297,8 @@
     },
     "node_modules/jest-resolve-dependencies": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20019,6 +20311,8 @@
     },
     "node_modules/jest-runner": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20050,6 +20344,8 @@
     },
     "node_modules/jest-runner/node_modules/source-map-support": {
       "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20059,6 +20355,8 @@
     },
     "node_modules/jest-runtime": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20091,6 +20389,8 @@
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
       "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20100,6 +20400,9 @@
     },
     "node_modules/jest-runtime/node_modules/glob": {
       "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -20119,6 +20422,8 @@
     },
     "node_modules/jest-runtime/node_modules/minimatch": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -20130,6 +20435,8 @@
     },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20160,6 +20467,8 @@
     },
     "node_modules/jest-util": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20176,6 +20485,8 @@
     },
     "node_modules/jest-validate": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20192,6 +20503,8 @@
     },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20210,6 +20523,8 @@
     },
     "node_modules/jest-worker": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20224,6 +20539,8 @@
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20367,6 +20684,8 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -20400,6 +20719,8 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT",
       "peer": true
     },
@@ -20535,6 +20856,8 @@
     },
     "node_modules/kleur": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -20726,6 +21049,8 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -20758,6 +21083,8 @@
     },
     "node_modules/libphonenumber-js": {
       "version": "1.12.15",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.15.tgz",
+      "integrity": "sha512-TMDCtIhWUDHh91wRC+wFuGlIzKdPzaTUHHVrIZ3vPUEoNaXFLrsIQ1ZpAeZeXApIF6rvDksMTvjrIQlLKaYxqQ==",
       "license": "MIT"
     },
     "node_modules/libqp": {
@@ -20773,6 +21100,8 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT",
       "peer": true
     },
@@ -20785,6 +21114,8 @@
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -21108,6 +21439,8 @@
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -21198,6 +21531,8 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT",
       "peer": true
     },
@@ -21248,6 +21583,8 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -21879,7 +22216,9 @@
       }
     },
     "node_modules/n8n": {
-      "version": "1.109.2",
+      "version": "1.110.1",
+      "resolved": "https://registry.npmjs.org/n8n/-/n8n-1.110.1.tgz",
+      "integrity": "sha512-HGRHD5MHyuIDMUCjgZgxRxI5zVdn9fWX2/j/Pe1iWI+EwIX418cy23cjXvo2vvG3wjfYutKwlyJzEOoDIq3Zcw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "3.808.0",
@@ -21888,21 +22227,21 @@
         "@google-cloud/secret-manager": "5.6.0",
         "@n8n_io/ai-assistant-sdk": "1.15.0",
         "@n8n_io/license-sdk": "2.23.0",
-        "@n8n/ai-workflow-builder": "0.19.0",
-        "@n8n/api-types": "0.43.0",
-        "@n8n/backend-common": "^0.19.0",
-        "@n8n/backend-test-utils": "^0.12.0",
-        "@n8n/client-oauth2": "0.28.0",
-        "@n8n/config": "1.52.0",
+        "@n8n/ai-workflow-builder": "0.20.0",
+        "@n8n/api-types": "0.44.0",
+        "@n8n/backend-common": "^0.20.0",
+        "@n8n/backend-test-utils": "^0.13.0",
+        "@n8n/client-oauth2": "0.29.0",
+        "@n8n/config": "1.53.0",
         "@n8n/constants": "^0.11.0",
-        "@n8n/db": "^0.20.0",
-        "@n8n/decorators": "0.19.0",
+        "@n8n/db": "^0.21.0",
+        "@n8n/decorators": "0.20.0",
         "@n8n/di": "0.9.0",
-        "@n8n/errors": "0.4.0",
+        "@n8n/errors": "0.5.0",
         "@n8n/localtunnel": "3.0.0",
-        "@n8n/n8n-nodes-langchain": "1.108.1",
-        "@n8n/permissions": "0.32.0",
-        "@n8n/task-runner": "1.45.0",
+        "@n8n/n8n-nodes-langchain": "1.109.1",
+        "@n8n/permissions": "0.33.0",
+        "@n8n/task-runner": "1.46.0",
         "@n8n/typeorm": "0.3.20-12",
         "@rudderstack/rudder-sdk-node": "2.1.4",
         "@sentry/node": "^9.42.1",
@@ -21941,10 +22280,10 @@
         "lodash": "4.17.21",
         "luxon": "3.4.4",
         "mysql2": "3.11.0",
-        "n8n-core": "1.108.0",
-        "n8n-editor-ui": "1.109.2",
-        "n8n-nodes-base": "1.107.0",
-        "n8n-workflow": "1.106.0",
+        "n8n-core": "1.109.0",
+        "n8n-editor-ui": "1.110.1",
+        "n8n-nodes-base": "1.108.0",
+        "n8n-workflow": "1.107.0",
         "nanoid": "3.3.8",
         "nodemailer": "6.9.9",
         "oauth-1.0a": "2.2.6",
@@ -22035,49 +22374,6 @@
         "n8n-copy-static-files": "bin/copy-static-files",
         "n8n-generate-metadata": "bin/generate-metadata",
         "n8n-generate-translations": "bin/generate-translations"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@n8n/backend-common": {
-      "version": "0.20.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/config": "^1.53.0",
-        "@n8n/constants": "^0.11.0",
-        "@n8n/decorators": "^0.20.0",
-        "@n8n/di": "^0.9.0",
-        "callsites": "3.1.0",
-        "n8n-workflow": "^1.107.0",
-        "picocolors": "1.0.1",
-        "reflect-metadata": "0.2.2",
-        "winston": "3.14.2",
-        "yargs-parser": "21.1.1"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@n8n/config": {
-      "version": "1.53.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/di": "0.9.0",
-        "reflect-metadata": "0.2.2",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@n8n/decorators": {
-      "version": "0.20.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/constants": "^0.11.0",
-        "@n8n/di": "^0.9.0",
-        "@n8n/permissions": "^0.33.0",
-        "lodash": "4.17.21",
-        "n8n-workflow": "^1.107.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@n8n/permissions": {
-      "version": "0.33.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "zod": "3.25.67"
       }
     },
     "node_modules/n8n-core/node_modules/axios": {
@@ -22183,7 +22479,9 @@
       }
     },
     "node_modules/n8n-editor-ui": {
-      "version": "1.109.2",
+      "version": "1.110.1",
+      "resolved": "https://registry.npmjs.org/n8n-editor-ui/-/n8n-editor-ui-1.110.1.tgz",
+      "integrity": "sha512-D3SF9dIPDEGnTTyGP7phD/qbntZOhqlcb4fCECBdwbW07xwxgrC1OTiby++nJX9W0uC7B6Zj+gvdkWbb+60B4A==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/n8n-nodes-base": {
@@ -22262,15 +22560,6 @@
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
         "xml2js": "0.6.2",
         "xmlhttprequest-ssl": "3.1.0"
-      }
-    },
-    "node_modules/n8n-nodes-base/node_modules/@n8n/config": {
-      "version": "1.53.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/di": "0.9.0",
-        "reflect-metadata": "0.2.2",
-        "zod": "3.25.67"
       }
     },
     "node_modules/n8n-nodes-base/node_modules/@redis/client": {
@@ -22515,13 +22804,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/n8n-nodes-base/node_modules/zod": {
-      "version": "3.25.67",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/n8n-workflow": {
       "version": "1.107.0",
       "license": "SEE LICENSE IN LICENSE.md",
@@ -22552,220 +22834,10 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
-    "node_modules/n8n/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.12.0",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.6",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/client-oauth2": {
-      "version": "0.28.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "axios": "1.8.3"
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/errors": {
-      "version": "0.4.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "callsites": "3.1.0"
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/imap": {
-      "version": "0.14.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "iconv-lite": "0.6.3",
-        "imap": "0.8.19",
-        "quoted-printable": "1.0.1",
-        "utf8": "3.0.0",
-        "uuencode": "0.0.4"
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain": {
-      "version": "1.108.1",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.808.0",
-        "@azure/identity": "4.3.0",
-        "@getzep/zep-cloud": "1.0.12",
-        "@getzep/zep-js": "0.9.0",
-        "@google-ai/generativelanguage": "2.6.0",
-        "@google-cloud/resource-manager": "5.3.0",
-        "@google/generative-ai": "0.21.0",
-        "@huggingface/inference": "4.0.5",
-        "@langchain/anthropic": "0.3.26",
-        "@langchain/aws": "0.1.11",
-        "@langchain/cohere": "0.3.4",
-        "@langchain/community": "0.3.50",
-        "@langchain/core": "0.3.68",
-        "@langchain/google-genai": "0.2.13",
-        "@langchain/google-vertexai": "0.2.13",
-        "@langchain/groq": "0.2.3",
-        "@langchain/mistralai": "0.2.1",
-        "@langchain/mongodb": "^0.1.0",
-        "@langchain/ollama": "0.2.3",
-        "@langchain/openai": "0.6.7",
-        "@langchain/pinecone": "0.2.0",
-        "@langchain/qdrant": "0.1.2",
-        "@langchain/redis": "0.1.1",
-        "@langchain/textsplitters": "0.1.0",
-        "@langchain/weaviate": "0.2.0",
-        "@modelcontextprotocol/sdk": "1.12.0",
-        "@mozilla/readability": "0.6.0",
-        "@n8n/client-oauth2": "0.28.0",
-        "@n8n/errors": "^0.4.0",
-        "@n8n/json-schema-to-zod": "1.5.0",
-        "@n8n/typeorm": "0.3.20-12",
-        "@n8n/typescript-config": "1.3.0",
-        "@n8n/vm2": "3.9.25",
-        "@pinecone-database/pinecone": "^5.0.2",
-        "@qdrant/js-client-rest": "1.14.1",
-        "@supabase/supabase-js": "2.49.9",
-        "@xata.io/client": "0.28.4",
-        "@zilliz/milvus2-sdk-node": "^2.5.7",
-        "basic-auth": "2.0.1",
-        "cheerio": "1.0.0",
-        "cohere-ai": "7.14.0",
-        "d3-dsv": "2.0.0",
-        "epub2": "3.0.2",
-        "form-data": "4.0.0",
-        "generate-schema": "2.6.0",
-        "html-to-text": "9.0.5",
-        "https-proxy-agent": "7.0.6",
-        "ignore": "^5.2.0",
-        "js-tiktoken": "^1.0.12",
-        "jsdom": "23.0.1",
-        "langchain": "0.3.30",
-        "lodash": "4.17.21",
-        "mammoth": "1.7.2",
-        "mime-types": "2.1.35",
-        "mongodb": "6.11.0",
-        "n8n-nodes-base": "1.107.0",
-        "n8n-workflow": "1.106.0",
-        "openai": "5.12.2",
-        "pdf-parse": "1.1.1",
-        "pg": "8.12.0",
-        "proxy-from-env": "^1.1.0",
-        "redis": "4.6.12",
-        "sanitize-html": "2.12.1",
-        "sqlite3": "5.1.7",
-        "temp": "0.9.4",
-        "tmp-promise": "3.0.3",
-        "undici": "^6.21.0",
-        "weaviate-client": "3.6.2",
-        "zod": "3.25.67",
-        "zod-to-json-schema": "3.23.3"
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain/node_modules/mongodb": {
-      "version": "6.11.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.0",
-        "mongodb-connection-string-url": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain/node_modules/openai": {
-      "version": "5.12.2",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain/node_modules/ws": {
-      "version": "8.18.3",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain/node_modules/zod-to-json-schema": {
-      "version": "3.23.3",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.23.3"
-      }
-    },
     "node_modules/n8n/node_modules/@n8n/typeorm": {
       "version": "0.3.20-12",
+      "resolved": "https://registry.npmjs.org/@n8n/typeorm/-/typeorm-0.3.20-12.tgz",
+      "integrity": "sha512-Jc+Uys9HXTRq+u2XTqnAqjZVvAPwYH4qy4wRcizN0u7sfBvRGRpeF8ZAoplOGjXPRBG278QKcfVAJ64j/bj+uQ==",
       "license": "MIT",
       "dependencies": {
         "@n8n/p-retry": "6.2.0-2",
@@ -22880,6 +22952,8 @@
     },
     "node_modules/n8n/node_modules/@n8n/typeorm/node_modules/dotenv": {
       "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -22890,6 +22964,8 @@
     },
     "node_modules/n8n/node_modules/@n8n/typeorm/node_modules/uuid": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -22899,36 +22975,10 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/n8n/node_modules/@qdrant/js-client-rest": {
-      "version": "1.14.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@qdrant/openapi-typescript-fetch": "1.2.6",
-        "@sevinf/maybe": "0.5.0",
-        "undici": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=18.17.0",
-        "pnpm": ">=8"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.7"
-      }
-    },
-    "node_modules/n8n/node_modules/@redis/client": {
-      "version": "1.5.16",
-      "license": "MIT",
-      "dependencies": {
-        "cluster-key-slot": "1.1.2",
-        "generic-pool": "3.9.0",
-        "yallist": "4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/n8n/node_modules/@types/whatwg-url": {
       "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -22939,6 +22989,8 @@
     },
     "node_modules/n8n/node_modules/axios": {
       "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -22948,6 +23000,8 @@
     },
     "node_modules/n8n/node_modules/better-sqlite3": {
       "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -22957,114 +23011,15 @@
         "prebuild-install": "^7.1.1"
       }
     },
-    "node_modules/n8n/node_modules/cheerio-select": {
-      "version": "1.6.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "css-select": "^4.3.0",
-        "css-what": "^6.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/n8n/node_modules/cheerio-select/node_modules/domhandler": {
-      "version": "4.3.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
+    "node_modules/n8n/node_modules/bson": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/cheerio-select/node_modules/domutils": {
-      "version": "2.8.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/css-select": {
-      "version": "4.3.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/n8n/node_modules/css-select/node_modules/domhandler": {
-      "version": "4.3.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/css-select/node_modules/domutils": {
-      "version": "2.8.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/dom-serializer/node_modules/domhandler": {
-      "version": "4.3.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+        "node": ">=14.20.1"
       }
     },
     "node_modules/n8n/node_modules/dotenv": {
@@ -23074,18 +23029,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/n8n/node_modules/entities": {
-      "version": "6.0.1",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/n8n/node_modules/express-rate-limit": {
       "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -23097,16 +23044,14 @@
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
-    "node_modules/n8n/node_modules/fflate": {
-      "version": "0.7.4",
-      "license": "MIT"
-    },
     "node_modules/n8n/node_modules/flatted": {
       "version": "3.2.7",
       "license": "ISC"
     },
     "node_modules/n8n/node_modules/glob": {
       "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -23123,25 +23068,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/n8n/node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
-      }
-    },
     "node_modules/n8n/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -23152,6 +23082,8 @@
     },
     "node_modules/n8n/node_modules/jackspeak": {
       "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -23165,10 +23097,14 @@
     },
     "node_modules/n8n/node_modules/lru-cache": {
       "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
     "node_modules/n8n/node_modules/mkdirp": {
       "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
       "license": "MIT",
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
@@ -23182,6 +23118,8 @@
     },
     "node_modules/n8n/node_modules/mongodb": {
       "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -23221,303 +23159,16 @@
         }
       }
     },
-    "node_modules/n8n/node_modules/mongodb/node_modules/bson": {
-      "version": "5.5.1",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14.20.1"
-      }
-    },
-    "node_modules/n8n/node_modules/mongodb/node_modules/mongodb-connection-string-url": {
+    "node_modules/n8n/node_modules/mongodb-connection-string-url": {
       "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-core": {
-      "version": "1.108.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@aws-sdk/client-s3": "3.808.0",
-        "@langchain/core": "0.3.68",
-        "@n8n/backend-common": "^0.19.0",
-        "@n8n/client-oauth2": "0.28.0",
-        "@n8n/config": "1.52.0",
-        "@n8n/constants": "0.11.0",
-        "@n8n/decorators": "0.19.0",
-        "@n8n/di": "0.9.0",
-        "@sentry/node": "^9.42.1",
-        "@sentry/node-native": "^9.42.1",
-        "axios": "1.8.3",
-        "callsites": "3.1.0",
-        "chardet": "2.0.0",
-        "cron": "3.1.7",
-        "fast-glob": "3.2.12",
-        "file-type": "16.5.4",
-        "form-data": "4.0.0",
-        "htmlparser2": "^10.0.0",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "iconv-lite": "0.6.3",
-        "jsonwebtoken": "9.0.2",
-        "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "mime-types": "2.1.35",
-        "n8n-workflow": "1.106.0",
-        "nanoid": "3.3.8",
-        "oauth-1.0a": "2.2.6",
-        "p-cancelable": "2.1.1",
-        "picocolors": "1.0.1",
-        "pretty-bytes": "5.6.0",
-        "proxy-from-env": "^1.1.0",
-        "qs": "6.11.0",
-        "ssh2": "1.15.0",
-        "uuid": "10.0.0",
-        "winston": "3.14.2",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
-      },
-      "bin": {
-        "n8n-copy-static-files": "bin/copy-static-files",
-        "n8n-generate-metadata": "bin/generate-metadata",
-        "n8n-generate-translations": "bin/generate-translations"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base": {
-      "version": "1.107.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.808.0",
-        "@kafkajs/confluent-schema-registry": "3.8.0",
-        "@mozilla/readability": "0.6.0",
-        "@n8n/config": "1.52.0",
-        "@n8n/di": "0.9.0",
-        "@n8n/errors": "^0.4.0",
-        "@n8n/imap": "0.14.0",
-        "@n8n/vm2": "3.9.25",
-        "alasql": "4.4.0",
-        "amqplib": "0.10.6",
-        "aws4": "1.11.0",
-        "basic-auth": "2.0.1",
-        "change-case": "4.1.2",
-        "cheerio": "1.0.0-rc.6",
-        "chokidar": "4.0.3",
-        "cron": "3.1.7",
-        "csv-parse": "5.5.0",
-        "currency-codes": "2.1.0",
-        "eventsource": "2.0.2",
-        "fast-glob": "3.2.12",
-        "fastest-levenshtein": "^1.0.16",
-        "fflate": "0.7.4",
-        "generate-schema": "2.6.0",
-        "get-system-fonts": "2.0.2",
-        "gm": "1.25.1",
-        "html-to-text": "9.0.5",
-        "iconv-lite": "0.6.3",
-        "ics": "2.40.0",
-        "isbot": "3.6.13",
-        "iso-639-1": "2.1.15",
-        "js-nacl": "1.4.0",
-        "jsdom": "23.0.1",
-        "jsonwebtoken": "9.0.2",
-        "kafkajs": "2.2.4",
-        "ldapts": "4.2.6",
-        "lodash": "4.17.21",
-        "lossless-json": "1.0.5",
-        "luxon": "3.4.4",
-        "mailparser": "3.6.7",
-        "minifaker": "1.34.1",
-        "moment-timezone": "0.5.48",
-        "mongodb": "6.11.0",
-        "mqtt": "5.7.2",
-        "mssql": "10.0.2",
-        "mysql2": "3.11.0",
-        "n8n-workflow": "1.106.0",
-        "node-html-markdown": "1.2.0",
-        "node-ssh": "13.2.0",
-        "nodemailer": "6.9.9",
-        "otpauth": "9.1.1",
-        "pdfjs-dist": "5.3.31",
-        "pg": "8.12.0",
-        "pg-promise": "11.9.1",
-        "promise-ftp": "1.3.5",
-        "pyodide": "0.28.0",
-        "redis": "4.6.14",
-        "rfc2047": "4.0.1",
-        "rhea": "1.0.24",
-        "rrule": "2.8.1",
-        "rss-parser": "3.13.0",
-        "sanitize-html": "2.12.1",
-        "semver": "7.5.4",
-        "showdown": "2.1.0",
-        "simple-git": "3.17.0",
-        "snowflake-sdk": "2.1.0",
-        "ssh2-sftp-client": "12.0.1",
-        "tmp-promise": "3.0.3",
-        "ts-ics": "1.2.2",
-        "uuid": "10.0.0",
-        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
-        "xml2js": "0.6.2",
-        "xmlhttprequest-ssl": "3.1.0"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/cheerio": {
-      "version": "1.0.0-rc.6",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^1.3.0",
-        "dom-serializer": "^1.3.1",
-        "domhandler": "^4.1.0",
-        "htmlparser2": "^6.1.0",
-        "parse5": "^6.0.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/domhandler": {
-      "version": "4.3.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/domutils": {
-      "version": "2.8.0",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/entities": {
-      "version": "2.2.0",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/eventsource": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/mongodb": {
-      "version": "6.11.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.0",
-        "mongodb-connection-string-url": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/redis": {
-      "version": "4.6.14",
-      "license": "MIT",
-      "workspaces": [
-        "./packages/*"
-      ],
-      "dependencies": {
-        "@redis/bloom": "1.2.0",
-        "@redis/client": "1.5.16",
-        "@redis/graph": "1.1.1",
-        "@redis/json": "1.0.6",
-        "@redis/search": "1.1.6",
-        "@redis/time-series": "1.0.5"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-workflow": {
-      "version": "1.106.0",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "^0.4.0",
-        "@n8n/tournament": "1.0.6",
-        "ast-types": "0.15.2",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.0",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.2",
-        "jssha": "3.3.1",
-        "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
       }
     },
     "node_modules/n8n/node_modules/open": {
@@ -23534,19 +23185,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/n8n/node_modules/parse5": {
-      "version": "6.0.1",
-      "license": "MIT"
-    },
-    "node_modules/n8n/node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^6.0.1"
-      }
-    },
     "node_modules/n8n/node_modules/path-scurry": {
       "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -23561,35 +23203,14 @@
     },
     "node_modules/n8n/node_modules/picocolors": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "license": "ISC"
-    },
-    "node_modules/n8n/node_modules/pyodide": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.28.0.tgz",
-      "integrity": "sha512-QML/Gh8eu50q5zZKLNpW6rgS0XUdK+94OSL54AUSKV8eJAxgwZrMebqj+CyM0EbF3EUX8JFJU3ryaxBViHammQ==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "ws": "^8.5.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/n8n/node_modules/qs": {
-      "version": "6.11.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/n8n/node_modules/raw-body": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -23601,20 +23222,10 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/n8n/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/n8n/node_modules/semver": {
       "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -23628,6 +23239,8 @@
     },
     "node_modules/n8n/node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -23638,6 +23251,8 @@
     },
     "node_modules/n8n/node_modules/tr46": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -23650,6 +23265,8 @@
     },
     "node_modules/n8n/node_modules/whatwg-url": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -23661,28 +23278,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/n8n/node_modules/winston": {
-      "version": "3.14.2",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/n8n/node_modules/ws": {
       "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -23702,6 +23301,8 @@
     },
     "node_modules/n8n/node_modules/zod": {
       "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -23759,6 +23360,8 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "license": "MIT",
       "peer": true
     },
@@ -24033,6 +23636,8 @@
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "license": "MIT",
       "peer": true
     },
@@ -24041,7 +23646,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.20.tgz",
+      "integrity": "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==",
       "license": "MIT",
       "peer": true
     },
@@ -24217,6 +23824,8 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -24380,6 +23989,8 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -24521,6 +24132,8 @@
     },
     "node_modules/p-lazy": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-lazy/-/p-lazy-3.1.0.tgz",
+      "integrity": "sha512-sCJn0Cdahs6G6SX9+DUihVFUhrzDEduzE5xeViVBGtoqy5dBWko7W8T6Kk6TjR2uevRXJO7CShfWrqdH5s3w3g==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24541,6 +24154,8 @@
     },
     "node_modules/p-locate": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -24552,6 +24167,8 @@
     },
     "node_modules/p-locate/node_modules/p-limit": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -24615,6 +24232,8 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -24639,6 +24258,8 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -24742,6 +24363,8 @@
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -24960,6 +24583,8 @@
     },
     "node_modules/pirates": {
       "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -24975,6 +24600,8 @@
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -25151,6 +24778,8 @@
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -25235,6 +24864,8 @@
     },
     "node_modules/prompts": {
       "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -25322,6 +24953,8 @@
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
       "funding": [
         {
           "type": "individual",
@@ -25479,6 +25112,8 @@
     },
     "node_modules/react-is": {
       "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT",
       "peer": true
     },
@@ -25721,6 +25356,8 @@
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -25732,6 +25369,8 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -25740,6 +25379,8 @@
     },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -26880,11 +26521,15 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -27253,6 +26898,8 @@
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -27264,6 +26911,8 @@
     },
     "node_modules/stack-utils/node_modules/escape-string-regexp": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -27363,6 +27012,8 @@
     },
     "node_modules/string-length": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -27375,6 +27026,8 @@
     },
     "node_modules/string-length/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -27383,6 +27036,8 @@
     },
     "node_modules/string-length/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -27524,6 +27179,8 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -27532,6 +27189,8 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -27551,6 +27210,8 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -28132,6 +27793,8 @@
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "license": "BSD-3-Clause",
       "peer": true
     },
@@ -28265,6 +27928,8 @@
     },
     "node_modules/ts-essentials": {
       "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.1.1.tgz",
+      "integrity": "sha512-4aTB7KLHKmUvkjNj8V+EdnmuVTiECzn3K+zIbRthumvHu+j44x3w63xpfs0JL3NGIzGXqoQ7AV591xHO+XrOTw==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.5.0"
@@ -28606,6 +28271,8 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "funding": [
         {
           "type": "opencollective",
@@ -28726,6 +28393,8 @@
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -28739,6 +28408,8 @@
     },
     "node_modules/validator": {
       "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -28966,6 +28637,8 @@
     },
     "node_modules/walker": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -29507,6 +29180,8 @@
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -29519,6 +29194,8 @@
     },
     "node_modules/write-file-atomic/node_modules/signal-exit": {
       "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC",
       "peer": true
     },
@@ -29642,6 +29319,8 @@
     },
     "node_modules/xss": {
       "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^2.20.3",
@@ -29851,6 +29530,8 @@
     },
     "node_modules/zod-class": {
       "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/zod-class/-/zod-class-0.0.16.tgz",
+      "integrity": "sha512-3A1l81VEUOxvSTGoNPsU4fTUY9CKin/HSySnXT3bIc+TJTDGCPbzSPE8W1VvwXqyzHEIWK608eFZja2uew9Ivw==",
       "dependencies": {
         "type-fest": "^4.14.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.10.8",
+  "version": "2.10.9",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "bin": {
@@ -128,12 +128,12 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.2",
-    "@n8n/n8n-nodes-langchain": "^1.108.1",
+    "@n8n/n8n-nodes-langchain": "^1.109.1",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "n8n": "^1.109.2",
-    "n8n-core": "^1.108.0",
-    "n8n-workflow": "^1.106.0",
+    "n8n": "^1.110.1",
+    "n8n-core": "^1.109.0",
+    "n8n-workflow": "^1.107.0",
     "sql.js": "^1.13.0",
     "uuid": "^10.0.0"
   },

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.10.1",
+  "version": "2.10.9",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
- Update n8n packages to version 1.110.1
- Rebuild node database with 536 nodes
- Update templates database with 499 latest workflows

## Dependencies Updated
- n8n: 1.109.2 → 1.110.1
- n8n-core: 1.108.0 → 1.109.0  
- n8n-workflow: 1.106.0 → 1.107.0
- @n8n/n8n-nodes-langchain: 1.108.1 → 1.109.1

## Changes
- Bumped version to 2.10.9
- Updated README badges
- Added CHANGELOG entry

## Test Status
All tests passing locally after dependency update.