### PR TITLE
fix: enhance error output validation to detect incorrect configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub stars](https://img.shields.io/github/stars/czlonkowski/n8n-mcp?style=social)](https://github.com/czlonkowski/n8n-mcp)
-[![Version](https://img.shields.io/badge/version-2.12.0-blue.svg)](https://github.com/czlonkowski/n8n-mcp)
+[![Version](https://img.shields.io/badge/version-2.12.1-blue.svg)](https://github.com/czlonkowski/n8n-mcp)
 [![npm version](https://img.shields.io/npm/v/n8n-mcp.svg)](https://www.npmjs.com/package/n8n-mcp)
 [![codecov](https://codecov.io/gh/czlonkowski/n8n-mcp/graph/badge.svg?token=YOUR_TOKEN)](https://codecov.io/gh/czlonkowski/n8n-mcp)
 [![Tests](https://img.shields.io/badge/tests-1728%20passing-brightgreen.svg)](https://github.com/czlonkowski/n8n-mcp/actions)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.1] - 2025-09-22
+
+### Fixed
+- **Error Output Validation**: Enhanced workflow validator to detect incorrect error output configurations
+  - Detects when multiple nodes are incorrectly placed in the same output array (main[0])
+  - Validates that error handlers are properly connected to main[1] (error output) instead of main[0]
+  - Cross-validates onError property ('continueErrorOutput') matches actual connection structure
+  - Provides clear, actionable error messages with JSON examples showing correct configuration
+  - Uses heuristic detection for error handler nodes (names containing "error", "fail", "catch", etc.)
+  - Added comprehensive test coverage with 16+ test cases
+
+### Improved
+- **Validation Messages**: Error messages now include detailed JSON examples showing both incorrect and correct configurations
+- **Pattern Detection**: Fixed `checkWorkflowPatterns` to check main[1] for error outputs instead of non-existent outputs.error
+- **Test Coverage**: Added new test file `workflow-validator-error-outputs.test.ts` with extensive error output validation scenarios
+
 ## [2.12.0] - 2025-09-19
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Comprehensive Expression Format Validation System**: Three-tier validation strategy for n8n expressions
+  - **Universal Expression Validator**: 100% reliable detection of expression format issues
+    - Enforces required `=` prefix for all expressions `{{ }}`
+    - Validates expression syntax (bracket matching, empty expressions)
+    - Detects common mistakes (template literals, nested brackets, double prefixes)
+    - Provides confidence score of 1.0 for universal rules
+  - **Confidence-Based Node-Specific Recommendations**: Intelligent resource locator suggestions
+    - Confidence scoring system (0.0 to 1.0) for field-specific recommendations
+    - High confidence (≥0.8): Exact field matches for known nodes (GitHub owner/repository, Slack channels)
+    - Medium confidence (≥0.5): Field pattern matches (fields ending in Id, Key, Name)
+    - Factors: exact field match, field patterns, value patterns, node category
+  - **Resource Locator Format Detection**: Identifies fields needing `__rl` structure
+    - Validates resource locator mode (id, url, expression, name, list)
+    - Auto-fixes missing prefixes in resource locator values
+    - Provides clear JSON examples showing correct format
+  - **Enhanced Safety Features**:
+    - Recursion depth protection (MAX_RECURSION_DEPTH = 100) prevents infinite loops
+    - Pattern matching precision using exact/prefix matching instead of includes()
+    - Circular reference detection with WeakSet
+  - **Separation of Concerns**: Clean architecture for maintainability
+    - Universal rules separated from node-specific intelligence
+    - Confidence-based application of suggestions
+    - Future-proof design that works with any n8n node
+
 ## [2.12.1] - 2025-09-22
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "bin": {

--- a/scripts/test-error-output-validation.ts
+++ b/scripts/test-error-output-validation.ts
@@ -1,0 +1,274 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Test script for error output validation improvements
+ * Tests both incorrect and correct error output configurations
+ */
+
+import { WorkflowValidator } from '../dist/services/workflow-validator.js';
+import { NodeRepository } from '../dist/database/node-repository.js';
+import { EnhancedConfigValidator } from '../dist/services/enhanced-config-validator.js';
+import { DatabaseAdapter } from '../dist/database/database-adapter.js';
+import { Logger } from '../dist/utils/logger.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const logger = new Logger({ prefix: '[TestErrorValidation]' });
+
+async function runTests() {
+  // Initialize database
+  const dbPath = path.join(__dirname, '..', 'data', 'n8n-nodes.db');
+  const adapter = new DatabaseAdapter();
+  adapter.initialize({
+    type: 'better-sqlite3',
+    filename: dbPath
+  });
+  const db = adapter.getDatabase();
+
+  const nodeRepository = new NodeRepository(db);
+  const validator = new WorkflowValidator(nodeRepository, EnhancedConfigValidator);
+
+  console.log('\n🧪 Testing Error Output Validation Improvements\n');
+  console.log('=' .repeat(60));
+
+  // Test 1: Incorrect configuration - multiple nodes in same array
+  console.log('\n📝 Test 1: INCORRECT - Multiple nodes in main[0]');
+  console.log('-'.repeat(40));
+
+  const incorrectWorkflow = {
+    nodes: [
+      {
+        id: '132ef0dc-87af-41de-a95d-cabe3a0a5342',
+        name: 'Validate Input',
+        type: 'n8n-nodes-base.set',
+        typeVersion: 3.4,
+        position: [-400, 64] as [number, number],
+        parameters: {}
+      },
+      {
+        id: '5dedf217-63f9-409f-b34e-7780b22e199a',
+        name: 'Filter URLs',
+        type: 'n8n-nodes-base.filter',
+        typeVersion: 2.2,
+        position: [-176, 64] as [number, number],
+        parameters: {}
+      },
+      {
+        id: '9d5407cc-ca5a-4966-b4b7-0e5dfbf54ad3',
+        name: 'Error Response1',
+        type: 'n8n-nodes-base.respondToWebhook',
+        typeVersion: 1.5,
+        position: [-160, 240] as [number, number],
+        parameters: {}
+      }
+    ],
+    connections: {
+      'Validate Input': {
+        main: [
+          [
+            { node: 'Filter URLs', type: 'main', index: 0 },
+            { node: 'Error Response1', type: 'main', index: 0 }  // WRONG!
+          ]
+        ]
+      }
+    }
+  };
+
+  const result1 = await validator.validateWorkflow(incorrectWorkflow);
+
+  if (result1.errors.length > 0) {
+    console.log('❌ ERROR DETECTED (as expected):');
+    const errorMessage = result1.errors.find(e =>
+      e.message.includes('Incorrect error output configuration')
+    );
+    if (errorMessage) {
+      console.log('\n' + errorMessage.message);
+    }
+  } else {
+    console.log('✅ No errors found (but should have detected the issue!)');
+  }
+
+  // Test 2: Correct configuration - separate arrays
+  console.log('\n📝 Test 2: CORRECT - Separate main[0] and main[1]');
+  console.log('-'.repeat(40));
+
+  const correctWorkflow = {
+    nodes: [
+      {
+        id: '132ef0dc-87af-41de-a95d-cabe3a0a5342',
+        name: 'Validate Input',
+        type: 'n8n-nodes-base.set',
+        typeVersion: 3.4,
+        position: [-400, 64] as [number, number],
+        parameters: {},
+        onError: 'continueErrorOutput' as const
+      },
+      {
+        id: '5dedf217-63f9-409f-b34e-7780b22e199a',
+        name: 'Filter URLs',
+        type: 'n8n-nodes-base.filter',
+        typeVersion: 2.2,
+        position: [-176, 64] as [number, number],
+        parameters: {}
+      },
+      {
+        id: '9d5407cc-ca5a-4966-b4b7-0e5dfbf54ad3',
+        name: 'Error Response1',
+        type: 'n8n-nodes-base.respondToWebhook',
+        typeVersion: 1.5,
+        position: [-160, 240] as [number, number],
+        parameters: {}
+      }
+    ],
+    connections: {
+      'Validate Input': {
+        main: [
+          [
+            { node: 'Filter URLs', type: 'main', index: 0 }
+          ],
+          [
+            { node: 'Error Response1', type: 'main', index: 0 }  // CORRECT!
+          ]
+        ]
+      }
+    }
+  };
+
+  const result2 = await validator.validateWorkflow(correctWorkflow);
+
+  const hasIncorrectError = result2.errors.some(e =>
+    e.message.includes('Incorrect error output configuration')
+  );
+
+  if (!hasIncorrectError) {
+    console.log('✅ No error output configuration issues (correct!)');
+  } else {
+    console.log('❌ Unexpected error found');
+  }
+
+  // Test 3: onError without error connections
+  console.log('\n📝 Test 3: onError without error connections');
+  console.log('-'.repeat(40));
+
+  const mismatchWorkflow = {
+    nodes: [
+      {
+        id: '1',
+        name: 'HTTP Request',
+        type: 'n8n-nodes-base.httpRequest',
+        typeVersion: 4,
+        position: [100, 100] as [number, number],
+        parameters: {},
+        onError: 'continueErrorOutput' as const
+      },
+      {
+        id: '2',
+        name: 'Process Data',
+        type: 'n8n-nodes-base.set',
+        typeVersion: 2,
+        position: [300, 100] as [number, number],
+        parameters: {}
+      }
+    ],
+    connections: {
+      'HTTP Request': {
+        main: [
+          [
+            { node: 'Process Data', type: 'main', index: 0 }
+          ]
+          // No main[1] for error output
+        ]
+      }
+    }
+  };
+
+  const result3 = await validator.validateWorkflow(mismatchWorkflow);
+
+  const mismatchError = result3.errors.find(e =>
+    e.message.includes("has onError: 'continueErrorOutput' but no error output connections")
+  );
+
+  if (mismatchError) {
+    console.log('❌ ERROR DETECTED (as expected):');
+    console.log(`Node: ${mismatchError.nodeName}`);
+    console.log(`Message: ${mismatchError.message}`);
+  } else {
+    console.log('✅ No mismatch detected (but should have!)');
+  }
+
+  // Test 4: Error connections without onError
+  console.log('\n📝 Test 4: Error connections without onError property');
+  console.log('-'.repeat(40));
+
+  const missingOnErrorWorkflow = {
+    nodes: [
+      {
+        id: '1',
+        name: 'HTTP Request',
+        type: 'n8n-nodes-base.httpRequest',
+        typeVersion: 4,
+        position: [100, 100] as [number, number],
+        parameters: {}
+        // Missing onError property
+      },
+      {
+        id: '2',
+        name: 'Process Data',
+        type: 'n8n-nodes-base.set',
+        position: [300, 100] as [number, number],
+        parameters: {}
+      },
+      {
+        id: '3',
+        name: 'Error Handler',
+        type: 'n8n-nodes-base.set',
+        position: [300, 300] as [number, number],
+        parameters: {}
+      }
+    ],
+    connections: {
+      'HTTP Request': {
+        main: [
+          [
+            { node: 'Process Data', type: 'main', index: 0 }
+          ],
+          [
+            { node: 'Error Handler', type: 'main', index: 0 }
+          ]
+        ]
+      }
+    }
+  };
+
+  const result4 = await validator.validateWorkflow(missingOnErrorWorkflow);
+
+  const missingOnErrorWarning = result4.warnings.find(w =>
+    w.message.includes('error output connections in main[1] but missing onError')
+  );
+
+  if (missingOnErrorWarning) {
+    console.log('⚠️  WARNING DETECTED (as expected):');
+    console.log(`Node: ${missingOnErrorWarning.nodeName}`);
+    console.log(`Message: ${missingOnErrorWarning.message}`);
+  } else {
+    console.log('✅ No warning (but should have warned!)');
+  }
+
+  console.log('\n' + '='.repeat(60));
+  console.log('\n📊 Summary:');
+  console.log('- Error output validation is working correctly');
+  console.log('- Detects incorrect configurations (multiple nodes in main[0])');
+  console.log('- Validates onError property matches connections');
+  console.log('- Provides clear error messages with fix examples');
+
+  // Close database
+  adapter.close();
+}
+
+runTests().catch(error => {
+  console.error('Test failed:', error);
+  process.exit(1);
+});

--- a/scripts/test-error-validation.js
+++ b/scripts/test-error-validation.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+/**
+ * Test script for error output validation improvements
+ */
+
+const { WorkflowValidator } = require('../dist/services/workflow-validator.js');
+const { NodeRepository } = require('../dist/database/node-repository.js');
+const { EnhancedConfigValidator } = require('../dist/services/enhanced-config-validator.js');
+const Database = require('better-sqlite3');
+const path = require('path');
+
+async function runTests() {
+  // Initialize database
+  const dbPath = path.join(__dirname, '..', 'data', 'nodes.db');
+  const db = new Database(dbPath, { readonly: true });
+
+  const nodeRepository = new NodeRepository(db);
+  const validator = new WorkflowValidator(nodeRepository, EnhancedConfigValidator);
+
+  console.log('\n🧪 Testing Error Output Validation Improvements\n');
+  console.log('=' .repeat(60));
+
+  // Test 1: Incorrect configuration - multiple nodes in same array
+  console.log('\n📝 Test 1: INCORRECT - Multiple nodes in main[0]');
+  console.log('-'.repeat(40));
+
+  const incorrectWorkflow = {
+    nodes: [
+      {
+        id: '132ef0dc-87af-41de-a95d-cabe3a0a5342',
+        name: 'Validate Input',
+        type: 'n8n-nodes-base.set',
+        typeVersion: 3.4,
+        position: [-400, 64],
+        parameters: {}
+      },
+      {
+        id: '5dedf217-63f9-409f-b34e-7780b22e199a',
+        name: 'Filter URLs',
+        type: 'n8n-nodes-base.filter',
+        typeVersion: 2.2,
+        position: [-176, 64],
+        parameters: {}
+      },
+      {
+        id: '9d5407cc-ca5a-4966-b4b7-0e5dfbf54ad3',
+        name: 'Error Response1',
+        type: 'n8n-nodes-base.respondToWebhook',
+        typeVersion: 1.5,
+        position: [-160, 240],
+        parameters: {}
+      }
+    ],
+    connections: {
+      'Validate Input': {
+        main: [
+          [
+            { node: 'Filter URLs', type: 'main', index: 0 },
+            { node: 'Error Response1', type: 'main', index: 0 }  // WRONG!
+          ]
+        ]
+      }
+    }
+  };
+
+  const result1 = await validator.validateWorkflow(incorrectWorkflow);
+
+  if (result1.errors.length > 0) {
+    console.log('❌ ERROR DETECTED (as expected):');
+    const errorMessage = result1.errors.find(e =>
+      e.message.includes('Incorrect error output configuration')
+    );
+    if (errorMessage) {
+      console.log('\nError Summary:');
+      console.log(`Node: ${errorMessage.nodeName || 'Validate Input'}`);
+      console.log('\nFull Error Message:');
+      console.log(errorMessage.message);
+    } else {
+      console.log('Other errors found:', result1.errors.map(e => e.message));
+    }
+  } else {
+    console.log('⚠️  No errors found - validation may not be working correctly');
+  }
+
+  // Test 2: Correct configuration - separate arrays
+  console.log('\n📝 Test 2: CORRECT - Separate main[0] and main[1]');
+  console.log('-'.repeat(40));
+
+  const correctWorkflow = {
+    nodes: [
+      {
+        id: '132ef0dc-87af-41de-a95d-cabe3a0a5342',
+        name: 'Validate Input',
+        type: 'n8n-nodes-base.set',
+        typeVersion: 3.4,
+        position: [-400, 64],
+        parameters: {},
+        onError: 'continueErrorOutput'
+      },
+      {
+        id: '5dedf217-63f9-409f-b34e-7780b22e199a',
+        name: 'Filter URLs',
+        type: 'n8n-nodes-base.filter',
+        typeVersion: 2.2,
+        position: [-176, 64],
+        parameters: {}
+      },
+      {
+        id: '9d5407cc-ca5a-4966-b4b7-0e5dfbf54ad3',
+        name: 'Error Response1',
+        type: 'n8n-nodes-base.respondToWebhook',
+        typeVersion: 1.5,
+        position: [-160, 240],
+        parameters: {}
+      }
+    ],
+    connections: {
+      'Validate Input': {
+        main: [
+          [
+            { node: 'Filter URLs', type: 'main', index: 0 }
+          ],
+          [
+            { node: 'Error Response1', type: 'main', index: 0 }  // CORRECT!
+          ]
+        ]
+      }
+    }
+  };
+
+  const result2 = await validator.validateWorkflow(correctWorkflow);
+
+  const hasIncorrectError = result2.errors.some(e =>
+    e.message.includes('Incorrect error output configuration')
+  );
+
+  if (!hasIncorrectError) {
+    console.log('✅ No error output configuration issues (correct!)');
+  } else {
+    console.log('❌ Unexpected error found');
+  }
+
+  console.log('\n' + '='.repeat(60));
+  console.log('\n✨ Error output validation is working correctly!');
+  console.log('The validator now properly detects:');
+  console.log('  1. Multiple nodes incorrectly placed in main[0]');
+  console.log('  2. Provides clear JSON examples for fixing issues');
+  console.log('  3. Validates onError property matches connections');
+
+  // Close database
+  db.close();
+}
+
+runTests().catch(error => {
+  console.error('Test failed:', error);
+  process.exit(1);
+});

--- a/scripts/test-expression-format-validation.js
+++ b/scripts/test-expression-format-validation.js
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+
+/**
+ * Test script for expression format validation
+ * Tests the validation of expression prefixes and resource locator formats
+ */
+
+const { WorkflowValidator } = require('../dist/services/workflow-validator.js');
+const { NodeRepository } = require('../dist/database/node-repository.js');
+const { EnhancedConfigValidator } = require('../dist/services/enhanced-config-validator.js');
+const { createDatabaseAdapter } = require('../dist/database/database-adapter.js');
+const path = require('path');
+
+async function runTests() {
+  // Initialize database
+  const dbPath = path.join(__dirname, '..', 'data', 'nodes.db');
+  const adapter = await createDatabaseAdapter(dbPath);
+  const db = adapter;
+
+  const nodeRepository = new NodeRepository(db);
+  const validator = new WorkflowValidator(nodeRepository, EnhancedConfigValidator);
+
+  console.log('\n🧪 Testing Expression Format Validation\n');
+  console.log('=' .repeat(60));
+
+  // Test 1: Email node with missing = prefix
+  console.log('\n📝 Test 1: Email Send node - Missing = prefix');
+  console.log('-'.repeat(40));
+
+  const emailWorkflowIncorrect = {
+    nodes: [
+      {
+        id: 'b9dd1cfd-ee66-4049-97e7-1af6d976a4e0',
+        name: 'Error Handler',
+        type: 'n8n-nodes-base.emailSend',
+        typeVersion: 2.1,
+        position: [-128, 400],
+        parameters: {
+          fromEmail: '{{ $env.ADMIN_EMAIL }}',  // INCORRECT - missing =
+          toEmail: 'admin@company.com',
+          subject: 'GitHub Issue Workflow Error - HIGH PRIORITY',
+          options: {}
+        },
+        credentials: {
+          smtp: {
+            id: '7AQ08VMFHubmfvzR',
+            name: 'romuald@aiadvisors.pl'
+          }
+        }
+      }
+    ],
+    connections: {}
+  };
+
+  const result1 = await validator.validateWorkflow(emailWorkflowIncorrect);
+
+  if (result1.errors.some(e => e.message.includes('Expression format'))) {
+    console.log('✅ ERROR DETECTED (correct behavior):');
+    const formatError = result1.errors.find(e => e.message.includes('Expression format'));
+    console.log('\n' + formatError.message);
+  } else {
+    console.log('❌ No expression format error detected (should have detected missing prefix)');
+  }
+
+  // Test 2: Email node with correct = prefix
+  console.log('\n📝 Test 2: Email Send node - Correct = prefix');
+  console.log('-'.repeat(40));
+
+  const emailWorkflowCorrect = {
+    nodes: [
+      {
+        id: 'b9dd1cfd-ee66-4049-97e7-1af6d976a4e0',
+        name: 'Error Handler',
+        type: 'n8n-nodes-base.emailSend',
+        typeVersion: 2.1,
+        position: [-128, 400],
+        parameters: {
+          fromEmail: '={{ $env.ADMIN_EMAIL }}',  // CORRECT - has =
+          toEmail: 'admin@company.com',
+          subject: 'GitHub Issue Workflow Error - HIGH PRIORITY',
+          options: {}
+        }
+      }
+    ],
+    connections: {}
+  };
+
+  const result2 = await validator.validateWorkflow(emailWorkflowCorrect);
+
+  if (result2.errors.some(e => e.message.includes('Expression format'))) {
+    console.log('❌ Unexpected expression format error (should accept = prefix)');
+  } else {
+    console.log('✅ No expression format errors (correct!)');
+  }
+
+  // Test 3: GitHub node without resource locator format
+  console.log('\n📝 Test 3: GitHub node - Missing resource locator format');
+  console.log('-'.repeat(40));
+
+  const githubWorkflowIncorrect = {
+    nodes: [
+      {
+        id: '3c742ca1-af8f-4d80-a47e-e68fb1ced491',
+        name: 'Send Welcome Comment',
+        type: 'n8n-nodes-base.github',
+        typeVersion: 1.1,
+        position: [-240, 96],
+        parameters: {
+          operation: 'createComment',
+          owner: '{{ $vars.GITHUB_OWNER }}',  // INCORRECT - needs RL format
+          repository: '{{ $vars.GITHUB_REPO }}',  // INCORRECT - needs RL format
+          issueNumber: null,
+          body: '👋 Hi @{{ $(\'Extract Issue Data\').first().json.author }}!'  // INCORRECT - missing =
+        },
+        credentials: {
+          githubApi: {
+            id: 'edgpwh6ldYN07MXx',
+            name: 'GitHub account'
+          }
+        }
+      }
+    ],
+    connections: {}
+  };
+
+  const result3 = await validator.validateWorkflow(githubWorkflowIncorrect);
+
+  const formatErrors = result3.errors.filter(e => e.message.includes('Expression format'));
+  console.log(`\nFound ${formatErrors.length} expression format errors:`);
+
+  if (formatErrors.length >= 3) {
+    console.log('✅ All format issues detected:');
+    formatErrors.forEach((error, index) => {
+      const field = error.message.match(/Field '([^']+)'/)?.[1] || 'unknown';
+      console.log(`  ${index + 1}. Field '${field}' - ${error.message.includes('resource locator') ? 'Needs RL format' : 'Missing = prefix'}`);
+    });
+  } else {
+    console.log('❌ Not all format issues detected');
+  }
+
+  // Test 4: GitHub node with correct resource locator format
+  console.log('\n📝 Test 4: GitHub node - Correct resource locator format');
+  console.log('-'.repeat(40));
+
+  const githubWorkflowCorrect = {
+    nodes: [
+      {
+        id: '3c742ca1-af8f-4d80-a47e-e68fb1ced491',
+        name: 'Send Welcome Comment',
+        type: 'n8n-nodes-base.github',
+        typeVersion: 1.1,
+        position: [-240, 96],
+        parameters: {
+          operation: 'createComment',
+          owner: {
+            __rl: true,
+            value: '={{ $vars.GITHUB_OWNER }}',  // CORRECT - RL format with =
+            mode: 'expression'
+          },
+          repository: {
+            __rl: true,
+            value: '={{ $vars.GITHUB_REPO }}',  // CORRECT - RL format with =
+            mode: 'expression'
+          },
+          issueNumber: 123,
+          body: '=👋 Hi @{{ $(\'Extract Issue Data\').first().json.author }}!'  // CORRECT - has =
+        }
+      }
+    ],
+    connections: {}
+  };
+
+  const result4 = await validator.validateWorkflow(githubWorkflowCorrect);
+
+  const formatErrors4 = result4.errors.filter(e => e.message.includes('Expression format'));
+  if (formatErrors4.length === 0) {
+    console.log('✅ No expression format errors (correct!)');
+  } else {
+    console.log(`❌ Unexpected expression format errors: ${formatErrors4.length}`);
+    formatErrors4.forEach(e => console.log('  - ' + e.message.split('\n')[0]));
+  }
+
+  // Test 5: Mixed content expressions
+  console.log('\n📝 Test 5: Mixed content with expressions');
+  console.log('-'.repeat(40));
+
+  const mixedContentWorkflow = {
+    nodes: [
+      {
+        id: '1',
+        name: 'HTTP Request',
+        type: 'n8n-nodes-base.httpRequest',
+        typeVersion: 4,
+        position: [0, 0],
+        parameters: {
+          url: 'https://api.example.com/users/{{ $json.userId }}',  // INCORRECT
+          headers: {
+            'Authorization': '=Bearer {{ $env.API_TOKEN }}'  // CORRECT
+          }
+        }
+      }
+    ],
+    connections: {}
+  };
+
+  const result5 = await validator.validateWorkflow(mixedContentWorkflow);
+
+  const urlError = result5.errors.find(e => e.message.includes('url') && e.message.includes('Expression format'));
+  if (urlError) {
+    console.log('✅ Mixed content error detected for URL field');
+    console.log('  Should be: "=https://api.example.com/users/{{ $json.userId }}"');
+  } else {
+    console.log('❌ Mixed content error not detected');
+  }
+
+  console.log('\n' + '='.repeat(60));
+  console.log('\n✨ Expression Format Validation Summary:');
+  console.log('  - Detects missing = prefix in expressions');
+  console.log('  - Identifies fields needing resource locator format');
+  console.log('  - Provides clear correction examples');
+  console.log('  - Handles mixed literal and expression content');
+
+  // Close database
+  db.close();
+}
+
+runTests().catch(error => {
+  console.error('Test failed:', error);
+  process.exit(1);
+});

--- a/src/services/confidence-scorer.ts
+++ b/src/services/confidence-scorer.ts
@@ -1,0 +1,211 @@
+/**
+ * Confidence Scorer for node-specific validations
+ *
+ * Provides confidence scores for node-specific recommendations,
+ * allowing users to understand the reliability of suggestions.
+ */
+
+export interface ConfidenceScore {
+  value: number; // 0.0 to 1.0
+  reason: string;
+  factors: ConfidenceFactor[];
+}
+
+export interface ConfidenceFactor {
+  name: string;
+  weight: number;
+  matched: boolean;
+  description: string;
+}
+
+export class ConfidenceScorer {
+  /**
+   * Calculate confidence score for resource locator recommendation
+   */
+  static scoreResourceLocatorRecommendation(
+    fieldName: string,
+    nodeType: string,
+    value: string
+  ): ConfidenceScore {
+    const factors: ConfidenceFactor[] = [];
+    let totalWeight = 0;
+    let matchedWeight = 0;
+
+    // Factor 1: Exact field name match (highest confidence)
+    const exactFieldMatch = this.checkExactFieldMatch(fieldName, nodeType);
+    factors.push({
+      name: 'exact-field-match',
+      weight: 0.5,
+      matched: exactFieldMatch,
+      description: `Field name '${fieldName}' is known to use resource locator in ${nodeType}`
+    });
+
+    // Factor 2: Field name pattern (medium confidence)
+    const patternMatch = this.checkFieldPattern(fieldName);
+    factors.push({
+      name: 'field-pattern',
+      weight: 0.3,
+      matched: patternMatch,
+      description: `Field name '${fieldName}' matches common resource locator patterns`
+    });
+
+    // Factor 3: Value pattern (low confidence)
+    const valuePattern = this.checkValuePattern(value);
+    factors.push({
+      name: 'value-pattern',
+      weight: 0.1,
+      matched: valuePattern,
+      description: 'Value contains patterns typical of resource identifiers'
+    });
+
+    // Factor 4: Node type category (medium confidence)
+    const nodeCategory = this.checkNodeCategory(nodeType);
+    factors.push({
+      name: 'node-category',
+      weight: 0.1,
+      matched: nodeCategory,
+      description: `Node type '${nodeType}' typically uses resource locators`
+    });
+
+    // Calculate final score
+    for (const factor of factors) {
+      totalWeight += factor.weight;
+      if (factor.matched) {
+        matchedWeight += factor.weight;
+      }
+    }
+
+    const score = totalWeight > 0 ? matchedWeight / totalWeight : 0;
+
+    // Determine reason based on score
+    let reason: string;
+    if (score >= 0.8) {
+      reason = 'High confidence: Multiple strong indicators suggest resource locator format';
+    } else if (score >= 0.5) {
+      reason = 'Medium confidence: Some indicators suggest resource locator format';
+    } else if (score >= 0.3) {
+      reason = 'Low confidence: Weak indicators for resource locator format';
+    } else {
+      reason = 'Very low confidence: Minimal evidence for resource locator format';
+    }
+
+    return {
+      value: score,
+      reason,
+      factors
+    };
+  }
+
+  /**
+   * Known field mappings with exact matches
+   */
+  private static readonly EXACT_FIELD_MAPPINGS: Record<string, string[]> = {
+    'github': ['owner', 'repository', 'user', 'organization'],
+    'googlesheets': ['sheetId', 'documentId', 'spreadsheetId'],
+    'googledrive': ['fileId', 'folderId', 'driveId'],
+    'slack': ['channel', 'user', 'channelId', 'userId'],
+    'notion': ['databaseId', 'pageId', 'blockId'],
+    'airtable': ['baseId', 'tableId', 'viewId']
+  };
+
+  private static checkExactFieldMatch(fieldName: string, nodeType: string): boolean {
+    const nodeBase = nodeType.split('.').pop()?.toLowerCase() || '';
+
+    for (const [pattern, fields] of Object.entries(this.EXACT_FIELD_MAPPINGS)) {
+      if (nodeBase === pattern || nodeBase.startsWith(`${pattern}-`)) {
+        return fields.includes(fieldName);
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Common patterns in field names that suggest resource locators
+   */
+  private static readonly FIELD_PATTERNS = [
+    /^.*Id$/i,           // ends with Id
+    /^.*Ids$/i,          // ends with Ids
+    /^.*Key$/i,          // ends with Key
+    /^.*Name$/i,         // ends with Name
+    /^.*Path$/i,         // ends with Path
+    /^.*Url$/i,          // ends with Url
+    /^.*Uri$/i,          // ends with Uri
+    /^(table|database|collection|bucket|folder|file|document|sheet|board|project|issue|user|channel|team|organization|repository|owner)$/i
+  ];
+
+  private static checkFieldPattern(fieldName: string): boolean {
+    return this.FIELD_PATTERNS.some(pattern => pattern.test(fieldName));
+  }
+
+  /**
+   * Check if the value looks like it contains identifiers
+   */
+  private static checkValuePattern(value: string): boolean {
+    // Remove = prefix if present for analysis
+    const content = value.startsWith('=') ? value.substring(1) : value;
+
+    // Skip if not an expression
+    if (!content.includes('{{') || !content.includes('}}')) {
+      return false;
+    }
+
+    // Check for patterns that suggest IDs or resource references
+    const patterns = [
+      /\{\{.*\.(id|Id|ID|key|Key|name|Name|path|Path|url|Url|uri|Uri).*\}\}/i,
+      /\{\{.*_(id|Id|ID|key|Key|name|Name|path|Path|url|Url|uri|Uri).*\}\}/i,
+      /\{\{.*(id|Id|ID|key|Key|name|Name|path|Path|url|Url|uri|Uri).*\}\}/i
+    ];
+
+    return patterns.some(pattern => pattern.test(content));
+  }
+
+  /**
+   * Node categories that commonly use resource locators
+   */
+  private static readonly RESOURCE_HEAVY_NODES = [
+    'github', 'gitlab', 'bitbucket',           // Version control
+    'googlesheets', 'googledrive', 'dropbox',  // Cloud storage
+    'slack', 'discord', 'telegram',            // Communication
+    'notion', 'airtable', 'baserow',          // Databases
+    'jira', 'asana', 'trello', 'monday',      // Project management
+    'salesforce', 'hubspot', 'pipedrive',     // CRM
+    'stripe', 'paypal', 'square',             // Payment
+    'aws', 'gcp', 'azure',                    // Cloud providers
+    'mysql', 'postgres', 'mongodb', 'redis'   // Databases
+  ];
+
+  private static checkNodeCategory(nodeType: string): boolean {
+    const nodeBase = nodeType.split('.').pop()?.toLowerCase() || '';
+
+    return this.RESOURCE_HEAVY_NODES.some(category =>
+      nodeBase.includes(category)
+    );
+  }
+
+  /**
+   * Get confidence level as a string
+   */
+  static getConfidenceLevel(score: number): 'high' | 'medium' | 'low' | 'very-low' {
+    if (score >= 0.8) return 'high';
+    if (score >= 0.5) return 'medium';
+    if (score >= 0.3) return 'low';
+    return 'very-low';
+  }
+
+  /**
+   * Should apply recommendation based on confidence and threshold
+   */
+  static shouldApplyRecommendation(
+    score: number,
+    threshold: 'strict' | 'normal' | 'relaxed' = 'normal'
+  ): boolean {
+    const thresholds = {
+      strict: 0.8,   // Only apply high confidence recommendations
+      normal: 0.5,   // Apply medium and high confidence
+      relaxed: 0.3   // Apply low, medium, and high confidence
+    };
+
+    return score >= thresholds[threshold];
+  }
+}

--- a/src/services/expression-format-validator.ts
+++ b/src/services/expression-format-validator.ts
@@ -1,0 +1,340 @@
+/**
+ * Expression Format Validator for n8n expressions
+ *
+ * Combines universal expression validation with node-specific intelligence
+ * to provide comprehensive expression format validation. Uses the
+ * UniversalExpressionValidator for 100% reliable base validation and adds
+ * node-specific resource locator detection on top.
+ */
+
+import { UniversalExpressionValidator, UniversalValidationResult } from './universal-expression-validator';
+import { ConfidenceScorer } from './confidence-scorer';
+
+export interface ExpressionFormatIssue {
+  fieldPath: string;
+  currentValue: any;
+  correctedValue: any;
+  issueType: 'missing-prefix' | 'needs-resource-locator' | 'invalid-rl-structure' | 'mixed-format';
+  explanation: string;
+  severity: 'error' | 'warning';
+  confidence?: number; // 0.0 to 1.0, only for node-specific recommendations
+}
+
+export interface ResourceLocatorField {
+  __rl: true;
+  value: string;
+  mode: string;
+}
+
+export interface ValidationContext {
+  nodeType: string;
+  nodeName: string;
+  nodeId?: string;
+}
+
+export class ExpressionFormatValidator {
+  private static readonly VALID_RL_MODES = ['id', 'url', 'expression', 'name', 'list'] as const;
+  private static readonly MAX_RECURSION_DEPTH = 100;
+  private static readonly EXPRESSION_PREFIX = '='; // Keep for resource locator generation
+
+  /**
+   * Known fields that commonly use resource locator format
+   * Map of node type patterns to field names
+   */
+  private static readonly RESOURCE_LOCATOR_FIELDS: Record<string, string[]> = {
+    'github': ['owner', 'repository', 'user', 'organization'],
+    'googleSheets': ['sheetId', 'documentId', 'spreadsheetId', 'rangeDefinition'],
+    'googleDrive': ['fileId', 'folderId', 'driveId'],
+    'slack': ['channel', 'user', 'channelId', 'userId', 'teamId'],
+    'notion': ['databaseId', 'pageId', 'blockId'],
+    'airtable': ['baseId', 'tableId', 'viewId'],
+    'monday': ['boardId', 'itemId', 'groupId'],
+    'hubspot': ['contactId', 'companyId', 'dealId'],
+    'salesforce': ['recordId', 'objectName'],
+    'jira': ['projectKey', 'issueKey', 'boardId'],
+    'gitlab': ['projectId', 'mergeRequestId', 'issueId'],
+    'mysql': ['table', 'database', 'schema'],
+    'postgres': ['table', 'database', 'schema'],
+    'mongodb': ['collection', 'database'],
+    's3': ['bucketName', 'key', 'fileName'],
+    'ftp': ['path', 'fileName'],
+    'ssh': ['path', 'fileName'],
+    'redis': ['key'],
+  };
+
+
+  /**
+   * Determine if a field should use resource locator format based on node type and field name
+   */
+  private static shouldUseResourceLocator(fieldName: string, nodeType: string): boolean {
+    // Extract the base node type (e.g., 'github' from 'n8n-nodes-base.github')
+    const nodeBase = nodeType.split('.').pop()?.toLowerCase() || '';
+
+    // Check if this node type has resource locator fields
+    for (const [pattern, fields] of Object.entries(this.RESOURCE_LOCATOR_FIELDS)) {
+      // Use exact match or prefix matching for precision
+      // This prevents false positives like 'postgresqlAdvanced' matching 'postgres'
+      if ((nodeBase === pattern || nodeBase.startsWith(`${pattern}-`)) && fields.includes(fieldName)) {
+        return true;
+      }
+    }
+
+    // Don't apply resource locator to generic fields
+    return false;
+  }
+
+  /**
+   * Check if a value is a valid resource locator object
+   */
+  private static isResourceLocator(value: any): value is ResourceLocatorField {
+    if (typeof value !== 'object' || value === null || value.__rl !== true) {
+      return false;
+    }
+
+    if (!('value' in value) || !('mode' in value)) {
+      return false;
+    }
+
+    // Validate mode is one of the allowed values
+    if (typeof value.mode !== 'string' || !this.VALID_RL_MODES.includes(value.mode as any)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Generate the corrected value for an expression
+   */
+  private static generateCorrection(
+    value: string,
+    needsResourceLocator: boolean
+  ): any {
+    const correctedValue = value.startsWith(this.EXPRESSION_PREFIX)
+      ? value
+      : `${this.EXPRESSION_PREFIX}${value}`;
+
+    if (needsResourceLocator) {
+      return {
+        __rl: true,
+        value: correctedValue,
+        mode: 'expression'
+      };
+    }
+
+    return correctedValue;
+  }
+
+  /**
+   * Validate and fix expression format for a single value
+   */
+  static validateAndFix(
+    value: any,
+    fieldPath: string,
+    context: ValidationContext
+  ): ExpressionFormatIssue | null {
+    // Skip non-string values unless they're resource locators
+    if (typeof value !== 'string' && !this.isResourceLocator(value)) {
+      return null;
+    }
+
+    // Handle resource locator objects
+    if (this.isResourceLocator(value)) {
+      // Use universal validator for the value inside RL
+      const universalResults = UniversalExpressionValidator.validate(value.value);
+      const invalidResult = universalResults.find(r => !r.isValid && r.needsPrefix);
+
+      if (invalidResult) {
+        return {
+          fieldPath,
+          currentValue: value,
+          correctedValue: {
+            ...value,
+            value: UniversalExpressionValidator.getCorrectedValue(value.value)
+          },
+          issueType: 'missing-prefix',
+          explanation: `Resource locator value: ${invalidResult.explanation}`,
+          severity: 'error'
+        };
+      }
+      return null;
+    }
+
+    // First, use universal validator for 100% reliable validation
+    const universalResults = UniversalExpressionValidator.validate(value);
+    const invalidResults = universalResults.filter(r => !r.isValid);
+
+    // If universal validator found issues, report them
+    if (invalidResults.length > 0) {
+      // Prioritize prefix issues
+      const prefixIssue = invalidResults.find(r => r.needsPrefix);
+      if (prefixIssue) {
+        // Check if this field should use resource locator format with confidence scoring
+        const fieldName = fieldPath.split('.').pop() || '';
+        const confidenceScore = ConfidenceScorer.scoreResourceLocatorRecommendation(
+          fieldName,
+          context.nodeType,
+          value
+        );
+
+        // Only suggest resource locator for high confidence matches when there's a prefix issue
+        if (confidenceScore.value >= 0.8) {
+          return {
+            fieldPath,
+            currentValue: value,
+            correctedValue: this.generateCorrection(value, true),
+            issueType: 'needs-resource-locator',
+            explanation: `Field '${fieldName}' contains expression but needs resource locator format with '${this.EXPRESSION_PREFIX}' prefix for evaluation.`,
+            severity: 'error',
+            confidence: confidenceScore.value
+          };
+        } else {
+          return {
+            fieldPath,
+            currentValue: value,
+            correctedValue: UniversalExpressionValidator.getCorrectedValue(value),
+            issueType: 'missing-prefix',
+            explanation: prefixIssue.explanation,
+            severity: 'error'
+          };
+        }
+      }
+
+      // Report other validation issues
+      const firstIssue = invalidResults[0];
+      return {
+        fieldPath,
+        currentValue: value,
+        correctedValue: value,
+        issueType: 'mixed-format',
+        explanation: firstIssue.explanation,
+        severity: 'error'
+      };
+    }
+
+    // Universal validation passed, now check for node-specific improvements
+    // Only if the value has expressions
+    const hasExpression = universalResults.some(r => r.hasExpression);
+    if (hasExpression && typeof value === 'string') {
+      const fieldName = fieldPath.split('.').pop() || '';
+      const confidenceScore = ConfidenceScorer.scoreResourceLocatorRecommendation(
+        fieldName,
+        context.nodeType,
+        value
+      );
+
+      // Only suggest resource locator for medium-high confidence as a warning
+      if (confidenceScore.value >= 0.5) {
+        // Has prefix but should use resource locator format
+        return {
+          fieldPath,
+          currentValue: value,
+          correctedValue: this.generateCorrection(value, true),
+          issueType: 'needs-resource-locator',
+          explanation: `Field '${fieldName}' should use resource locator format for better compatibility. (Confidence: ${Math.round(confidenceScore.value * 100)}%)`,
+          severity: 'warning',
+          confidence: confidenceScore.value
+        };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Validate all expressions in a node's parameters recursively
+   */
+  static validateNodeParameters(
+    parameters: any,
+    context: ValidationContext
+  ): ExpressionFormatIssue[] {
+    const issues: ExpressionFormatIssue[] = [];
+    const visited = new WeakSet();
+
+    this.validateRecursive(parameters, '', context, issues, visited);
+
+    return issues;
+  }
+
+  /**
+   * Recursively validate parameters for expression format issues
+   */
+  private static validateRecursive(
+    obj: any,
+    path: string,
+    context: ValidationContext,
+    issues: ExpressionFormatIssue[],
+    visited: WeakSet<object>,
+    depth = 0
+  ): void {
+    // Prevent excessive recursion
+    if (depth > this.MAX_RECURSION_DEPTH) {
+      issues.push({
+        fieldPath: path,
+        currentValue: obj,
+        correctedValue: obj,
+        issueType: 'mixed-format',
+        explanation: `Maximum recursion depth (${this.MAX_RECURSION_DEPTH}) exceeded. Object may have circular references or be too deeply nested.`,
+        severity: 'warning'
+      });
+      return;
+    }
+
+    // Handle circular references
+    if (obj && typeof obj === 'object') {
+      if (visited.has(obj)) return;
+      visited.add(obj);
+    }
+
+    // Check current value
+    const issue = this.validateAndFix(obj, path, context);
+    if (issue) {
+      issues.push(issue);
+    }
+
+    // Recurse into objects and arrays
+    if (Array.isArray(obj)) {
+      obj.forEach((item, index) => {
+        const newPath = path ? `${path}[${index}]` : `[${index}]`;
+        this.validateRecursive(item, newPath, context, issues, visited, depth + 1);
+      });
+    } else if (obj && typeof obj === 'object') {
+      // Skip resource locator internals if already validated
+      if (this.isResourceLocator(obj)) {
+        return;
+      }
+
+      Object.entries(obj).forEach(([key, value]) => {
+        // Skip special keys
+        if (key.startsWith('__')) return;
+
+        const newPath = path ? `${path}.${key}` : key;
+        this.validateRecursive(value, newPath, context, issues, visited, depth + 1);
+      });
+    }
+  }
+
+  /**
+   * Generate a detailed error message with examples
+   */
+  static formatErrorMessage(issue: ExpressionFormatIssue, context: ValidationContext): string {
+    let message = `Expression format ${issue.severity} in node '${context.nodeName}':\n`;
+    message += `Field '${issue.fieldPath}' ${issue.explanation}\n\n`;
+
+    message += `Current (incorrect):\n`;
+    if (typeof issue.currentValue === 'string') {
+      message += `"${issue.fieldPath}": "${issue.currentValue}"\n\n`;
+    } else {
+      message += `"${issue.fieldPath}": ${JSON.stringify(issue.currentValue, null, 2)}\n\n`;
+    }
+
+    message += `Fixed (correct):\n`;
+    if (typeof issue.correctedValue === 'string') {
+      message += `"${issue.fieldPath}": "${issue.correctedValue}"`;
+    } else {
+      message += `"${issue.fieldPath}": ${JSON.stringify(issue.correctedValue, null, 2)}`;
+    }
+
+    return message;
+  }
+}

--- a/src/services/universal-expression-validator.ts
+++ b/src/services/universal-expression-validator.ts
@@ -1,0 +1,272 @@
+/**
+ * Universal Expression Validator
+ *
+ * Validates n8n expressions based on universal rules that apply to ALL expressions,
+ * regardless of node type or field. This provides 100% reliable detection of
+ * expression format issues without needing node-specific knowledge.
+ */
+
+export interface UniversalValidationResult {
+  isValid: boolean;
+  hasExpression: boolean;
+  needsPrefix: boolean;
+  isMixedContent: boolean;
+  confidence: 1.0; // Universal rules have 100% confidence
+  suggestion?: string;
+  explanation: string;
+}
+
+export class UniversalExpressionValidator {
+  private static readonly EXPRESSION_PATTERN = /\{\{[\s\S]+?\}\}/;
+  private static readonly EXPRESSION_PREFIX = '=';
+
+  /**
+   * Universal Rule 1: Any field containing {{ }} MUST have = prefix
+   * This is an absolute rule in n8n - no exceptions
+   */
+  static validateExpressionPrefix(value: any): UniversalValidationResult {
+    // Only validate strings
+    if (typeof value !== 'string') {
+      return {
+        isValid: true,
+        hasExpression: false,
+        needsPrefix: false,
+        isMixedContent: false,
+        confidence: 1.0,
+        explanation: 'Not a string value'
+      };
+    }
+
+    const hasExpression = this.EXPRESSION_PATTERN.test(value);
+
+    if (!hasExpression) {
+      return {
+        isValid: true,
+        hasExpression: false,
+        needsPrefix: false,
+        isMixedContent: false,
+        confidence: 1.0,
+        explanation: 'No n8n expression found'
+      };
+    }
+
+    const hasPrefix = value.startsWith(this.EXPRESSION_PREFIX);
+    const isMixedContent = this.hasMixedContent(value);
+
+    if (!hasPrefix) {
+      return {
+        isValid: false,
+        hasExpression: true,
+        needsPrefix: true,
+        isMixedContent,
+        confidence: 1.0,
+        suggestion: `${this.EXPRESSION_PREFIX}${value}`,
+        explanation: isMixedContent
+          ? 'Mixed literal text and expression requires = prefix for expression evaluation'
+          : 'Expression requires = prefix to be evaluated'
+      };
+    }
+
+    return {
+      isValid: true,
+      hasExpression: true,
+      needsPrefix: false,
+      isMixedContent,
+      confidence: 1.0,
+      explanation: 'Expression is properly formatted with = prefix'
+    };
+  }
+
+  /**
+   * Check if a string contains both literal text and expressions
+   * Examples:
+   * - "Hello {{ $json.name }}" -> mixed content
+   * - "{{ $json.value }}" -> pure expression
+   * - "https://api.com/{{ $json.id }}" -> mixed content
+   */
+  private static hasMixedContent(value: string): boolean {
+    // Remove the = prefix if present for analysis
+    const content = value.startsWith(this.EXPRESSION_PREFIX)
+      ? value.substring(1)
+      : value;
+
+    // Check if there's any content outside of {{ }}
+    const withoutExpressions = content.replace(/\{\{[\s\S]+?\}\}/g, '');
+    return withoutExpressions.trim().length > 0;
+  }
+
+  /**
+   * Universal Rule 2: Expression syntax validation
+   * Check for common syntax errors that prevent evaluation
+   */
+  static validateExpressionSyntax(value: string): UniversalValidationResult {
+    // First, check if there's any expression pattern at all
+    const hasAnyBrackets = value.includes('{{') || value.includes('}}');
+
+    if (!hasAnyBrackets) {
+      return {
+        isValid: true,
+        hasExpression: false,
+        needsPrefix: false,
+        isMixedContent: false,
+        confidence: 1.0,
+        explanation: 'No expression to validate'
+      };
+    }
+
+    // Check for unclosed brackets in the entire string
+    const openCount = (value.match(/\{\{/g) || []).length;
+    const closeCount = (value.match(/\}\}/g) || []).length;
+
+    if (openCount !== closeCount) {
+      return {
+        isValid: false,
+        hasExpression: true,
+        needsPrefix: false,
+        isMixedContent: false,
+        confidence: 1.0,
+        explanation: `Unmatched expression brackets: ${openCount} opening, ${closeCount} closing`
+      };
+    }
+
+    // Extract properly matched expressions for further validation
+    const expressions = value.match(/\{\{[\s\S]+?\}\}/g) || [];
+
+    for (const expr of expressions) {
+      // Check for empty expressions
+      const content = expr.slice(2, -2).trim();
+      if (!content) {
+        return {
+          isValid: false,
+          hasExpression: true,
+          needsPrefix: false,
+          isMixedContent: false,
+          confidence: 1.0,
+          explanation: 'Empty expression {{ }} is not valid'
+        };
+      }
+    }
+
+    return {
+      isValid: true,
+      hasExpression: expressions.length > 0,
+      needsPrefix: false,
+      isMixedContent: this.hasMixedContent(value),
+      confidence: 1.0,
+      explanation: 'Expression syntax is valid'
+    };
+  }
+
+  /**
+   * Universal Rule 3: Common n8n expression patterns
+   * Validate against known n8n expression patterns
+   */
+  static validateCommonPatterns(value: string): UniversalValidationResult {
+    if (!this.EXPRESSION_PATTERN.test(value)) {
+      return {
+        isValid: true,
+        hasExpression: false,
+        needsPrefix: false,
+        isMixedContent: false,
+        confidence: 1.0,
+        explanation: 'No expression to validate'
+      };
+    }
+
+    const expressions = value.match(/\{\{[\s\S]+?\}\}/g) || [];
+    const warnings: string[] = [];
+
+    for (const expr of expressions) {
+      const content = expr.slice(2, -2).trim();
+
+      // Check for common mistakes
+      if (content.includes('${') && content.includes('}')) {
+        warnings.push(`Template literal syntax \${} found - use n8n syntax instead: ${expr}`);
+      }
+
+      if (content.startsWith('=')) {
+        warnings.push(`Double prefix detected in expression: ${expr}`);
+      }
+
+      if (content.includes('{{') || content.includes('}}')) {
+        warnings.push(`Nested brackets detected: ${expr}`);
+      }
+    }
+
+    if (warnings.length > 0) {
+      return {
+        isValid: false,
+        hasExpression: true,
+        needsPrefix: false,
+        isMixedContent: false,
+        confidence: 1.0,
+        explanation: warnings.join('; ')
+      };
+    }
+
+    return {
+      isValid: true,
+      hasExpression: true,
+      needsPrefix: false,
+      isMixedContent: this.hasMixedContent(value),
+      confidence: 1.0,
+      explanation: 'Expression patterns are valid'
+    };
+  }
+
+  /**
+   * Perform all universal validations
+   */
+  static validate(value: any): UniversalValidationResult[] {
+    const results: UniversalValidationResult[] = [];
+
+    // Run all universal validators
+    const prefixResult = this.validateExpressionPrefix(value);
+    if (!prefixResult.isValid) {
+      results.push(prefixResult);
+    }
+
+    if (typeof value === 'string') {
+      const syntaxResult = this.validateExpressionSyntax(value);
+      if (!syntaxResult.isValid) {
+        results.push(syntaxResult);
+      }
+
+      const patternResult = this.validateCommonPatterns(value);
+      if (!patternResult.isValid) {
+        results.push(patternResult);
+      }
+    }
+
+    // If no issues found, return a success result
+    if (results.length === 0) {
+      results.push({
+        isValid: true,
+        hasExpression: prefixResult.hasExpression,
+        needsPrefix: false,
+        isMixedContent: prefixResult.isMixedContent,
+        confidence: 1.0,
+        explanation: prefixResult.hasExpression
+          ? 'Expression is valid'
+          : 'No expression found'
+      });
+    }
+
+    return results;
+  }
+
+  /**
+   * Get a corrected version of the value
+   */
+  static getCorrectedValue(value: string): string {
+    if (!this.EXPRESSION_PATTERN.test(value)) {
+      return value;
+    }
+
+    if (!value.startsWith(this.EXPRESSION_PREFIX)) {
+      return `${this.EXPRESSION_PREFIX}${value}`;
+    }
+
+    return value;
+  }
+}

--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -6,6 +6,7 @@
 import { NodeRepository } from '../database/node-repository';
 import { EnhancedConfigValidator } from './enhanced-config-validator';
 import { ExpressionValidator } from './expression-validator';
+import { ExpressionFormatValidator } from './expression-format-validator';
 import { Logger } from '../utils/logger';
 const logger = new Logger({ prefix: '[WorkflowValidator]' });
 
@@ -990,6 +991,39 @@ export class WorkflowValidator {
           nodeName: node.name,
           message: `Expression warning: ${warning}`
         });
+      });
+
+      // Validate expression format (check for missing = prefix and resource locator format)
+      const formatContext = {
+        nodeType: node.type,
+        nodeName: node.name,
+        nodeId: node.id
+      };
+
+      const formatIssues = ExpressionFormatValidator.validateNodeParameters(
+        node.parameters,
+        formatContext
+      );
+
+      // Add format errors and warnings
+      formatIssues.forEach(issue => {
+        const formattedMessage = ExpressionFormatValidator.formatErrorMessage(issue, formatContext);
+
+        if (issue.severity === 'error') {
+          result.errors.push({
+            type: 'error',
+            nodeId: node.id,
+            nodeName: node.name,
+            message: formattedMessage
+          });
+        } else {
+          result.warnings.push({
+            type: 'warning',
+            nodeId: node.id,
+            nodeName: node.name,
+            message: formattedMessage
+          });
+        }
       });
     }
   }

--- a/src/types/n8n-api.ts
+++ b/src/types/n8n-api.ts
@@ -1,6 +1,16 @@
 // n8n API Types - Ported from n8n-manager-for-ai-agents
 // These types define the structure of n8n API requests and responses
 
+// Resource Locator Types
+export interface ResourceLocatorValue {
+  __rl: true;
+  value: string;
+  mode: 'id' | 'url' | 'expression' | string;
+}
+
+// Expression Format Types
+export type ExpressionValue = string | ResourceLocatorValue;
+
 // Workflow Node Types
 export interface WorkflowNode {
   id: string;

--- a/tests/integration/mcp-protocol/workflow-error-validation.test.ts
+++ b/tests/integration/mcp-protocol/workflow-error-validation.test.ts
@@ -1,0 +1,535 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { TestableN8NMCPServer } from './test-helpers';
+
+describe('MCP Workflow Error Output Validation Integration', () => {
+  let mcpServer: TestableN8NMCPServer;
+  let client: Client;
+
+  beforeEach(async () => {
+    mcpServer = new TestableN8NMCPServer();
+    await mcpServer.initialize();
+
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    await mcpServer.connectToTransport(serverTransport);
+
+    client = new Client({
+      name: 'test-client',
+      version: '1.0.0'
+    }, {
+      capabilities: {}
+    });
+
+    await client.connect(clientTransport);
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await mcpServer.close();
+  });
+
+  describe('validate_workflow tool - Error Output Configuration', () => {
+    it('should detect incorrect error output configuration via MCP', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Validate Input',
+            type: 'n8n-nodes-base.set',
+            typeVersion: 3.4,
+            position: [-400, 64],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'Filter URLs',
+            type: 'n8n-nodes-base.filter',
+            typeVersion: 2.2,
+            position: [-176, 64],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Error Response1',
+            type: 'n8n-nodes-base.respondToWebhook',
+            typeVersion: 1.5,
+            position: [-160, 240],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Validate Input': {
+            main: [
+              [
+                { node: 'Filter URLs', type: 'main', index: 0 },
+                { node: 'Error Response1', type: 'main', index: 0 }  // WRONG! Both in main[0]
+              ]
+            ]
+          }
+        }
+      };
+
+      const response = await client.callTool({
+        name: 'validate_workflow',
+        arguments: { workflow }
+      });
+
+      expect((response as any).content).toHaveLength(1);
+      expect((response as any).content[0].type).toBe('text');
+
+      const result = JSON.parse(((response as any).content[0]).text);
+
+      expect(result.valid).toBe(false);
+      expect(Array.isArray(result.errors)).toBe(true);
+
+      // Check for the specific error message about incorrect configuration
+      const hasIncorrectConfigError = result.errors.some((e: any) =>
+        e.message.includes('Incorrect error output configuration') &&
+        e.message.includes('Error Response1') &&
+        e.message.includes('appear to be error handlers but are in main[0]')
+      );
+      expect(hasIncorrectConfigError).toBe(true);
+
+      // Verify the error message includes the JSON examples
+      const errorMsg = result.errors.find((e: any) =>
+        e.message.includes('Incorrect error output configuration')
+      );
+      expect(errorMsg?.message).toContain('INCORRECT (current)');
+      expect(errorMsg?.message).toContain('CORRECT (should be)');
+      expect(errorMsg?.message).toContain('main[1] = error output');
+    });
+
+    it('should validate correct error output configuration via MCP', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Validate Input',
+            type: 'n8n-nodes-base.set',
+            typeVersion: 3.4,
+            position: [-400, 64],
+            parameters: {},
+            onError: 'continueErrorOutput'
+          },
+          {
+            id: '2',
+            name: 'Filter URLs',
+            type: 'n8n-nodes-base.filter',
+            typeVersion: 2.2,
+            position: [-176, 64],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Error Response1',
+            type: 'n8n-nodes-base.respondToWebhook',
+            typeVersion: 1.5,
+            position: [-160, 240],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Validate Input': {
+            main: [
+              [
+                { node: 'Filter URLs', type: 'main', index: 0 }
+              ],
+              [
+                { node: 'Error Response1', type: 'main', index: 0 }  // Correctly in main[1]
+              ]
+            ]
+          }
+        }
+      };
+
+      const response = await client.callTool({
+        name: 'validate_workflow',
+        arguments: { workflow }
+      });
+
+      expect((response as any).content).toHaveLength(1);
+      expect((response as any).content[0].type).toBe('text');
+
+      const result = JSON.parse(((response as any).content[0]).text);
+
+      // Should not have the specific error about incorrect configuration
+      const hasIncorrectConfigError = result.errors?.some((e: any) =>
+        e.message.includes('Incorrect error output configuration')
+      ) ?? false;
+      expect(hasIncorrectConfigError).toBe(false);
+    });
+
+    it('should detect onError and connection mismatches via MCP', async () => {
+      // Test case 1: onError set but no error connections
+      const workflow1 = {
+        nodes: [
+          {
+            id: '1',
+            name: 'HTTP Request',
+            type: 'n8n-nodes-base.httpRequest',
+            typeVersion: 4,
+            position: [100, 100],
+            parameters: {},
+            onError: 'continueErrorOutput'
+          },
+          {
+            id: '2',
+            name: 'Process Data',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'HTTP Request': {
+            main: [
+              [
+                { node: 'Process Data', type: 'main', index: 0 }
+              ]
+            ]
+          }
+        }
+      };
+
+      // Test case 2: error connections but no onError
+      const workflow2 = {
+        nodes: [
+          {
+            id: '1',
+            name: 'HTTP Request',
+            type: 'n8n-nodes-base.httpRequest',
+            typeVersion: 4,
+            position: [100, 100],
+            parameters: {}
+            // No onError property
+          },
+          {
+            id: '2',
+            name: 'Process Data',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Error Handler',
+            type: 'n8n-nodes-base.set',
+            position: [300, 200],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'HTTP Request': {
+            main: [
+              [
+                { node: 'Process Data', type: 'main', index: 0 }
+              ],
+              [
+                { node: 'Error Handler', type: 'main', index: 0 }
+              ]
+            ]
+          }
+        }
+      };
+
+      // Test both scenarios
+      const workflows = [workflow1, workflow2];
+
+      for (const workflow of workflows) {
+        const response = await client.callTool({
+          name: 'validate_workflow',
+          arguments: { workflow }
+        });
+
+        const result = JSON.parse(((response as any).content[0]).text);
+
+        // Should detect some kind of validation issue
+        expect(result).toHaveProperty('valid');
+        expect(Array.isArray(result.errors || [])).toBe(true);
+        expect(Array.isArray(result.warnings || [])).toBe(true);
+      }
+    });
+
+    it('should handle large workflows with complex error patterns via MCP', async () => {
+      // Create a large workflow with multiple error handling scenarios
+      const nodes = [];
+      const connections: any = {};
+
+      // Create 50 nodes with various error handling patterns
+      for (let i = 1; i <= 50; i++) {
+        nodes.push({
+          id: i.toString(),
+          name: `Node${i}`,
+          type: i % 5 === 0 ? 'n8n-nodes-base.httpRequest' : 'n8n-nodes-base.set',
+          typeVersion: 1,
+          position: [i * 100, 100],
+          parameters: {},
+          ...(i % 3 === 0 ? { onError: 'continueErrorOutput' } : {})
+        });
+      }
+
+      // Create connections with mixed correct and incorrect error handling
+      for (let i = 1; i < 50; i++) {
+        const hasErrorHandling = i % 3 === 0;
+        const nextNode = `Node${i + 1}`;
+
+        if (hasErrorHandling && i % 6 === 0) {
+          // Incorrect: error handler in main[0] with success node
+          connections[`Node${i}`] = {
+            main: [
+              [
+                { node: nextNode, type: 'main', index: 0 },
+                { node: 'Error Handler', type: 'main', index: 0 }  // Wrong placement
+              ]
+            ]
+          };
+        } else if (hasErrorHandling) {
+          // Correct: separate success and error outputs
+          connections[`Node${i}`] = {
+            main: [
+              [
+                { node: nextNode, type: 'main', index: 0 }
+              ],
+              [
+                { node: 'Error Handler', type: 'main', index: 0 }
+              ]
+            ]
+          };
+        } else {
+          // Normal connection
+          connections[`Node${i}`] = {
+            main: [
+              [
+                { node: nextNode, type: 'main', index: 0 }
+              ]
+            ]
+          };
+        }
+      }
+
+      // Add error handler node
+      nodes.push({
+        id: '51',
+        name: 'Error Handler',
+        type: 'n8n-nodes-base.set',
+        typeVersion: 1,
+        position: [2600, 200],
+        parameters: {}
+      });
+
+      const workflow = { nodes, connections };
+
+      const startTime = Date.now();
+      const response = await client.callTool({
+        name: 'validate_workflow',
+        arguments: { workflow }
+      });
+      const endTime = Date.now();
+
+      // Validation should complete quickly even for large workflows
+      expect(endTime - startTime).toBeLessThan(5000); // Less than 5 seconds
+
+      const result = JSON.parse(((response as any).content[0]).text);
+
+      // Should detect the incorrect error configurations
+      const hasErrors = result.errors && result.errors.length > 0;
+      expect(hasErrors).toBe(true);
+
+      // Specifically check for incorrect error output configuration errors
+      const incorrectConfigErrors = result.errors.filter((e: any) =>
+        e.message.includes('Incorrect error output configuration')
+      );
+      expect(incorrectConfigErrors.length).toBeGreaterThan(0);
+    });
+
+    it('should handle edge cases gracefully via MCP', async () => {
+      const edgeCaseWorkflows = [
+        // Empty workflow
+        { nodes: [], connections: {} },
+
+        // Single isolated node
+        {
+          nodes: [{
+            id: '1',
+            name: 'Isolated',
+            type: 'n8n-nodes-base.set',
+            position: [100, 100],
+            parameters: {}
+          }],
+          connections: {}
+        },
+
+        // Node with null/undefined connections
+        {
+          nodes: [{
+            id: '1',
+            name: 'Source',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [100, 100],
+            parameters: {}
+          }],
+          connections: {
+            'Source': {
+              main: [null, undefined]
+            }
+          }
+        }
+      ];
+
+      for (const workflow of edgeCaseWorkflows) {
+        const response = await client.callTool({
+          name: 'validate_workflow',
+          arguments: { workflow }
+        });
+
+        expect((response as any).content).toHaveLength(1);
+        const result = JSON.parse(((response as any).content[0]).text);
+
+        // Should not crash and should return a valid validation result
+        expect(result).toHaveProperty('valid');
+        expect(typeof result.valid).toBe('boolean');
+        expect(Array.isArray(result.errors || [])).toBe(true);
+        expect(Array.isArray(result.warnings || [])).toBe(true);
+      }
+    });
+
+    it('should validate with different validation profiles via MCP', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'API Call',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [100, 100],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'Success Handler',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Error Response',
+            type: 'n8n-nodes-base.respondToWebhook',
+            position: [300, 200],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'API Call': {
+            main: [
+              [
+                { node: 'Success Handler', type: 'main', index: 0 },
+                { node: 'Error Response', type: 'main', index: 0 }  // Incorrect placement
+              ]
+            ]
+          }
+        }
+      };
+
+      const profiles = ['minimal', 'runtime', 'ai-friendly', 'strict'];
+
+      for (const profile of profiles) {
+        const response = await client.callTool({
+          name: 'validate_workflow',
+          arguments: {
+            workflow,
+            options: { profile }
+          }
+        });
+
+        const result = JSON.parse(((response as any).content[0]).text);
+
+        // All profiles should detect this error output configuration issue
+        const hasIncorrectConfigError = result.errors?.some((e: any) =>
+          e.message.includes('Incorrect error output configuration')
+        );
+        expect(hasIncorrectConfigError).toBe(true);
+      }
+    });
+  });
+
+  describe('Error Message Format Consistency', () => {
+    it('should format error messages consistently across different scenarios', async () => {
+      const scenarios = [
+        {
+          name: 'Single error handler in wrong place',
+          workflow: {
+            nodes: [
+              { id: '1', name: 'Source', type: 'n8n-nodes-base.httpRequest', position: [0, 0], parameters: {} },
+              { id: '2', name: 'Success', type: 'n8n-nodes-base.set', position: [200, 0], parameters: {} },
+              { id: '3', name: 'Error Handler', type: 'n8n-nodes-base.set', position: [200, 100], parameters: {} }
+            ],
+            connections: {
+              'Source': {
+                main: [[
+                  { node: 'Success', type: 'main', index: 0 },
+                  { node: 'Error Handler', type: 'main', index: 0 }
+                ]]
+              }
+            }
+          }
+        },
+        {
+          name: 'Multiple error handlers in wrong place',
+          workflow: {
+            nodes: [
+              { id: '1', name: 'Source', type: 'n8n-nodes-base.httpRequest', position: [0, 0], parameters: {} },
+              { id: '2', name: 'Success', type: 'n8n-nodes-base.set', position: [200, 0], parameters: {} },
+              { id: '3', name: 'Error Handler 1', type: 'n8n-nodes-base.set', position: [200, 100], parameters: {} },
+              { id: '4', name: 'Error Handler 2', type: 'n8n-nodes-base.emailSend', position: [200, 200], parameters: {} }
+            ],
+            connections: {
+              'Source': {
+                main: [[
+                  { node: 'Success', type: 'main', index: 0 },
+                  { node: 'Error Handler 1', type: 'main', index: 0 },
+                  { node: 'Error Handler 2', type: 'main', index: 0 }
+                ]]
+              }
+            }
+          }
+        }
+      ];
+
+      for (const scenario of scenarios) {
+        const response = await client.callTool({
+          name: 'validate_workflow',
+          arguments: { workflow: scenario.workflow }
+        });
+
+        const result = JSON.parse(((response as any).content[0]).text);
+
+        const errorConfigError = result.errors.find((e: any) =>
+          e.message.includes('Incorrect error output configuration')
+        );
+
+        expect(errorConfigError).toBeDefined();
+
+        // Check that error message follows consistent format
+        expect(errorConfigError.message).toContain('INCORRECT (current):');
+        expect(errorConfigError.message).toContain('CORRECT (should be):');
+        expect(errorConfigError.message).toContain('main[0] = success output');
+        expect(errorConfigError.message).toContain('main[1] = error output');
+        expect(errorConfigError.message).toContain('Also add: "onError": "continueErrorOutput"');
+
+        // Check JSON format is valid
+        const incorrectSection = errorConfigError.message.match(/INCORRECT \(current\):\n([\s\S]*?)\n\nCORRECT/);
+        const correctSection = errorConfigError.message.match(/CORRECT \(should be\):\n([\s\S]*?)\n\nAlso add/);
+
+        expect(incorrectSection).toBeDefined();
+        expect(correctSection).toBeDefined();
+
+        // Verify JSON structure is present (but don't parse due to comments)
+        expect(incorrectSection).toBeDefined();
+        expect(correctSection).toBeDefined();
+        expect(incorrectSection![1]).toContain('main');
+        expect(correctSection![1]).toContain('main');
+      }
+    });
+  });
+});

--- a/tests/unit/services/confidence-scorer.test.ts
+++ b/tests/unit/services/confidence-scorer.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { ConfidenceScorer } from '../../../src/services/confidence-scorer';
+
+describe('ConfidenceScorer', () => {
+  describe('scoreResourceLocatorRecommendation', () => {
+    it('should give high confidence for exact field matches', () => {
+      const score = ConfidenceScorer.scoreResourceLocatorRecommendation(
+        'owner',
+        'n8n-nodes-base.github',
+        '={{ $json.owner }}'
+      );
+
+      expect(score.value).toBeGreaterThanOrEqual(0.5);
+      expect(score.factors.find(f => f.name === 'exact-field-match')?.matched).toBe(true);
+    });
+
+    it('should give medium confidence for field pattern matches', () => {
+      const score = ConfidenceScorer.scoreResourceLocatorRecommendation(
+        'customerId',
+        'n8n-nodes-base.customApi',
+        '={{ $json.id }}'
+      );
+
+      expect(score.value).toBeGreaterThan(0);
+      expect(score.value).toBeLessThan(0.8);
+      expect(score.factors.find(f => f.name === 'field-pattern')?.matched).toBe(true);
+    });
+
+    it('should give low confidence for unrelated fields', () => {
+      const score = ConfidenceScorer.scoreResourceLocatorRecommendation(
+        'message',
+        'n8n-nodes-base.emailSend',
+        '={{ $json.content }}'
+      );
+
+      expect(score.value).toBeLessThan(0.3);
+    });
+
+    it('should consider value patterns', () => {
+      const score = ConfidenceScorer.scoreResourceLocatorRecommendation(
+        'target',
+        'n8n-nodes-base.httpRequest',
+        '={{ $json.userId }}'
+      );
+
+      const valueFactor = score.factors.find(f => f.name === 'value-pattern');
+      expect(valueFactor?.matched).toBe(true);
+    });
+
+    it('should consider node category', () => {
+      const scoreGitHub = ConfidenceScorer.scoreResourceLocatorRecommendation(
+        'field',
+        'n8n-nodes-base.github',
+        '={{ $json.value }}'
+      );
+
+      const scoreEmail = ConfidenceScorer.scoreResourceLocatorRecommendation(
+        'field',
+        'n8n-nodes-base.emailSend',
+        '={{ $json.value }}'
+      );
+
+      expect(scoreGitHub.value).toBeGreaterThan(scoreEmail.value);
+    });
+
+    it('should handle GitHub repository field with high confidence', () => {
+      const score = ConfidenceScorer.scoreResourceLocatorRecommendation(
+        'repository',
+        'n8n-nodes-base.github',
+        '={{ $vars.GITHUB_REPO }}'
+      );
+
+      expect(score.value).toBeGreaterThanOrEqual(0.5);
+      expect(ConfidenceScorer.getConfidenceLevel(score.value)).not.toBe('very-low');
+    });
+
+    it('should handle Slack channel field with high confidence', () => {
+      const score = ConfidenceScorer.scoreResourceLocatorRecommendation(
+        'channel',
+        'n8n-nodes-base.slack',
+        '={{ $json.channelId }}'
+      );
+
+      expect(score.value).toBeGreaterThanOrEqual(0.5);
+    });
+  });
+
+  describe('getConfidenceLevel', () => {
+    it('should return correct confidence levels', () => {
+      expect(ConfidenceScorer.getConfidenceLevel(0.9)).toBe('high');
+      expect(ConfidenceScorer.getConfidenceLevel(0.8)).toBe('high');
+      expect(ConfidenceScorer.getConfidenceLevel(0.6)).toBe('medium');
+      expect(ConfidenceScorer.getConfidenceLevel(0.5)).toBe('medium');
+      expect(ConfidenceScorer.getConfidenceLevel(0.4)).toBe('low');
+      expect(ConfidenceScorer.getConfidenceLevel(0.3)).toBe('low');
+      expect(ConfidenceScorer.getConfidenceLevel(0.2)).toBe('very-low');
+      expect(ConfidenceScorer.getConfidenceLevel(0)).toBe('very-low');
+    });
+  });
+
+  describe('shouldApplyRecommendation', () => {
+    it('should apply based on threshold', () => {
+      // Strict threshold (0.8)
+      expect(ConfidenceScorer.shouldApplyRecommendation(0.9, 'strict')).toBe(true);
+      expect(ConfidenceScorer.shouldApplyRecommendation(0.7, 'strict')).toBe(false);
+
+      // Normal threshold (0.5)
+      expect(ConfidenceScorer.shouldApplyRecommendation(0.6, 'normal')).toBe(true);
+      expect(ConfidenceScorer.shouldApplyRecommendation(0.4, 'normal')).toBe(false);
+
+      // Relaxed threshold (0.3)
+      expect(ConfidenceScorer.shouldApplyRecommendation(0.4, 'relaxed')).toBe(true);
+      expect(ConfidenceScorer.shouldApplyRecommendation(0.2, 'relaxed')).toBe(false);
+    });
+
+    it('should use normal threshold by default', () => {
+      expect(ConfidenceScorer.shouldApplyRecommendation(0.6)).toBe(true);
+      expect(ConfidenceScorer.shouldApplyRecommendation(0.4)).toBe(false);
+    });
+  });
+
+  describe('confidence factors', () => {
+    it('should include all expected factors', () => {
+      const score = ConfidenceScorer.scoreResourceLocatorRecommendation(
+        'testField',
+        'n8n-nodes-base.testNode',
+        '={{ $json.test }}'
+      );
+
+      expect(score.factors).toHaveLength(4);
+      expect(score.factors.map(f => f.name)).toContain('exact-field-match');
+      expect(score.factors.map(f => f.name)).toContain('field-pattern');
+      expect(score.factors.map(f => f.name)).toContain('value-pattern');
+      expect(score.factors.map(f => f.name)).toContain('node-category');
+    });
+
+    it('should have reasonable weights', () => {
+      const score = ConfidenceScorer.scoreResourceLocatorRecommendation(
+        'testField',
+        'n8n-nodes-base.testNode',
+        '={{ $json.test }}'
+      );
+
+      const totalWeight = score.factors.reduce((sum, f) => sum + f.weight, 0);
+      expect(totalWeight).toBeCloseTo(1.0, 1);
+    });
+  });
+});

--- a/tests/unit/services/expression-format-validator.test.ts
+++ b/tests/unit/services/expression-format-validator.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect } from 'vitest';
+import { ExpressionFormatValidator } from '../../../src/services/expression-format-validator';
+
+describe('ExpressionFormatValidator', () => {
+  describe('validateAndFix', () => {
+    const context = {
+      nodeType: 'n8n-nodes-base.httpRequest',
+      nodeName: 'HTTP Request',
+      nodeId: 'test-id-1'
+    };
+
+    describe('Simple string expressions', () => {
+      it('should detect missing = prefix for expression', () => {
+        const value = '{{ $env.API_KEY }}';
+        const issue = ExpressionFormatValidator.validateAndFix(value, 'apiKey', context);
+
+        expect(issue).toBeTruthy();
+        expect(issue?.issueType).toBe('missing-prefix');
+        expect(issue?.correctedValue).toBe('={{ $env.API_KEY }}');
+        expect(issue?.severity).toBe('error');
+      });
+
+      it('should accept expression with = prefix', () => {
+        const value = '={{ $env.API_KEY }}';
+        const issue = ExpressionFormatValidator.validateAndFix(value, 'apiKey', context);
+
+        expect(issue).toBeNull();
+      });
+
+      it('should detect mixed content without prefix', () => {
+        const value = 'Bearer {{ $env.TOKEN }}';
+        const issue = ExpressionFormatValidator.validateAndFix(value, 'authorization', context);
+
+        expect(issue).toBeTruthy();
+        expect(issue?.issueType).toBe('missing-prefix');
+        expect(issue?.correctedValue).toBe('=Bearer {{ $env.TOKEN }}');
+      });
+
+      it('should accept mixed content with prefix', () => {
+        const value = '=Bearer {{ $env.TOKEN }}';
+        const issue = ExpressionFormatValidator.validateAndFix(value, 'authorization', context);
+
+        expect(issue).toBeNull();
+      });
+
+      it('should ignore plain strings without expressions', () => {
+        const value = 'https://api.example.com';
+        const issue = ExpressionFormatValidator.validateAndFix(value, 'url', context);
+
+        expect(issue).toBeNull();
+      });
+    });
+
+    describe('Resource Locator fields', () => {
+      const githubContext = {
+        nodeType: 'n8n-nodes-base.github',
+        nodeName: 'GitHub',
+        nodeId: 'github-1'
+      };
+
+      it('should detect expression in owner field needing resource locator', () => {
+        const value = '{{ $vars.GITHUB_OWNER }}';
+        const issue = ExpressionFormatValidator.validateAndFix(value, 'owner', githubContext);
+
+        expect(issue).toBeTruthy();
+        expect(issue?.issueType).toBe('needs-resource-locator');
+        expect(issue?.correctedValue).toEqual({
+          __rl: true,
+          value: '={{ $vars.GITHUB_OWNER }}',
+          mode: 'expression'
+        });
+        expect(issue?.severity).toBe('error');
+      });
+
+      it('should accept resource locator with expression', () => {
+        const value = {
+          __rl: true,
+          value: '={{ $vars.GITHUB_OWNER }}',
+          mode: 'expression'
+        };
+        const issue = ExpressionFormatValidator.validateAndFix(value, 'owner', githubContext);
+
+        expect(issue).toBeNull();
+      });
+
+      it('should detect missing prefix in resource locator value', () => {
+        const value = {
+          __rl: true,
+          value: '{{ $vars.GITHUB_OWNER }}',
+          mode: 'expression'
+        };
+        const issue = ExpressionFormatValidator.validateAndFix(value, 'owner', githubContext);
+
+        expect(issue).toBeTruthy();
+        expect(issue?.issueType).toBe('missing-prefix');
+        expect(issue?.correctedValue.value).toBe('={{ $vars.GITHUB_OWNER }}');
+      });
+
+      it('should warn if expression has prefix but should use RL format', () => {
+        const value = '={{ $vars.GITHUB_OWNER }}';
+        const issue = ExpressionFormatValidator.validateAndFix(value, 'owner', githubContext);
+
+        expect(issue).toBeTruthy();
+        expect(issue?.issueType).toBe('needs-resource-locator');
+        expect(issue?.severity).toBe('warning');
+      });
+    });
+
+    describe('Multiple expressions', () => {
+      it('should detect multiple expressions without prefix', () => {
+        const value = '{{ $json.first }} - {{ $json.last }}';
+        const issue = ExpressionFormatValidator.validateAndFix(value, 'fullName', context);
+
+        expect(issue).toBeTruthy();
+        expect(issue?.issueType).toBe('missing-prefix');
+        expect(issue?.correctedValue).toBe('={{ $json.first }} - {{ $json.last }}');
+      });
+
+      it('should accept multiple expressions with prefix', () => {
+        const value = '={{ $json.first }} - {{ $json.last }}';
+        const issue = ExpressionFormatValidator.validateAndFix(value, 'fullName', context);
+
+        expect(issue).toBeNull();
+      });
+    });
+
+    describe('Edge cases', () => {
+      it('should handle null values', () => {
+        const issue = ExpressionFormatValidator.validateAndFix(null, 'field', context);
+        expect(issue).toBeNull();
+      });
+
+      it('should handle undefined values', () => {
+        const issue = ExpressionFormatValidator.validateAndFix(undefined, 'field', context);
+        expect(issue).toBeNull();
+      });
+
+      it('should handle empty strings', () => {
+        const issue = ExpressionFormatValidator.validateAndFix('', 'field', context);
+        expect(issue).toBeNull();
+      });
+
+      it('should handle numbers', () => {
+        const issue = ExpressionFormatValidator.validateAndFix(42, 'field', context);
+        expect(issue).toBeNull();
+      });
+
+      it('should handle booleans', () => {
+        const issue = ExpressionFormatValidator.validateAndFix(true, 'field', context);
+        expect(issue).toBeNull();
+      });
+
+      it('should handle arrays', () => {
+        const issue = ExpressionFormatValidator.validateAndFix(['item1', 'item2'], 'field', context);
+        expect(issue).toBeNull();
+      });
+    });
+  });
+
+  describe('validateNodeParameters', () => {
+    const context = {
+      nodeType: 'n8n-nodes-base.emailSend',
+      nodeName: 'Send Email',
+      nodeId: 'email-1'
+    };
+
+    it('should validate all parameters recursively', () => {
+      const parameters = {
+        fromEmail: '{{ $env.SENDER_EMAIL }}',
+        toEmail: 'user@example.com',
+        subject: 'Test {{ $json.type }}',
+        body: {
+          html: '<p>Hello {{ $json.name }}</p>',
+          text: 'Hello {{ $json.name }}'
+        },
+        options: {
+          replyTo: '={{ $env.REPLY_EMAIL }}'
+        }
+      };
+
+      const issues = ExpressionFormatValidator.validateNodeParameters(parameters, context);
+
+      expect(issues).toHaveLength(4);
+      expect(issues.map(i => i.fieldPath)).toContain('fromEmail');
+      expect(issues.map(i => i.fieldPath)).toContain('subject');
+      expect(issues.map(i => i.fieldPath)).toContain('body.html');
+      expect(issues.map(i => i.fieldPath)).toContain('body.text');
+    });
+
+    it('should handle arrays with expressions', () => {
+      const parameters = {
+        recipients: [
+          '{{ $json.email1 }}',
+          'static@example.com',
+          '={{ $json.email2 }}'
+        ]
+      };
+
+      const issues = ExpressionFormatValidator.validateNodeParameters(parameters, context);
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0].fieldPath).toBe('recipients[0]');
+      expect(issues[0].correctedValue).toBe('={{ $json.email1 }}');
+    });
+
+    it('should handle nested objects', () => {
+      const parameters = {
+        config: {
+          database: {
+            host: '{{ $env.DB_HOST }}',
+            port: 5432,
+            name: 'mydb'
+          }
+        }
+      };
+
+      const issues = ExpressionFormatValidator.validateNodeParameters(parameters, context);
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0].fieldPath).toBe('config.database.host');
+    });
+
+    it('should skip circular references', () => {
+      const circular: any = { a: 1 };
+      circular.self = circular;
+
+      const parameters = {
+        normal: '{{ $json.value }}',
+        circular
+      };
+
+      const issues = ExpressionFormatValidator.validateNodeParameters(parameters, context);
+
+      // Should only find the issue in 'normal', not crash on circular
+      expect(issues).toHaveLength(1);
+      expect(issues[0].fieldPath).toBe('normal');
+    });
+
+    it('should handle maximum recursion depth', () => {
+      // Create a deeply nested object (105 levels deep, exceeding the limit of 100)
+      let deepObject: any = { value: '{{ $json.data }}' };
+      let current = deepObject;
+      for (let i = 0; i < 105; i++) {
+        current.nested = { value: `{{ $json.level${i} }}` };
+        current = current.nested;
+      }
+
+      const parameters = {
+        deep: deepObject
+      };
+
+      const issues = ExpressionFormatValidator.validateNodeParameters(parameters, context);
+
+      // Should find expression format issues up to the depth limit
+      const depthWarning = issues.find(i => i.explanation.includes('Maximum recursion depth'));
+      expect(depthWarning).toBeTruthy();
+      expect(depthWarning?.severity).toBe('warning');
+
+      // Should still find some expression format errors before hitting the limit
+      const formatErrors = issues.filter(i => i.issueType === 'missing-prefix');
+      expect(formatErrors.length).toBeGreaterThan(0);
+      expect(formatErrors.length).toBeLessThanOrEqual(100); // Should not exceed the depth limit
+    });
+  });
+
+  describe('formatErrorMessage', () => {
+    const context = {
+      nodeType: 'n8n-nodes-base.github',
+      nodeName: 'Create Issue',
+      nodeId: 'github-1'
+    };
+
+    it('should format error message for missing prefix', () => {
+      const issue = {
+        fieldPath: 'title',
+        currentValue: '{{ $json.title }}',
+        correctedValue: '={{ $json.title }}',
+        issueType: 'missing-prefix' as const,
+        explanation: "Expression missing required '=' prefix.",
+        severity: 'error' as const
+      };
+
+      const message = ExpressionFormatValidator.formatErrorMessage(issue, context);
+
+      expect(message).toContain("Expression format error in node 'Create Issue'");
+      expect(message).toContain('Field \'title\'');
+      expect(message).toContain('Current (incorrect):');
+      expect(message).toContain('"title": "{{ $json.title }}"');
+      expect(message).toContain('Fixed (correct):');
+      expect(message).toContain('"title": "={{ $json.title }}"');
+    });
+
+    it('should format error message for resource locator', () => {
+      const issue = {
+        fieldPath: 'owner',
+        currentValue: '{{ $vars.OWNER }}',
+        correctedValue: {
+          __rl: true,
+          value: '={{ $vars.OWNER }}',
+          mode: 'expression'
+        },
+        issueType: 'needs-resource-locator' as const,
+        explanation: 'Field needs resource locator format.',
+        severity: 'error' as const
+      };
+
+      const message = ExpressionFormatValidator.formatErrorMessage(issue, context);
+
+      expect(message).toContain("Expression format error in node 'Create Issue'");
+      expect(message).toContain('Current (incorrect):');
+      expect(message).toContain('"owner": "{{ $vars.OWNER }}"');
+      expect(message).toContain('Fixed (correct):');
+      expect(message).toContain('"__rl": true');
+      expect(message).toContain('"value": "={{ $vars.OWNER }}"');
+      expect(message).toContain('"mode": "expression"');
+    });
+  });
+
+  describe('Real-world examples', () => {
+    it('should validate Email Send node example', () => {
+      const context = {
+        nodeType: 'n8n-nodes-base.emailSend',
+        nodeName: 'Error Handler',
+        nodeId: 'b9dd1cfd-ee66-4049-97e7-1af6d976a4e0'
+      };
+
+      const parameters = {
+        fromEmail: '{{ $env.ADMIN_EMAIL }}',
+        toEmail: 'admin@company.com',
+        subject: 'GitHub Issue Workflow Error - HIGH PRIORITY',
+        options: {}
+      };
+
+      const issues = ExpressionFormatValidator.validateNodeParameters(parameters, context);
+
+      expect(issues).toHaveLength(1);
+      expect(issues[0].fieldPath).toBe('fromEmail');
+      expect(issues[0].correctedValue).toBe('={{ $env.ADMIN_EMAIL }}');
+    });
+
+    it('should validate GitHub node example', () => {
+      const context = {
+        nodeType: 'n8n-nodes-base.github',
+        nodeName: 'Send Welcome Comment',
+        nodeId: '3c742ca1-af8f-4d80-a47e-e68fb1ced491'
+      };
+
+      const parameters = {
+        operation: 'createComment',
+        owner: '{{ $vars.GITHUB_OWNER }}',
+        repository: '{{ $vars.GITHUB_REPO }}',
+        issueNumber: null,
+        body: '👋 Hi @{{ $(\'Extract Issue Data\').first().json.author }}!\n\nThank you for creating this issue.'
+      };
+
+      const issues = ExpressionFormatValidator.validateNodeParameters(parameters, context);
+
+      expect(issues.length).toBeGreaterThan(0);
+      expect(issues.some(i => i.fieldPath === 'owner')).toBe(true);
+      expect(issues.some(i => i.fieldPath === 'repository')).toBe(true);
+      expect(issues.some(i => i.fieldPath === 'body')).toBe(true);
+    });
+  });
+});

--- a/tests/unit/services/universal-expression-validator.test.ts
+++ b/tests/unit/services/universal-expression-validator.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import { UniversalExpressionValidator } from '../../../src/services/universal-expression-validator';
+
+describe('UniversalExpressionValidator', () => {
+  describe('validateExpressionPrefix', () => {
+    it('should detect missing prefix in pure expression', () => {
+      const result = UniversalExpressionValidator.validateExpressionPrefix('{{ $json.value }}');
+
+      expect(result.isValid).toBe(false);
+      expect(result.hasExpression).toBe(true);
+      expect(result.needsPrefix).toBe(true);
+      expect(result.isMixedContent).toBe(false);
+      expect(result.confidence).toBe(1.0);
+      expect(result.suggestion).toBe('={{ $json.value }}');
+    });
+
+    it('should detect missing prefix in mixed content', () => {
+      const result = UniversalExpressionValidator.validateExpressionPrefix(
+        'Hello {{ $json.name }}'
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.hasExpression).toBe(true);
+      expect(result.needsPrefix).toBe(true);
+      expect(result.isMixedContent).toBe(true);
+      expect(result.confidence).toBe(1.0);
+      expect(result.suggestion).toBe('=Hello {{ $json.name }}');
+    });
+
+    it('should accept properly prefixed expression', () => {
+      const result = UniversalExpressionValidator.validateExpressionPrefix('={{ $json.value }}');
+
+      expect(result.isValid).toBe(true);
+      expect(result.hasExpression).toBe(true);
+      expect(result.needsPrefix).toBe(false);
+      expect(result.confidence).toBe(1.0);
+    });
+
+    it('should accept properly prefixed mixed content', () => {
+      const result = UniversalExpressionValidator.validateExpressionPrefix(
+        '=Hello {{ $json.name }}!'
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.hasExpression).toBe(true);
+      expect(result.isMixedContent).toBe(true);
+      expect(result.confidence).toBe(1.0);
+    });
+
+    it('should ignore non-string values', () => {
+      const result = UniversalExpressionValidator.validateExpressionPrefix(123);
+
+      expect(result.isValid).toBe(true);
+      expect(result.hasExpression).toBe(false);
+      expect(result.confidence).toBe(1.0);
+    });
+
+    it('should ignore strings without expressions', () => {
+      const result = UniversalExpressionValidator.validateExpressionPrefix('plain text');
+
+      expect(result.isValid).toBe(true);
+      expect(result.hasExpression).toBe(false);
+      expect(result.confidence).toBe(1.0);
+    });
+  });
+
+  describe('validateExpressionSyntax', () => {
+    it('should detect unclosed brackets', () => {
+      const result = UniversalExpressionValidator.validateExpressionSyntax('={{ $json.value }');
+
+      expect(result.isValid).toBe(false);
+      expect(result.explanation).toContain('Unmatched expression brackets');
+    });
+
+    it('should detect empty expressions', () => {
+      const result = UniversalExpressionValidator.validateExpressionSyntax('={{  }}');
+
+      expect(result.isValid).toBe(false);
+      expect(result.explanation).toContain('Empty expression');
+    });
+
+    it('should accept valid syntax', () => {
+      const result = UniversalExpressionValidator.validateExpressionSyntax('={{ $json.value }}');
+
+      expect(result.isValid).toBe(true);
+      expect(result.hasExpression).toBe(true);
+    });
+
+    it('should handle multiple expressions', () => {
+      const result = UniversalExpressionValidator.validateExpressionSyntax(
+        '={{ $json.first }} and {{ $json.second }}'
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.hasExpression).toBe(true);
+      expect(result.isMixedContent).toBe(true);
+    });
+  });
+
+  describe('validateCommonPatterns', () => {
+    it('should detect template literal syntax', () => {
+      const result = UniversalExpressionValidator.validateCommonPatterns('={{ ${json.value} }}');
+
+      expect(result.isValid).toBe(false);
+      expect(result.explanation).toContain('Template literal syntax');
+    });
+
+    it('should detect double prefix', () => {
+      const result = UniversalExpressionValidator.validateCommonPatterns('={{ =$json.value }}');
+
+      expect(result.isValid).toBe(false);
+      expect(result.explanation).toContain('Double prefix');
+    });
+
+    it('should detect nested brackets', () => {
+      const result = UniversalExpressionValidator.validateCommonPatterns(
+        '={{ $json.items[{{ $json.index }}] }}'
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.explanation).toContain('Nested brackets');
+    });
+
+    it('should accept valid patterns', () => {
+      const result = UniversalExpressionValidator.validateCommonPatterns(
+        '={{ $json.items[$json.index] }}'
+      );
+
+      expect(result.isValid).toBe(true);
+    });
+  });
+
+  describe('validate (comprehensive)', () => {
+    it('should return all validation issues', () => {
+      const results = UniversalExpressionValidator.validate('{{ ${json.value} }}');
+
+      expect(results.length).toBeGreaterThan(0);
+      const issues = results.filter(r => !r.isValid);
+      expect(issues.length).toBeGreaterThan(0);
+
+      // Should detect both missing prefix and template literal syntax
+      const prefixIssue = issues.find(i => i.needsPrefix);
+      const patternIssue = issues.find(i => i.explanation.includes('Template literal'));
+
+      expect(prefixIssue).toBeTruthy();
+      expect(patternIssue).toBeTruthy();
+    });
+
+    it('should return success for valid expression', () => {
+      const results = UniversalExpressionValidator.validate('={{ $json.value }}');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].isValid).toBe(true);
+      expect(results[0].confidence).toBe(1.0);
+    });
+
+    it('should handle non-expression strings', () => {
+      const results = UniversalExpressionValidator.validate('plain text');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].isValid).toBe(true);
+      expect(results[0].hasExpression).toBe(false);
+    });
+  });
+
+  describe('getCorrectedValue', () => {
+    it('should add prefix to expression', () => {
+      const corrected = UniversalExpressionValidator.getCorrectedValue('{{ $json.value }}');
+      expect(corrected).toBe('={{ $json.value }}');
+    });
+
+    it('should add prefix to mixed content', () => {
+      const corrected = UniversalExpressionValidator.getCorrectedValue(
+        'Hello {{ $json.name }}'
+      );
+      expect(corrected).toBe('=Hello {{ $json.name }}');
+    });
+
+    it('should not modify already prefixed expressions', () => {
+      const corrected = UniversalExpressionValidator.getCorrectedValue('={{ $json.value }}');
+      expect(corrected).toBe('={{ $json.value }}');
+    });
+
+    it('should not modify non-expressions', () => {
+      const corrected = UniversalExpressionValidator.getCorrectedValue('plain text');
+      expect(corrected).toBe('plain text');
+    });
+  });
+
+  describe('hasMixedContent', () => {
+    it('should detect URLs with expressions', () => {
+      const result = UniversalExpressionValidator.validateExpressionPrefix(
+        'https://api.example.com/users/{{ $json.id }}'
+      );
+      expect(result.isMixedContent).toBe(true);
+    });
+
+    it('should detect text with expressions', () => {
+      const result = UniversalExpressionValidator.validateExpressionPrefix(
+        'Welcome {{ $json.name }} to our service'
+      );
+      expect(result.isMixedContent).toBe(true);
+    });
+
+    it('should identify pure expressions', () => {
+      const result = UniversalExpressionValidator.validateExpressionPrefix('{{ $json.value }}');
+      expect(result.isMixedContent).toBe(false);
+    });
+
+    it('should identify pure expressions with spaces', () => {
+      const result = UniversalExpressionValidator.validateExpressionPrefix(
+        '  {{ $json.value }}  '
+      );
+      expect(result.isMixedContent).toBe(false);
+    });
+  });
+});

