### PR TITLE
Fix: Extract instance context from HTTP headers for multi-tenant support

### DIFF
--- a/docs/FLEXIBLE_INSTANCE_CONFIGURATION.md
+++ b/docs/FLEXIBLE_INSTANCE_CONFIGURATION.md
@@ -99,6 +99,61 @@ if (client) {
 }
 ```
 
+### HTTP Headers for Multi-Tenant Support
+
+When using the HTTP server mode, clients can pass instance-specific configuration via HTTP headers:
+
+```bash
+# Example curl request with instance headers
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer your-auth-token" \
+  -H "Content-Type: application/json" \
+  -H "X-N8n-Url: https://instance1.n8n.cloud" \
+  -H "X-N8n-Key: instance1-api-key" \
+  -H "X-Instance-Id: instance-1" \
+  -H "X-Session-Id: session-123" \
+  -d '{"method": "n8n_list_workflows", "params": {}, "id": 1}'
+```
+
+#### Supported Headers
+
+- **X-N8n-Url**: The n8n instance URL (e.g., `https://instance.n8n.cloud`)
+- **X-N8n-Key**: The API key for authentication with the n8n instance
+- **X-Instance-Id**: A unique identifier for the instance (optional, for tracking)
+- **X-Session-Id**: A session identifier (optional, for session tracking)
+
+#### Header Extraction Logic
+
+1. If either `X-N8n-Url` or `X-N8n-Key` header is present, an instance context is created
+2. All headers are extracted and passed to the MCP server
+3. The server uses the instance-specific configuration instead of environment variables
+4. If no headers are present, the server falls back to environment variables (backward compatible)
+
+#### Example: JavaScript Client
+
+```javascript
+const headers = {
+  'Authorization': 'Bearer your-auth-token',
+  'Content-Type': 'application/json',
+  'X-N8n-Url': 'https://customer1.n8n.cloud',
+  'X-N8n-Key': 'customer1-api-key',
+  'X-Instance-Id': 'customer-1',
+  'X-Session-Id': 'session-456'
+};
+
+const response = await fetch('http://localhost:3000/mcp', {
+  method: 'POST',
+  headers: headers,
+  body: JSON.stringify({
+    method: 'n8n_list_workflows',
+    params: {},
+    id: 1
+  })
+});
+
+const result = await response.json();
+```
+
 ### HTTP Server Integration
 
 ```typescript


### PR DESCRIPTION
## Summary
Fixes the critical bug in the multi-tenant feature (PR #209) where HTTP headers containing instance-specific configuration were not being extracted and passed to the MCP server.

## Problem
The flexible instance configuration feature was implemented but not working because:
- Instance context headers (X-N8n-Url, X-N8n-Key, etc.) were sent by clients
- Headers were NOT extracted in the POST /mcp handler
- The `handleRequest()` method was called without the instance context
- Server always fell back to environment variables, preventing multi-tenant routing

## Solution
Extract headers and pass them to the existing `handleRequest()` method:
```typescript
// Extract instance context from headers if present
const instanceContext = (req.headers['x-n8n-url'] || req.headers['x-n8n-key']) ? {
  n8nApiUrl: req.headers['x-n8n-url'],
  n8nApiKey: req.headers['x-n8n-key'],
  instanceId: req.headers['x-instance-id'],
  sessionId: req.headers['x-session-id']
} : undefined;

await this.handleRequest(req, res, instanceContext);
```

## Changes
- ✅ Added header extraction logic in `http-server-single-session.ts`
- ✅ Added comprehensive tests for all header extraction scenarios
- ✅ Updated documentation with header specifications and examples
- ✅ Maintains full backward compatibility

## Testing
- All 16 new tests pass
- TypeScript compilation successful
- Type checking passes
- Linting passes
- No breaking changes

## Backward Compatibility
✅ **Fully backward compatible**:
- When no headers are sent → `instanceContext` is `undefined` → falls back to env vars
- Existing single-instance deployments continue working unchanged
- The `instanceContext` parameter was already optional in `handleRequest()`

## Related
- Fixes issue reported in multi-tenant test report
- Completes feature from PR #209

🤖 Generated with [Claude Code](https://claude.ai/code)