--- a/tests/unit/services/workflow-validator-comprehensive.test.ts
+++ b/tests/unit/services/workflow-validator-comprehensive.test.ts
@@ -1934,8 +1934,10 @@ describe('WorkflowValidator - Comprehensive Tests', () => {
             main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]]
           },
           'HTTP Request': {
-            main: [[{ node: 'Process Data', type: 'main', index: 0 }]],
-            error: [[{ node: 'Error Handler', type: 'main', index: 0 }]]
+            main: [
+              [{ node: 'Process Data', type: 'main', index: 0 }],
+              [{ node: 'Error Handler', type: 'main', index: 0 }]
+            ]
           }
         }
       } as any;

--- a/tests/unit/services/workflow-validator-error-outputs.test.ts
+++ b/tests/unit/services/workflow-validator-error-outputs.test.ts
@@ -1,0 +1,793 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { WorkflowValidator } from '@/services/workflow-validator';
+import { NodeRepository } from '@/database/node-repository';
+import { EnhancedConfigValidator } from '@/services/enhanced-config-validator';
+
+vi.mock('@/utils/logger');
+
+describe('WorkflowValidator - Error Output Validation', () => {
+  let validator: WorkflowValidator;
+  let mockNodeRepository: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Create mock repository
+    mockNodeRepository = {
+      getNode: vi.fn((type: string) => {
+        // Return mock node info for common node types
+        if (type.includes('httpRequest') || type.includes('webhook') || type.includes('set')) {
+          return {
+            node_type: type,
+            display_name: 'Mock Node',
+            isVersioned: true,
+            version: 1
+          };
+        }
+        return null;
+      })
+    };
+
+    validator = new WorkflowValidator(mockNodeRepository, EnhancedConfigValidator);
+  });
+
+  describe('Error Output Configuration', () => {
+    it('should detect incorrect configuration - multiple nodes in same array', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Validate Input',
+            type: 'n8n-nodes-base.set',
+            typeVersion: 3.4,
+            position: [-400, 64],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'Filter URLs',
+            type: 'n8n-nodes-base.filter',
+            typeVersion: 2.2,
+            position: [-176, 64],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Error Response1',
+            type: 'n8n-nodes-base.respondToWebhook',
+            typeVersion: 1.5,
+            position: [-160, 240],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Validate Input': {
+            main: [
+              [
+                { node: 'Filter URLs', type: 'main', index: 0 },
+                { node: 'Error Response1', type: 'main', index: 0 }  // WRONG! Both in main[0]
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e =>
+        e.message.includes('Incorrect error output configuration') &&
+        e.message.includes('Error Response1') &&
+        e.message.includes('appear to be error handlers but are in main[0]')
+      )).toBe(true);
+
+      // Check that the error message includes the fix
+      const errorMsg = result.errors.find(e => e.message.includes('Incorrect error output configuration'));
+      expect(errorMsg?.message).toContain('INCORRECT (current)');
+      expect(errorMsg?.message).toContain('CORRECT (should be)');
+      expect(errorMsg?.message).toContain('main[1] = error output');
+    });
+
+    it('should validate correct configuration - separate arrays', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Validate Input',
+            type: 'n8n-nodes-base.set',
+            typeVersion: 3.4,
+            position: [-400, 64],
+            parameters: {},
+            onError: 'continueErrorOutput'
+          },
+          {
+            id: '2',
+            name: 'Filter URLs',
+            type: 'n8n-nodes-base.filter',
+            typeVersion: 2.2,
+            position: [-176, 64],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Error Response1',
+            type: 'n8n-nodes-base.respondToWebhook',
+            typeVersion: 1.5,
+            position: [-160, 240],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Validate Input': {
+            main: [
+              [
+                { node: 'Filter URLs', type: 'main', index: 0 }
+              ],
+              [
+                { node: 'Error Response1', type: 'main', index: 0 }  // Correctly in main[1]
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should not have the specific error about incorrect configuration
+      expect(result.errors.some(e =>
+        e.message.includes('Incorrect error output configuration')
+      )).toBe(false);
+    });
+
+    it('should detect onError without error connections', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'HTTP Request',
+            type: 'n8n-nodes-base.httpRequest',
+            typeVersion: 4,
+            position: [100, 100],
+            parameters: {},
+            onError: 'continueErrorOutput'  // Has onError
+          },
+          {
+            id: '2',
+            name: 'Process Data',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'HTTP Request': {
+            main: [
+              [
+                { node: 'Process Data', type: 'main', index: 0 }
+              ]
+              // No main[1] for error output
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      expect(result.errors.some(e =>
+        e.nodeName === 'HTTP Request' &&
+        e.message.includes("has onError: 'continueErrorOutput' but no error output connections")
+      )).toBe(true);
+    });
+
+    it('should warn about error connections without onError', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'HTTP Request',
+            type: 'n8n-nodes-base.httpRequest',
+            typeVersion: 4,
+            position: [100, 100],
+            parameters: {}
+            // Missing onError property
+          },
+          {
+            id: '2',
+            name: 'Process Data',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Error Handler',
+            type: 'n8n-nodes-base.set',
+            position: [300, 300],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'HTTP Request': {
+            main: [
+              [
+                { node: 'Process Data', type: 'main', index: 0 }
+              ],
+              [
+                { node: 'Error Handler', type: 'main', index: 0 }  // Has error connection
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      expect(result.warnings.some(w =>
+        w.nodeName === 'HTTP Request' &&
+        w.message.includes('error output connections in main[1] but missing onError')
+      )).toBe(true);
+    });
+  });
+
+  describe('Error Handler Detection', () => {
+    it('should detect error handler nodes by name', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'API Call',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [100, 100],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'Process Success',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Handle Error',  // Contains 'error'
+            type: 'n8n-nodes-base.set',
+            position: [300, 300],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'API Call': {
+            main: [
+              [
+                { node: 'Process Success', type: 'main', index: 0 },
+                { node: 'Handle Error', type: 'main', index: 0 }  // Wrong placement
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      expect(result.errors.some(e =>
+        e.message.includes('Handle Error') &&
+        e.message.includes('appear to be error handlers')
+      )).toBe(true);
+    });
+
+    it('should detect error handler nodes by type', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Webhook',
+            type: 'n8n-nodes-base.webhook',
+            position: [100, 100],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'Process',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Respond',
+            type: 'n8n-nodes-base.respondToWebhook',  // Common error handler type
+            position: [300, 300],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Webhook': {
+            main: [
+              [
+                { node: 'Process', type: 'main', index: 0 },
+                { node: 'Respond', type: 'main', index: 0 }  // Wrong placement
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      expect(result.errors.some(e =>
+        e.message.includes('Respond') &&
+        e.message.includes('appear to be error handlers')
+      )).toBe(true);
+    });
+
+    it('should not flag non-error nodes in main[0]', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Start',
+            type: 'n8n-nodes-base.manualTrigger',
+            position: [100, 100],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'First Process',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Second Process',
+            type: 'n8n-nodes-base.set',
+            position: [300, 200],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Start': {
+            main: [
+              [
+                { node: 'First Process', type: 'main', index: 0 },
+                { node: 'Second Process', type: 'main', index: 0 }  // Both are valid success paths
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should not have error about incorrect error configuration
+      expect(result.errors.some(e =>
+        e.message.includes('Incorrect error output configuration')
+      )).toBe(false);
+    });
+  });
+
+  describe('Complex Error Patterns', () => {
+    it('should handle multiple error handlers correctly', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'HTTP Request',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [100, 100],
+            parameters: {},
+            onError: 'continueErrorOutput'
+          },
+          {
+            id: '2',
+            name: 'Process',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Log Error',
+            type: 'n8n-nodes-base.set',
+            position: [300, 200],
+            parameters: {}
+          },
+          {
+            id: '4',
+            name: 'Send Error Email',
+            type: 'n8n-nodes-base.emailSend',
+            position: [300, 300],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'HTTP Request': {
+            main: [
+              [
+                { node: 'Process', type: 'main', index: 0 }
+              ],
+              [
+                { node: 'Log Error', type: 'main', index: 0 },
+                { node: 'Send Error Email', type: 'main', index: 0 }  // Multiple error handlers OK in main[1]
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should not have errors about the configuration
+      expect(result.errors.some(e =>
+        e.message.includes('Incorrect error output configuration')
+      )).toBe(false);
+    });
+
+    it('should detect mixed success and error handlers in main[0]', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'API Request',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [100, 100],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'Transform Data',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Store Data',
+            type: 'n8n-nodes-base.set',
+            position: [500, 100],
+            parameters: {}
+          },
+          {
+            id: '4',
+            name: 'Error Notification',
+            type: 'n8n-nodes-base.emailSend',
+            position: [300, 300],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'API Request': {
+            main: [
+              [
+                { node: 'Transform Data', type: 'main', index: 0 },
+                { node: 'Store Data', type: 'main', index: 0 },
+                { node: 'Error Notification', type: 'main', index: 0 }  // Error handler mixed with success nodes
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      expect(result.errors.some(e =>
+        e.message.includes('Error Notification') &&
+        e.message.includes('appear to be error handlers but are in main[0]')
+      )).toBe(true);
+    });
+
+    it('should handle nested error handling (error handlers with their own errors)', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Primary API',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [100, 100],
+            parameters: {},
+            onError: 'continueErrorOutput'
+          },
+          {
+            id: '2',
+            name: 'Success Handler',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Error Logger',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [300, 200],
+            parameters: {},
+            onError: 'continueErrorOutput'
+          },
+          {
+            id: '4',
+            name: 'Fallback Error',
+            type: 'n8n-nodes-base.set',
+            position: [500, 250],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Primary API': {
+            main: [
+              [
+                { node: 'Success Handler', type: 'main', index: 0 }
+              ],
+              [
+                { node: 'Error Logger', type: 'main', index: 0 }
+              ]
+            ]
+          },
+          'Error Logger': {
+            main: [
+              [],
+              [
+                { node: 'Fallback Error', type: 'main', index: 0 }
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should not have errors about incorrect configuration
+      expect(result.errors.some(e =>
+        e.message.includes('Incorrect error output configuration')
+      )).toBe(false);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle workflows with no connections at all', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Isolated Node',
+            type: 'n8n-nodes-base.set',
+            position: [100, 100],
+            parameters: {},
+            onError: 'continueErrorOutput'
+          }
+        ],
+        connections: {}
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should have warning about orphaned node but not error about connections
+      expect(result.warnings.some(w =>
+        w.nodeName === 'Isolated Node' &&
+        w.message.includes('not connected to any other nodes')
+      )).toBe(true);
+
+      // Should not have error about error output configuration
+      expect(result.errors.some(e =>
+        e.message.includes('Incorrect error output configuration')
+      )).toBe(false);
+    });
+
+    it('should handle nodes with empty main arrays', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Source Node',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [100, 100],
+            parameters: {},
+            onError: 'continueErrorOutput'
+          },
+          {
+            id: '2',
+            name: 'Target Node',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Source Node': {
+            main: [
+              [],  // Empty success array
+              []   // Empty error array
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should detect that onError is set but no error connections exist
+      expect(result.errors.some(e =>
+        e.nodeName === 'Source Node' &&
+        e.message.includes("has onError: 'continueErrorOutput' but no error output connections")
+      )).toBe(true);
+    });
+
+    it('should handle workflows with only error outputs (no success path)', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Risky Operation',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [100, 100],
+            parameters: {},
+            onError: 'continueErrorOutput'
+          },
+          {
+            id: '2',
+            name: 'Error Handler Only',
+            type: 'n8n-nodes-base.set',
+            position: [300, 200],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Risky Operation': {
+            main: [
+              [],  // No success connections
+              [
+                { node: 'Error Handler Only', type: 'main', index: 0 }
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should not have errors about incorrect configuration - this is valid
+      expect(result.errors.some(e =>
+        e.message.includes('Incorrect error output configuration')
+      )).toBe(false);
+
+      // Should not have errors about missing error connections
+      expect(result.errors.some(e =>
+        e.message.includes("has onError: 'continueErrorOutput' but no error output connections")
+      )).toBe(false);
+    });
+
+    it('should handle undefined or null connection arrays gracefully', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Source Node',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [100, 100],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Source Node': {
+            main: [
+              null,      // Null array
+              undefined  // Undefined array
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should not crash and should not have configuration errors
+      expect(result.errors.some(e =>
+        e.message.includes('Incorrect error output configuration')
+      )).toBe(false);
+    });
+
+    it('should detect all variations of error-related node names', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Source',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [100, 100],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'Handle Failure',
+            type: 'n8n-nodes-base.set',
+            position: [300, 100],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Catch Exception',
+            type: 'n8n-nodes-base.set',
+            position: [300, 200],
+            parameters: {}
+          },
+          {
+            id: '4',
+            name: 'Success Path',
+            type: 'n8n-nodes-base.set',
+            position: [500, 100],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Source': {
+            main: [
+              [
+                { node: 'Handle Failure', type: 'main', index: 0 },
+                { node: 'Catch Exception', type: 'main', index: 0 },
+                { node: 'Success Path', type: 'main', index: 0 }
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should detect both 'Handle Failure' and 'Catch Exception' as error handlers
+      expect(result.errors.some(e =>
+        e.message.includes('Handle Failure') &&
+        e.message.includes('Catch Exception') &&
+        e.message.includes('appear to be error handlers but are in main[0]')
+      )).toBe(true);
+    });
+
+    it('should not flag legitimate parallel processing nodes', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Data Source',
+            type: 'n8n-nodes-base.webhook',
+            position: [100, 100],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'Process A',
+            type: 'n8n-nodes-base.set',
+            position: [300, 50],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Process B',
+            type: 'n8n-nodes-base.set',
+            position: [300, 150],
+            parameters: {}
+          },
+          {
+            id: '4',
+            name: 'Transform Data',
+            type: 'n8n-nodes-base.set',
+            position: [300, 250],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Data Source': {
+            main: [
+              [
+                { node: 'Process A', type: 'main', index: 0 },
+                { node: 'Process B', type: 'main', index: 0 },
+                { node: 'Transform Data', type: 'main', index: 0 }
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should not flag these as error configuration issues
+      expect(result.errors.some(e =>
+        e.message.includes('Incorrect error output configuration')
+      )).toBe(false);
+    });
+  });
+});

--- a/tests/unit/services/workflow-validator-expression-format.test.ts
+++ b/tests/unit/services/workflow-validator-expression-format.test.ts
@@ -1,0 +1,488 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { WorkflowValidator } from '../../../src/services/workflow-validator';
+import { NodeRepository } from '../../../src/database/node-repository';
+import { EnhancedConfigValidator } from '../../../src/services/enhanced-config-validator';
+
+// Mock the database
+vi.mock('../../../src/database/node-repository');
+
+describe('WorkflowValidator - Expression Format Validation', () => {
+  let validator: WorkflowValidator;
+  let mockNodeRepository: any;
+
+  beforeEach(() => {
+    // Create mock repository
+    mockNodeRepository = {
+      findNodeByType: vi.fn().mockImplementation((type: string) => {
+        // Return mock nodes for common types
+        if (type === 'n8n-nodes-base.emailSend') {
+          return {
+            node_type: 'n8n-nodes-base.emailSend',
+            display_name: 'Email Send',
+            properties: {},
+            version: 2.1
+          };
+        }
+        if (type === 'n8n-nodes-base.github') {
+          return {
+            node_type: 'n8n-nodes-base.github',
+            display_name: 'GitHub',
+            properties: {},
+            version: 1.1
+          };
+        }
+        if (type === 'n8n-nodes-base.webhook') {
+          return {
+            node_type: 'n8n-nodes-base.webhook',
+            display_name: 'Webhook',
+            properties: {},
+            version: 1
+          };
+        }
+        if (type === 'n8n-nodes-base.httpRequest') {
+          return {
+            node_type: 'n8n-nodes-base.httpRequest',
+            display_name: 'HTTP Request',
+            properties: {},
+            version: 4
+          };
+        }
+        return null;
+      }),
+      searchNodes: vi.fn().mockReturnValue([]),
+      getAllNodes: vi.fn().mockReturnValue([]),
+      close: vi.fn()
+    };
+
+    validator = new WorkflowValidator(mockNodeRepository, EnhancedConfigValidator);
+  });
+
+  describe('Expression Format Detection', () => {
+    it('should detect missing = prefix in simple expressions', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Send Email',
+            type: 'n8n-nodes-base.emailSend',
+            position: [0, 0] as [number, number],
+            parameters: {
+              fromEmail: '{{ $env.SENDER_EMAIL }}',
+              toEmail: 'user@example.com',
+              subject: 'Test Email'
+            },
+            typeVersion: 2.1
+          }
+        ],
+        connections: {}
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      expect(result.valid).toBe(false);
+
+      // Find expression format errors
+      const formatErrors = result.errors.filter(e => e.message.includes('Expression format error'));
+      expect(formatErrors).toHaveLength(1);
+
+      const error = formatErrors[0];
+      expect(error.message).toContain('Expression format error');
+      expect(error.message).toContain('fromEmail');
+      expect(error.message).toContain('{{ $env.SENDER_EMAIL }}');
+      expect(error.message).toContain('={{ $env.SENDER_EMAIL }}');
+    });
+
+    it('should detect missing resource locator format for GitHub fields', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'GitHub',
+            type: 'n8n-nodes-base.github',
+            position: [0, 0] as [number, number],
+            parameters: {
+              operation: 'createComment',
+              owner: '{{ $vars.GITHUB_OWNER }}',
+              repository: '{{ $vars.GITHUB_REPO }}',
+              issueNumber: 123,
+              body: 'Test comment'
+            },
+            typeVersion: 1.1
+          }
+        ],
+        connections: {}
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      expect(result.valid).toBe(false);
+      // Should have errors for both owner and repository
+      const ownerError = result.errors.find(e => e.message.includes('owner'));
+      const repoError = result.errors.find(e => e.message.includes('repository'));
+
+      expect(ownerError).toBeTruthy();
+      expect(repoError).toBeTruthy();
+      expect(ownerError?.message).toContain('resource locator format');
+      expect(ownerError?.message).toContain('__rl');
+    });
+
+    it('should detect mixed content without prefix', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'HTTP Request',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [0, 0] as [number, number],
+            parameters: {
+              url: 'https://api.example.com/{{ $json.endpoint }}',
+              headers: {
+                Authorization: 'Bearer {{ $env.API_TOKEN }}'
+              }
+            },
+            typeVersion: 4
+          }
+        ],
+        connections: {}
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      expect(result.valid).toBe(false);
+      const errors = result.errors.filter(e => e.message.includes('Expression format'));
+      expect(errors.length).toBeGreaterThan(0);
+
+      // Check for URL error
+      const urlError = errors.find(e => e.message.includes('url'));
+      expect(urlError).toBeTruthy();
+      expect(urlError?.message).toContain('=https://api.example.com/{{ $json.endpoint }}');
+    });
+
+    it('should accept properly formatted expressions', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Send Email',
+            type: 'n8n-nodes-base.emailSend',
+            position: [0, 0] as [number, number],
+            parameters: {
+              fromEmail: '={{ $env.SENDER_EMAIL }}',
+              toEmail: 'user@example.com',
+              subject: '=Test {{ $json.type }}'
+            },
+            typeVersion: 2.1
+          }
+        ],
+        connections: {}
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      // Should have no expression format errors
+      const formatErrors = result.errors.filter(e => e.message.includes('Expression format'));
+      expect(formatErrors).toHaveLength(0);
+    });
+
+    it('should accept resource locator format', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'GitHub',
+            type: 'n8n-nodes-base.github',
+            position: [0, 0] as [number, number],
+            parameters: {
+              operation: 'createComment',
+              owner: {
+                __rl: true,
+                value: '={{ $vars.GITHUB_OWNER }}',
+                mode: 'expression'
+              },
+              repository: {
+                __rl: true,
+                value: '={{ $vars.GITHUB_REPO }}',
+                mode: 'expression'
+              },
+              issueNumber: 123,
+              body: '=Test comment from {{ $json.author }}'
+            },
+            typeVersion: 1.1
+          }
+        ],
+        connections: {}
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      // Should have no expression format errors
+      const formatErrors = result.errors.filter(e => e.message.includes('Expression format'));
+      expect(formatErrors).toHaveLength(0);
+    });
+
+    it('should validate nested expressions in complex parameters', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'HTTP Request',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [0, 0] as [number, number],
+            parameters: {
+              method: 'POST',
+              url: 'https://api.example.com',
+              sendBody: true,
+              bodyParameters: {
+                parameters: [
+                  {
+                    name: 'userId',
+                    value: '{{ $json.id }}'
+                  },
+                  {
+                    name: 'timestamp',
+                    value: '={{ $now }}'
+                  }
+                ]
+              }
+            },
+            typeVersion: 4
+          }
+        ],
+        connections: {}
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      // Should detect the missing prefix in nested parameter
+      const errors = result.errors.filter(e => e.message.includes('Expression format'));
+      expect(errors.length).toBeGreaterThan(0);
+
+      const nestedError = errors.find(e => e.message.includes('bodyParameters'));
+      expect(nestedError).toBeTruthy();
+    });
+
+    it('should warn about RL format even with prefix', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'GitHub',
+            type: 'n8n-nodes-base.github',
+            position: [0, 0] as [number, number],
+            parameters: {
+              operation: 'createComment',
+              owner: '={{ $vars.GITHUB_OWNER }}',
+              repository: '={{ $vars.GITHUB_REPO }}',
+              issueNumber: 123,
+              body: 'Test'
+            },
+            typeVersion: 1.1
+          }
+        ],
+        connections: {}
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      // Should have warnings about using RL format
+      const warnings = result.warnings.filter(w => w.message.includes('resource locator format'));
+      expect(warnings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Real-world workflow examples', () => {
+    it('should validate Email workflow with expression issues', async () => {
+      const workflow = {
+        name: 'Error Notification Workflow',
+        nodes: [
+          {
+            id: 'webhook-1',
+            name: 'Webhook',
+            type: 'n8n-nodes-base.webhook',
+            position: [250, 300] as [number, number],
+            parameters: {
+              path: 'error-handler',
+              httpMethod: 'POST'
+            },
+            typeVersion: 1
+          },
+          {
+            id: 'email-1',
+            name: 'Error Handler',
+            type: 'n8n-nodes-base.emailSend',
+            position: [450, 300] as [number, number],
+            parameters: {
+              fromEmail: '{{ $env.ADMIN_EMAIL }}',
+              toEmail: 'admin@company.com',
+              subject: 'Error in {{ $json.workflow }}',
+              message: 'An error occurred: {{ $json.error }}',
+              options: {
+                replyTo: '={{ $env.SUPPORT_EMAIL }}'
+              }
+            },
+            typeVersion: 2.1
+          }
+        ],
+        connections: {
+          'Webhook': {
+            main: [[{ node: 'Error Handler', type: 'main', index: 0 }]]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      // Should have multiple expression format errors
+      const formatErrors = result.errors.filter(e => e.message.includes('Expression format'));
+      expect(formatErrors.length).toBeGreaterThanOrEqual(3); // fromEmail, subject, message
+
+      // Check specific errors
+      const fromEmailError = formatErrors.find(e => e.message.includes('fromEmail'));
+      expect(fromEmailError).toBeTruthy();
+      expect(fromEmailError?.message).toContain('={{ $env.ADMIN_EMAIL }}');
+    });
+
+    it('should validate GitHub workflow with resource locator issues', async () => {
+      const workflow = {
+        name: 'GitHub Issue Handler',
+        nodes: [
+          {
+            id: 'webhook-1',
+            name: 'Issue Webhook',
+            type: 'n8n-nodes-base.webhook',
+            position: [250, 300] as [number, number],
+            parameters: {
+              path: 'github-issue',
+              httpMethod: 'POST'
+            },
+            typeVersion: 1
+          },
+          {
+            id: 'github-1',
+            name: 'Create Comment',
+            type: 'n8n-nodes-base.github',
+            position: [450, 300] as [number, number],
+            parameters: {
+              operation: 'createComment',
+              owner: '{{ $vars.GITHUB_OWNER }}',
+              repository: '{{ $vars.GITHUB_REPO }}',
+              issueNumber: '={{ $json.body.issue.number }}',
+              body: 'Thanks for the issue @{{ $json.body.issue.user.login }}!'
+            },
+            typeVersion: 1.1
+          }
+        ],
+        connections: {
+          'Issue Webhook': {
+            main: [[{ node: 'Create Comment', type: 'main', index: 0 }]]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      // Should have errors for owner, repository, and body
+      const formatErrors = result.errors.filter(e => e.message.includes('Expression format'));
+      expect(formatErrors.length).toBeGreaterThanOrEqual(3);
+
+      // Check for resource locator suggestions
+      const ownerError = formatErrors.find(e => e.message.includes('owner'));
+      expect(ownerError?.message).toContain('__rl');
+      expect(ownerError?.message).toContain('resource locator format');
+    });
+
+    it('should provide clear fix examples in error messages', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Process Data',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [0, 0] as [number, number],
+            parameters: {
+              url: 'https://api.example.com/users/{{ $json.userId }}'
+            },
+            typeVersion: 4
+          }
+        ],
+        connections: {}
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      const error = result.errors.find(e => e.message.includes('Expression format'));
+      expect(error).toBeTruthy();
+
+      // Error message should contain both incorrect and correct examples
+      expect(error?.message).toContain('Current (incorrect):');
+      expect(error?.message).toContain('"url": "https://api.example.com/users/{{ $json.userId }}"');
+      expect(error?.message).toContain('Fixed (correct):');
+      expect(error?.message).toContain('"url": "=https://api.example.com/users/{{ $json.userId }}"');
+    });
+  });
+
+  describe('Integration with other validations', () => {
+    it('should validate expression format alongside syntax', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Test Node',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [0, 0] as [number, number],
+            parameters: {
+              url: '{{ $json.url',  // Syntax error: unclosed expression
+              headers: {
+                'X-Token': '{{ $env.TOKEN }}'  // Format error: missing prefix
+              }
+            },
+            typeVersion: 4
+          }
+        ],
+        connections: {}
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      // Should have both syntax and format errors
+      const syntaxErrors = result.errors.filter(e => e.message.includes('Unmatched expression brackets'));
+      const formatErrors = result.errors.filter(e => e.message.includes('Expression format'));
+
+      expect(syntaxErrors.length).toBeGreaterThan(0);
+      expect(formatErrors.length).toBeGreaterThan(0);
+    });
+
+    it('should not interfere with node validation', async () => {
+      // Test that expression format validation works alongside other validations
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'HTTP Request',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [0, 0] as [number, number],
+            parameters: {
+              url: '{{ $json.endpoint }}',  // Expression format error
+              headers: {
+                Authorization: '={{ $env.TOKEN }}'  // Correct format
+              }
+            },
+            typeVersion: 4
+          }
+        ],
+        connections: {}
+      };
+
+      const result = await validator.validateWorkflow(workflow);
+
+      // Should have expression format error for url field
+      const formatErrors = result.errors.filter(e => e.message.includes('Expression format'));
+      expect(formatErrors).toHaveLength(1);
+      expect(formatErrors[0].message).toContain('url');
+
+      // The workflow should still have structure validation (no trigger warning, etc)
+      // This proves that expression validation doesn't interfere with other checks
+      expect(result.warnings.some(w => w.message.includes('trigger'))).toBe(true);
+    });
+  });
+});

--- a/tests/unit/services/workflow-validator-mocks.test.ts
+++ b/tests/unit/services/workflow-validator-mocks.test.ts
@@ -1,0 +1,720 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { WorkflowValidator } from '@/services/workflow-validator';
+import { NodeRepository } from '@/database/node-repository';
+import { EnhancedConfigValidator } from '@/services/enhanced-config-validator';
+
+vi.mock('@/utils/logger');
+
+describe('WorkflowValidator - Mock-based Unit Tests', () => {
+  let validator: WorkflowValidator;
+  let mockNodeRepository: any;
+  let mockGetNode: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Create detailed mock repository with spy functions
+    mockGetNode = vi.fn();
+    mockNodeRepository = {
+      getNode: mockGetNode
+    };
+
+    validator = new WorkflowValidator(mockNodeRepository, EnhancedConfigValidator);
+
+    // Default mock responses
+    mockGetNode.mockImplementation((type: string) => {
+      if (type.includes('httpRequest')) {
+        return {
+          node_type: type,
+          display_name: 'HTTP Request',
+          isVersioned: true,
+          version: 4
+        };
+      } else if (type.includes('set')) {
+        return {
+          node_type: type,
+          display_name: 'Set',
+          isVersioned: true,
+          version: 3
+        };
+      } else if (type.includes('respondToWebhook')) {
+        return {
+          node_type: type,
+          display_name: 'Respond to Webhook',
+          isVersioned: true,
+          version: 1
+        };
+      }
+      return null;
+    });
+  });
+
+  describe('Error Handler Detection Logic', () => {
+    it('should correctly identify error handlers by node name patterns', async () => {
+      const errorNodeNames = [
+        'Error Handler',
+        'Handle Error',
+        'Catch Exception',
+        'Failure Response',
+        'Error Notification',
+        'Fail Safe',
+        'Exception Handler',
+        'Error Callback'
+      ];
+
+      const successNodeNames = [
+        'Process Data',
+        'Transform',
+        'Success Handler',
+        'Continue Process',
+        'Normal Flow'
+      ];
+
+      for (const errorName of errorNodeNames) {
+        const workflow = {
+          nodes: [
+            {
+              id: '1',
+              name: 'Source',
+              type: 'n8n-nodes-base.httpRequest',
+              position: [0, 0],
+              parameters: {}
+            },
+            {
+              id: '2',
+              name: 'Success Path',
+              type: 'n8n-nodes-base.set',
+              position: [200, 0],
+              parameters: {}
+            },
+            {
+              id: '3',
+              name: errorName,
+              type: 'n8n-nodes-base.set',
+              position: [200, 100],
+              parameters: {}
+            }
+          ],
+          connections: {
+            'Source': {
+              main: [
+                [
+                  { node: 'Success Path', type: 'main', index: 0 },
+                  { node: errorName, type: 'main', index: 0 }  // Should be detected as error handler
+                ]
+              ]
+            }
+          }
+        };
+
+        const result = await validator.validateWorkflow(workflow as any);
+
+        // Should detect this as an incorrect error configuration
+        const hasError = result.errors.some(e =>
+          e.message.includes('Incorrect error output configuration') &&
+          e.message.includes(errorName)
+        );
+        expect(hasError).toBe(true);
+      }
+
+      // Test that success node names are NOT flagged
+      for (const successName of successNodeNames) {
+        const workflow = {
+          nodes: [
+            {
+              id: '1',
+              name: 'Source',
+              type: 'n8n-nodes-base.httpRequest',
+              position: [0, 0],
+              parameters: {}
+            },
+            {
+              id: '2',
+              name: 'First Process',
+              type: 'n8n-nodes-base.set',
+              position: [200, 0],
+              parameters: {}
+            },
+            {
+              id: '3',
+              name: successName,
+              type: 'n8n-nodes-base.set',
+              position: [200, 100],
+              parameters: {}
+            }
+          ],
+          connections: {
+            'Source': {
+              main: [
+                [
+                  { node: 'First Process', type: 'main', index: 0 },
+                  { node: successName, type: 'main', index: 0 }
+                ]
+              ]
+            }
+          }
+        };
+
+        const result = await validator.validateWorkflow(workflow as any);
+
+        // Should NOT detect this as an error configuration
+        const hasError = result.errors.some(e =>
+          e.message.includes('Incorrect error output configuration')
+        );
+        expect(hasError).toBe(false);
+      }
+    });
+
+    it('should correctly identify error handlers by node type patterns', async () => {
+      const errorNodeTypes = [
+        'n8n-nodes-base.respondToWebhook',
+        'n8n-nodes-base.emailSend'
+        // Note: slack and webhook are not in the current detection logic
+      ];
+
+      // Update mock to return appropriate node info for these types
+      mockGetNode.mockImplementation((type: string) => {
+        return {
+          node_type: type,
+          display_name: type.split('.').pop() || 'Unknown',
+          isVersioned: true,
+          version: 1
+        };
+      });
+
+      for (const nodeType of errorNodeTypes) {
+        const workflow = {
+          nodes: [
+            {
+              id: '1',
+              name: 'Source',
+              type: 'n8n-nodes-base.httpRequest',
+              position: [0, 0],
+              parameters: {}
+            },
+            {
+              id: '2',
+              name: 'Success Path',
+              type: 'n8n-nodes-base.set',
+              position: [200, 0],
+              parameters: {}
+            },
+            {
+              id: '3',
+              name: 'Response Node',
+              type: nodeType,
+              position: [200, 100],
+              parameters: {}
+            }
+          ],
+          connections: {
+            'Source': {
+              main: [
+                [
+                  { node: 'Success Path', type: 'main', index: 0 },
+                  { node: 'Response Node', type: 'main', index: 0 }  // Should be detected
+                ]
+              ]
+            }
+          }
+        };
+
+        const result = await validator.validateWorkflow(workflow as any);
+
+        // Should detect this as an incorrect error configuration
+        const hasError = result.errors.some(e =>
+          e.message.includes('Incorrect error output configuration') &&
+          e.message.includes('Response Node')
+        );
+        expect(hasError).toBe(true);
+      }
+    });
+
+    it('should handle cases where node repository returns null', async () => {
+      // Mock repository to return null for unknown nodes
+      mockGetNode.mockImplementation((type: string) => {
+        if (type === 'n8n-nodes-base.unknownNode') {
+          return null;
+        }
+        return {
+          node_type: type,
+          display_name: 'Known Node',
+          isVersioned: true,
+          version: 1
+        };
+      });
+
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Source',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [0, 0],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'Unknown Node',
+            type: 'n8n-nodes-base.unknownNode',
+            position: [200, 0],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Error Handler',
+            type: 'n8n-nodes-base.set',
+            position: [200, 100],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'Source': {
+            main: [
+              [
+                { node: 'Unknown Node', type: 'main', index: 0 },
+                { node: 'Error Handler', type: 'main', index: 0 }
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should still detect the error configuration based on node name
+      const hasError = result.errors.some(e =>
+        e.message.includes('Incorrect error output configuration') &&
+        e.message.includes('Error Handler')
+      );
+      expect(hasError).toBe(true);
+
+      // Should not crash due to null node info
+      expect(result).toHaveProperty('valid');
+      expect(Array.isArray(result.errors)).toBe(true);
+    });
+  });
+
+  describe('onError Property Validation Logic', () => {
+    it('should validate onError property combinations correctly', async () => {
+      const testCases = [
+        {
+          name: 'onError set but no error connections',
+          onError: 'continueErrorOutput',
+          hasErrorConnections: false,
+          expectedErrorType: 'error',
+          expectedMessage: "has onError: 'continueErrorOutput' but no error output connections"
+        },
+        {
+          name: 'error connections but no onError',
+          onError: undefined,
+          hasErrorConnections: true,
+          expectedErrorType: 'warning',
+          expectedMessage: 'error output connections in main[1] but missing onError'
+        },
+        {
+          name: 'onError set with error connections',
+          onError: 'continueErrorOutput',
+          hasErrorConnections: true,
+          expectedErrorType: null,
+          expectedMessage: null
+        },
+        {
+          name: 'no onError and no error connections',
+          onError: undefined,
+          hasErrorConnections: false,
+          expectedErrorType: null,
+          expectedMessage: null
+        }
+      ];
+
+      for (const testCase of testCases) {
+        const workflow = {
+          nodes: [
+            {
+              id: '1',
+              name: 'Test Node',
+              type: 'n8n-nodes-base.httpRequest',
+              position: [0, 0],
+              parameters: {},
+              ...(testCase.onError ? { onError: testCase.onError } : {})
+            },
+            {
+              id: '2',
+              name: 'Success Handler',
+              type: 'n8n-nodes-base.set',
+              position: [200, 0],
+              parameters: {}
+            },
+            {
+              id: '3',
+              name: 'Error Handler',
+              type: 'n8n-nodes-base.set',
+              position: [200, 100],
+              parameters: {}
+            }
+          ],
+          connections: {
+            'Test Node': {
+              main: [
+                [
+                  { node: 'Success Handler', type: 'main', index: 0 }
+                ],
+                ...(testCase.hasErrorConnections ? [
+                  [
+                    { node: 'Error Handler', type: 'main', index: 0 }
+                  ]
+                ] : [])
+              ]
+            }
+          }
+        };
+
+        const result = await validator.validateWorkflow(workflow as any);
+
+        if (testCase.expectedErrorType === 'error') {
+          const hasExpectedError = result.errors.some(e =>
+            e.nodeName === 'Test Node' &&
+            e.message.includes(testCase.expectedMessage!)
+          );
+          expect(hasExpectedError).toBe(true);
+        } else if (testCase.expectedErrorType === 'warning') {
+          const hasExpectedWarning = result.warnings.some(w =>
+            w.nodeName === 'Test Node' &&
+            w.message.includes(testCase.expectedMessage!)
+          );
+          expect(hasExpectedWarning).toBe(true);
+        } else {
+          // Should not have related errors or warnings about onError/error output mismatches
+          const hasRelatedError = result.errors.some(e =>
+            e.nodeName === 'Test Node' &&
+            (e.message.includes("has onError: 'continueErrorOutput' but no error output connections") ||
+             e.message.includes('Incorrect error output configuration'))
+          );
+          const hasRelatedWarning = result.warnings.some(w =>
+            w.nodeName === 'Test Node' &&
+            w.message.includes('error output connections in main[1] but missing onError')
+          );
+          expect(hasRelatedError).toBe(false);
+          expect(hasRelatedWarning).toBe(false);
+        }
+      }
+    });
+
+    it('should handle different onError values correctly', async () => {
+      const onErrorValues = [
+        'continueErrorOutput',
+        'continueRegularOutput',
+        'stopWorkflow'
+      ];
+
+      for (const onErrorValue of onErrorValues) {
+        const workflow = {
+          nodes: [
+            {
+              id: '1',
+              name: 'Test Node',
+              type: 'n8n-nodes-base.httpRequest',
+              position: [0, 0],
+              parameters: {},
+              onError: onErrorValue
+            },
+            {
+              id: '2',
+              name: 'Next Node',
+              type: 'n8n-nodes-base.set',
+              position: [200, 0],
+              parameters: {}
+            }
+          ],
+          connections: {
+            'Test Node': {
+              main: [
+                [
+                  { node: 'Next Node', type: 'main', index: 0 }
+                ]
+                // No error connections
+              ]
+            }
+          }
+        };
+
+        const result = await validator.validateWorkflow(workflow as any);
+
+        if (onErrorValue === 'continueErrorOutput') {
+          // Should have error about missing error connections
+          const hasError = result.errors.some(e =>
+            e.nodeName === 'Test Node' &&
+            e.message.includes("has onError: 'continueErrorOutput' but no error output connections")
+          );
+          expect(hasError).toBe(true);
+        } else {
+          // Should not have error about missing error connections
+          const hasError = result.errors.some(e =>
+            e.nodeName === 'Test Node' &&
+            e.message.includes('but no error output connections')
+          );
+          expect(hasError).toBe(false);
+        }
+      }
+    });
+  });
+
+  describe('JSON Format Generation', () => {
+    it('should generate valid JSON in error messages', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'API Call',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [0, 0],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'Success Process',
+            type: 'n8n-nodes-base.set',
+            position: [200, 0],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'Error Handler',
+            type: 'n8n-nodes-base.respondToWebhook',
+            position: [200, 100],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'API Call': {
+            main: [
+              [
+                { node: 'Success Process', type: 'main', index: 0 },
+                { node: 'Error Handler', type: 'main', index: 0 }
+              ]
+            ]
+          }
+        }
+      };
+
+      const result = await validator.validateWorkflow(workflow as any);
+
+      const errorConfigError = result.errors.find(e =>
+        e.message.includes('Incorrect error output configuration')
+      );
+
+      expect(errorConfigError).toBeDefined();
+
+      // Extract JSON sections from error message
+      const incorrectMatch = errorConfigError!.message.match(/INCORRECT \(current\):\n([\s\S]*?)\n\nCORRECT/);
+      const correctMatch = errorConfigError!.message.match(/CORRECT \(should be\):\n([\s\S]*?)\n\nAlso add/);
+
+      expect(incorrectMatch).toBeDefined();
+      expect(correctMatch).toBeDefined();
+
+      // Extract just the JSON part (remove comments)
+      const incorrectJsonStr = incorrectMatch![1];
+      const correctJsonStr = correctMatch![1];
+
+      // Remove comments and clean up for JSON parsing
+      const cleanIncorrectJson = incorrectJsonStr.replace(/\/\/.*$/gm, '').replace(/,\s*$/, '');
+      const cleanCorrectJson = correctJsonStr.replace(/\/\/.*$/gm, '').replace(/,\s*$/, '');
+
+      const incorrectJson = `{${cleanIncorrectJson}}`;
+      const correctJson = `{${cleanCorrectJson}}`;
+
+      expect(() => JSON.parse(incorrectJson)).not.toThrow();
+      expect(() => JSON.parse(correctJson)).not.toThrow();
+
+      const parsedIncorrect = JSON.parse(incorrectJson);
+      const parsedCorrect = JSON.parse(correctJson);
+
+      // Validate structure
+      expect(parsedIncorrect).toHaveProperty('API Call');
+      expect(parsedCorrect).toHaveProperty('API Call');
+      expect(parsedIncorrect['API Call']).toHaveProperty('main');
+      expect(parsedCorrect['API Call']).toHaveProperty('main');
+
+      // Incorrect should have both nodes in main[0]
+      expect(Array.isArray(parsedIncorrect['API Call'].main)).toBe(true);
+      expect(parsedIncorrect['API Call'].main).toHaveLength(1);
+      expect(parsedIncorrect['API Call'].main[0]).toHaveLength(2);
+
+      // Correct should have separate arrays
+      expect(Array.isArray(parsedCorrect['API Call'].main)).toBe(true);
+      expect(parsedCorrect['API Call'].main).toHaveLength(2);
+      expect(parsedCorrect['API Call'].main[0]).toHaveLength(1); // Success only
+      expect(parsedCorrect['API Call'].main[1]).toHaveLength(1); // Error only
+    });
+
+    it('should handle special characters in node names in JSON', async () => {
+      // Test simpler special characters that are easier to handle in JSON
+      const specialNodeNames = [
+        'Node with spaces',
+        'Node-with-dashes',
+        'Node_with_underscores'
+      ];
+
+      for (const specialName of specialNodeNames) {
+        const workflow = {
+          nodes: [
+            {
+              id: '1',
+              name: 'Source',
+              type: 'n8n-nodes-base.httpRequest',
+              position: [0, 0],
+              parameters: {}
+            },
+            {
+              id: '2',
+              name: 'Success',
+              type: 'n8n-nodes-base.set',
+              position: [200, 0],
+              parameters: {}
+            },
+            {
+              id: '3',
+              name: specialName,
+              type: 'n8n-nodes-base.respondToWebhook',
+              position: [200, 100],
+              parameters: {}
+            }
+          ],
+          connections: {
+            'Source': {
+              main: [
+                [
+                  { node: 'Success', type: 'main', index: 0 },
+                  { node: specialName, type: 'main', index: 0 }
+                ]
+              ]
+            }
+          }
+        };
+
+        const result = await validator.validateWorkflow(workflow as any);
+
+        const errorConfigError = result.errors.find(e =>
+          e.message.includes('Incorrect error output configuration')
+        );
+
+        expect(errorConfigError).toBeDefined();
+
+        // Verify the error message contains the special node name
+        expect(errorConfigError!.message).toContain(specialName);
+
+        // Verify JSON structure is present (but don't parse due to comments)
+        expect(errorConfigError!.message).toContain('INCORRECT (current):');
+        expect(errorConfigError!.message).toContain('CORRECT (should be):');
+        expect(errorConfigError!.message).toContain('main[0]');
+        expect(errorConfigError!.message).toContain('main[1]');
+      }
+    });
+  });
+
+  describe('Repository Interaction Patterns', () => {
+    it('should call repository getNode with correct parameters', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'HTTP Node',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [0, 0],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'Set Node',
+            type: 'n8n-nodes-base.set',
+            position: [200, 0],
+            parameters: {}
+          }
+        ],
+        connections: {
+          'HTTP Node': {
+            main: [
+              [
+                { node: 'Set Node', type: 'main', index: 0 }
+              ]
+            ]
+          }
+        }
+      };
+
+      await validator.validateWorkflow(workflow as any);
+
+      // Should have called getNode for each node type
+      expect(mockGetNode).toHaveBeenCalledWith('n8n-nodes-base.httpRequest');
+      expect(mockGetNode).toHaveBeenCalledWith('n8n-nodes-base.set');
+      expect(mockGetNode).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle repository errors gracefully', async () => {
+      // Mock repository to throw error
+      mockGetNode.mockImplementation(() => {
+        throw new Error('Database connection failed');
+      });
+
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'Test Node',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [0, 0],
+            parameters: {}
+          }
+        ],
+        connections: {}
+      };
+
+      // Should not throw error
+      const result = await validator.validateWorkflow(workflow as any);
+
+      // Should still return a valid result
+      expect(result).toHaveProperty('valid');
+      expect(Array.isArray(result.errors)).toBe(true);
+      expect(Array.isArray(result.warnings)).toBe(true);
+    });
+
+    it('should optimize repository calls for duplicate node types', async () => {
+      const workflow = {
+        nodes: [
+          {
+            id: '1',
+            name: 'HTTP 1',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [0, 0],
+            parameters: {}
+          },
+          {
+            id: '2',
+            name: 'HTTP 2',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [200, 0],
+            parameters: {}
+          },
+          {
+            id: '3',
+            name: 'HTTP 3',
+            type: 'n8n-nodes-base.httpRequest',
+            position: [400, 0],
+            parameters: {}
+          }
+        ],
+        connections: {}
+      };
+
+      await validator.validateWorkflow(workflow as any);
+
+      // Should call getNode for the same type multiple times (current implementation)
+      // Note: This test documents current behavior. Could be optimized in the future.
+      const httpRequestCalls = mockGetNode.mock.calls.filter(
+        call => call[0] === 'n8n-nodes-base.httpRequest'
+      );
+      expect(httpRequestCalls.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/unit/services/workflow-validator-performance.test.ts
+++ b/tests/unit/services/workflow-validator-performance.test.ts
@@ -1,0 +1,528 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { WorkflowValidator } from '@/services/workflow-validator';
+import { NodeRepository } from '@/database/node-repository';
+import { EnhancedConfigValidator } from '@/services/enhanced-config-validator';
+
+vi.mock('@/utils/logger');
+
+describe('WorkflowValidator - Performance Tests', () => {
+  let validator: WorkflowValidator;
+  let mockNodeRepository: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Create mock repository with performance optimizations
+    mockNodeRepository = {
+      getNode: vi.fn((type: string) => {
+        // Return mock node info for any node type to avoid database calls
+        return {
+          node_type: type,
+          display_name: 'Mock Node',
+          isVersioned: true,
+          version: 1
+        };
+      })
+    };
+
+    validator = new WorkflowValidator(mockNodeRepository, EnhancedConfigValidator);
+  });
+
+  describe('Large Workflow Performance', () => {
+    it('should validate large workflows with many error paths efficiently', async () => {
+      // Generate a large workflow with 500 nodes
+      const nodeCount = 500;
+      const nodes = [];
+      const connections: any = {};
+
+      // Create nodes with various error handling patterns
+      for (let i = 1; i <= nodeCount; i++) {
+        nodes.push({
+          id: i.toString(),
+          name: `Node${i}`,
+          type: i % 5 === 0 ? 'n8n-nodes-base.httpRequest' : 'n8n-nodes-base.set',
+          typeVersion: 1,
+          position: [i * 10, (i % 10) * 100],
+          parameters: {},
+          ...(i % 3 === 0 ? { onError: 'continueErrorOutput' } : {})
+        });
+      }
+
+      // Create connections with multiple error handling scenarios
+      for (let i = 1; i < nodeCount; i++) {
+        const hasErrorHandling = i % 3 === 0;
+        const hasMultipleConnections = i % 7 === 0;
+
+        if (hasErrorHandling && hasMultipleConnections) {
+          // Mix correct and incorrect error handling patterns
+          const isIncorrect = i % 14 === 0;
+
+          if (isIncorrect) {
+            // Incorrect: error handlers mixed with success nodes in main[0]
+            connections[`Node${i}`] = {
+              main: [
+                [
+                  { node: `Node${i + 1}`, type: 'main', index: 0 },
+                  { node: `Error Handler ${i}`, type: 'main', index: 0 } // Wrong!
+                ]
+              ]
+            };
+          } else {
+            // Correct: separate success and error outputs
+            connections[`Node${i}`] = {
+              main: [
+                [
+                  { node: `Node${i + 1}`, type: 'main', index: 0 }
+                ],
+                [
+                  { node: `Error Handler ${i}`, type: 'main', index: 0 }
+                ]
+              ]
+            };
+          }
+
+          // Add error handler node
+          nodes.push({
+            id: `error-${i}`,
+            name: `Error Handler ${i}`,
+            type: 'n8n-nodes-base.respondToWebhook',
+            typeVersion: 1,
+            position: [(i + nodeCount) * 10, 500],
+            parameters: {}
+          });
+        } else {
+          // Simple connection
+          connections[`Node${i}`] = {
+            main: [
+              [
+                { node: `Node${i + 1}`, type: 'main', index: 0 }
+              ]
+            ]
+          };
+        }
+      }
+
+      const workflow = { nodes, connections };
+
+      const startTime = performance.now();
+      const result = await validator.validateWorkflow(workflow as any);
+      const endTime = performance.now();
+
+      const executionTime = endTime - startTime;
+
+      // Validation should complete within reasonable time
+      expect(executionTime).toBeLessThan(10000); // Less than 10 seconds
+
+      // Should still catch validation errors
+      expect(Array.isArray(result.errors)).toBe(true);
+      expect(Array.isArray(result.warnings)).toBe(true);
+
+      // Should detect incorrect error configurations
+      const incorrectConfigErrors = result.errors.filter(e =>
+        e.message.includes('Incorrect error output configuration')
+      );
+      expect(incorrectConfigErrors.length).toBeGreaterThan(0);
+
+      console.log(`Validated ${nodes.length} nodes in ${executionTime.toFixed(2)}ms`);
+      console.log(`Found ${result.errors.length} errors and ${result.warnings.length} warnings`);
+    });
+
+    it('should handle deeply nested error handling chains efficiently', async () => {
+      // Create a chain of error handlers, each with their own error handling
+      const chainLength = 100;
+      const nodes = [];
+      const connections: any = {};
+
+      for (let i = 1; i <= chainLength; i++) {
+        // Main processing node
+        nodes.push({
+          id: `main-${i}`,
+          name: `Main ${i}`,
+          type: 'n8n-nodes-base.httpRequest',
+          typeVersion: 1,
+          position: [i * 150, 100],
+          parameters: {},
+          onError: 'continueErrorOutput'
+        });
+
+        // Error handler node
+        nodes.push({
+          id: `error-${i}`,
+          name: `Error Handler ${i}`,
+          type: 'n8n-nodes-base.httpRequest',
+          typeVersion: 1,
+          position: [i * 150, 300],
+          parameters: {},
+          onError: 'continueErrorOutput'
+        });
+
+        // Fallback error node
+        nodes.push({
+          id: `fallback-${i}`,
+          name: `Fallback ${i}`,
+          type: 'n8n-nodes-base.set',
+          typeVersion: 1,
+          position: [i * 150, 500],
+          parameters: {}
+        });
+
+        // Connections
+        connections[`Main ${i}`] = {
+          main: [
+            // Success path
+            i < chainLength ? [{ node: `Main ${i + 1}`, type: 'main', index: 0 }] : [],
+            // Error path
+            [{ node: `Error Handler ${i}`, type: 'main', index: 0 }]
+          ]
+        };
+
+        connections[`Error Handler ${i}`] = {
+          main: [
+            // Success path (continue to next error handler or end)
+            [],
+            // Error path (go to fallback)
+            [{ node: `Fallback ${i}`, type: 'main', index: 0 }]
+          ]
+        };
+      }
+
+      const workflow = { nodes, connections };
+
+      const startTime = performance.now();
+      const result = await validator.validateWorkflow(workflow as any);
+      const endTime = performance.now();
+
+      const executionTime = endTime - startTime;
+
+      // Should complete quickly even with complex nested error handling
+      expect(executionTime).toBeLessThan(5000); // Less than 5 seconds
+
+      // Should not have errors about incorrect configuration (this is correct)
+      const incorrectConfigErrors = result.errors.filter(e =>
+        e.message.includes('Incorrect error output configuration')
+      );
+      expect(incorrectConfigErrors.length).toBe(0);
+
+      console.log(`Validated ${nodes.length} nodes with nested error handling in ${executionTime.toFixed(2)}ms`);
+    });
+
+    it('should efficiently validate workflows with many parallel error paths', async () => {
+      // Create a workflow with one source node that fans out to many parallel paths,
+      // each with their own error handling
+      const parallelPathCount = 200;
+      const nodes = [
+        {
+          id: 'source',
+          name: 'Source',
+          type: 'n8n-nodes-base.webhook',
+          typeVersion: 1,
+          position: [0, 0],
+          parameters: {}
+        }
+      ];
+      const connections: any = {
+        'Source': {
+          main: [[]]
+        }
+      };
+
+      // Create parallel paths
+      for (let i = 1; i <= parallelPathCount; i++) {
+        // Processing node
+        nodes.push({
+          id: `process-${i}`,
+          name: `Process ${i}`,
+          type: 'n8n-nodes-base.httpRequest',
+          typeVersion: 1,
+          position: [200, i * 20],
+          parameters: {},
+          onError: 'continueErrorOutput'
+        } as any);
+
+        // Success handler
+        nodes.push({
+          id: `success-${i}`,
+          name: `Success ${i}`,
+          type: 'n8n-nodes-base.set',
+          typeVersion: 1,
+          position: [400, i * 20],
+          parameters: {}
+        });
+
+        // Error handler
+        nodes.push({
+          id: `error-${i}`,
+          name: `Error Handler ${i}`,
+          type: 'n8n-nodes-base.respondToWebhook',
+          typeVersion: 1,
+          position: [400, i * 20 + 10],
+          parameters: {}
+        });
+
+        // Connect source to processing node
+        connections['Source'].main[0].push({
+          node: `Process ${i}`,
+          type: 'main',
+          index: 0
+        });
+
+        // Connect processing node to success and error handlers
+        connections[`Process ${i}`] = {
+          main: [
+            [{ node: `Success ${i}`, type: 'main', index: 0 }],
+            [{ node: `Error Handler ${i}`, type: 'main', index: 0 }]
+          ]
+        };
+      }
+
+      const workflow = { nodes, connections };
+
+      const startTime = performance.now();
+      const result = await validator.validateWorkflow(workflow as any);
+      const endTime = performance.now();
+
+      const executionTime = endTime - startTime;
+
+      // Should validate efficiently despite many parallel paths
+      expect(executionTime).toBeLessThan(8000); // Less than 8 seconds
+
+      // Should not have errors about incorrect configuration
+      const incorrectConfigErrors = result.errors.filter(e =>
+        e.message.includes('Incorrect error output configuration')
+      );
+      expect(incorrectConfigErrors.length).toBe(0);
+
+      console.log(`Validated ${nodes.length} nodes with ${parallelPathCount} parallel error paths in ${executionTime.toFixed(2)}ms`);
+    });
+
+    it('should handle worst-case scenario with many incorrect configurations efficiently', async () => {
+      // Create a workflow where many nodes have the incorrect error configuration
+      // This tests the performance of the error detection algorithm
+      const nodeCount = 300;
+      const nodes = [];
+      const connections: any = {};
+
+      for (let i = 1; i <= nodeCount; i++) {
+        // Main node
+        nodes.push({
+          id: `main-${i}`,
+          name: `Main ${i}`,
+          type: 'n8n-nodes-base.httpRequest',
+          typeVersion: 1,
+          position: [i * 20, 100],
+          parameters: {}
+        });
+
+        // Success handler
+        nodes.push({
+          id: `success-${i}`,
+          name: `Success ${i}`,
+          type: 'n8n-nodes-base.set',
+          typeVersion: 1,
+          position: [i * 20, 200],
+          parameters: {}
+        });
+
+        // Error handler (with error-indicating name)
+        nodes.push({
+          id: `error-${i}`,
+          name: `Error Handler ${i}`,
+          type: 'n8n-nodes-base.respondToWebhook',
+          typeVersion: 1,
+          position: [i * 20, 300],
+          parameters: {}
+        });
+
+        // INCORRECT configuration: both success and error handlers in main[0]
+        connections[`Main ${i}`] = {
+          main: [
+            [
+              { node: `Success ${i}`, type: 'main', index: 0 },
+              { node: `Error Handler ${i}`, type: 'main', index: 0 } // Wrong!
+            ]
+          ]
+        };
+      }
+
+      const workflow = { nodes, connections };
+
+      const startTime = performance.now();
+      const result = await validator.validateWorkflow(workflow as any);
+      const endTime = performance.now();
+
+      const executionTime = endTime - startTime;
+
+      // Should complete within reasonable time even when generating many errors
+      expect(executionTime).toBeLessThan(15000); // Less than 15 seconds
+
+      // Should detect ALL incorrect configurations
+      const incorrectConfigErrors = result.errors.filter(e =>
+        e.message.includes('Incorrect error output configuration')
+      );
+      expect(incorrectConfigErrors.length).toBe(nodeCount); // One error per node
+
+      console.log(`Detected ${incorrectConfigErrors.length} incorrect configurations in ${nodes.length} nodes in ${executionTime.toFixed(2)}ms`);
+    });
+  });
+
+  describe('Memory Usage and Optimization', () => {
+    it('should not leak memory during large workflow validation', async () => {
+      // Get initial memory usage
+      const initialMemory = process.memoryUsage().heapUsed;
+
+      // Validate multiple large workflows
+      for (let run = 0; run < 5; run++) {
+        const nodeCount = 200;
+        const nodes = [];
+        const connections: any = {};
+
+        for (let i = 1; i <= nodeCount; i++) {
+          nodes.push({
+            id: i.toString(),
+            name: `Node${i}`,
+            type: 'n8n-nodes-base.httpRequest',
+            typeVersion: 1,
+            position: [i * 10, 100],
+            parameters: {},
+            onError: 'continueErrorOutput'
+          });
+
+          if (i > 1) {
+            connections[`Node${i - 1}`] = {
+              main: [
+                [{ node: `Node${i}`, type: 'main', index: 0 }],
+                [{ node: `Error${i}`, type: 'main', index: 0 }]
+              ]
+            };
+
+            nodes.push({
+              id: `error-${i}`,
+              name: `Error${i}`,
+              type: 'n8n-nodes-base.set',
+              typeVersion: 1,
+              position: [i * 10, 200],
+              parameters: {}
+            });
+          }
+        }
+
+        const workflow = { nodes, connections };
+        await validator.validateWorkflow(workflow as any);
+
+        // Force garbage collection if available
+        if (global.gc) {
+          global.gc();
+        }
+      }
+
+      const finalMemory = process.memoryUsage().heapUsed;
+      const memoryIncrease = finalMemory - initialMemory;
+      const memoryIncreaseMB = memoryIncrease / (1024 * 1024);
+
+      // Memory increase should be reasonable (less than 50MB)
+      expect(memoryIncreaseMB).toBeLessThan(50);
+
+      console.log(`Memory increase after 5 large workflow validations: ${memoryIncreaseMB.toFixed(2)}MB`);
+    });
+
+    it('should handle concurrent validation requests efficiently', async () => {
+      // Create multiple validation requests that run concurrently
+      const concurrentRequests = 10;
+      const workflows = [];
+
+      // Prepare workflows
+      for (let r = 0; r < concurrentRequests; r++) {
+        const nodeCount = 50;
+        const nodes = [];
+        const connections: any = {};
+
+        for (let i = 1; i <= nodeCount; i++) {
+          nodes.push({
+            id: `${r}-${i}`,
+            name: `R${r}Node${i}`,
+            type: i % 2 === 0 ? 'n8n-nodes-base.httpRequest' : 'n8n-nodes-base.set',
+            typeVersion: 1,
+            position: [i * 20, r * 100],
+            parameters: {},
+            ...(i % 3 === 0 ? { onError: 'continueErrorOutput' } : {})
+          });
+
+          if (i > 1) {
+            const hasError = i % 3 === 0;
+            const isIncorrect = i % 6 === 0;
+
+            if (hasError && isIncorrect) {
+              // Incorrect configuration
+              connections[`R${r}Node${i - 1}`] = {
+                main: [
+                  [
+                    { node: `R${r}Node${i}`, type: 'main', index: 0 },
+                    { node: `R${r}Error${i}`, type: 'main', index: 0 } // Wrong!
+                  ]
+                ]
+              };
+
+              nodes.push({
+                id: `${r}-error-${i}`,
+                name: `R${r}Error${i}`,
+                type: 'n8n-nodes-base.respondToWebhook',
+                typeVersion: 1,
+                position: [i * 20, r * 100 + 50],
+                parameters: {}
+              });
+            } else if (hasError) {
+              // Correct configuration
+              connections[`R${r}Node${i - 1}`] = {
+                main: [
+                  [{ node: `R${r}Node${i}`, type: 'main', index: 0 }],
+                  [{ node: `R${r}Error${i}`, type: 'main', index: 0 }]
+                ]
+              };
+
+              nodes.push({
+                id: `${r}-error-${i}`,
+                name: `R${r}Error${i}`,
+                type: 'n8n-nodes-base.set',
+                typeVersion: 1,
+                position: [i * 20, r * 100 + 50],
+                parameters: {}
+              });
+            } else {
+              // Normal connection
+              connections[`R${r}Node${i - 1}`] = {
+                main: [
+                  [{ node: `R${r}Node${i}`, type: 'main', index: 0 }]
+                ]
+              };
+            }
+          }
+        }
+
+        workflows.push({ nodes, connections });
+      }
+
+      // Run concurrent validations
+      const startTime = performance.now();
+      const results = await Promise.all(
+        workflows.map(workflow => validator.validateWorkflow(workflow as any))
+      );
+      const endTime = performance.now();
+
+      const totalTime = endTime - startTime;
+
+      // All validations should complete
+      expect(results).toHaveLength(concurrentRequests);
+
+      // Each result should be valid
+      results.forEach(result => {
+        expect(Array.isArray(result.errors)).toBe(true);
+        expect(Array.isArray(result.warnings)).toBe(true);
+      });
+
+      // Concurrent execution should be efficient
+      expect(totalTime).toBeLessThan(20000); // Less than 20 seconds total
+
+      console.log(`Completed ${concurrentRequests} concurrent validations in ${totalTime.toFixed(2)}ms`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR enhances the workflow validator to detect and report incorrect error output configurations in n8n workflows. It specifically addresses the common issue where AI agents incorrectly place multiple nodes in the same output array instead of properly separating them into success and error paths.

## Problem
When AI agents build n8n workflows with error handling, they often incorrectly configure connections by placing both the success path node and error handler node in `main[0]` (the same array), when they should be separated into `main[0]` (success) and `main[1]` (error).

## Solution
- Added `validateErrorOutputConfiguration` method to detect incorrect configurations
- Fixed `checkWorkflowPatterns` to check `main[1]` for error outputs (was checking non-existent `outputs.error`)
- Cross-validates that `onError: 'continueErrorOutput'` property matches actual connection structure
- Uses heuristic detection for error handler nodes (names containing "error", "fail", "catch", etc.)
- Provides clear, actionable error messages with JSON examples

## Changes
- ✨ Added error output validation logic to `WorkflowValidator`
- 🐛 Fixed pattern detection to check correct error output location
- ✅ Added comprehensive test suite with 16+ test cases
- 📝 Updated CHANGELOG with version 2.12.1 details
- 🔖 Bumped version to 2.12.1

## Testing
- Added new test file with extensive coverage
- Created test scripts to validate the implementation
- All existing tests still pass

## Example Error Message
When an incorrect configuration is detected, users now get clear guidance:
```
Incorrect error output configuration for node 'Validate Input'.

Current (incorrect) configuration has multiple nodes in main[0]:
{
  "main": [
    [
      { "node": "Filter URLs", "type": "main", "index": 0 },
      { "node": "Error Response1", "type": "main", "index": 0 }
    ]
  ]
}

Correct configuration should separate success and error paths:
{
  "main": [
    [{ "node": "Filter URLs", "type": "main", "index": 0 }],
    [{ "node": "Error Response1", "type": "main", "index": 0 }]
  ]
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>