### PR TITLE
chore: update n8n dependencies to v1.112.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub stars](https://img.shields.io/github/stars/czlonkowski/n8n-mcp?style=social)](https://github.com/czlonkowski/n8n-mcp)
-[![Version](https://img.shields.io/badge/version-2.12.1-blue.svg)](https://github.com/czlonkowski/n8n-mcp)
+[![Version](https://img.shields.io/badge/version-2.12.2-blue.svg)](https://github.com/czlonkowski/n8n-mcp)
 [![npm version](https://img.shields.io/npm/v/n8n-mcp.svg)](https://www.npmjs.com/package/n8n-mcp)
 [![codecov](https://codecov.io/gh/czlonkowski/n8n-mcp/graph/badge.svg?token=YOUR_TOKEN)](https://codecov.io/gh/czlonkowski/n8n-mcp)
 [![Tests](https://img.shields.io/badge/tests-1728%20passing-brightgreen.svg)](https://github.com/czlonkowski/n8n-mcp/actions)
-[![n8n version](https://img.shields.io/badge/n8n-^1.111.0-orange.svg)](https://github.com/n8n-io/n8n)
+[![n8n version](https://img.shields.io/badge/n8n-^1.112.3-orange.svg)](https://github.com/n8n-io/n8n)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io%2Fczlonkowski%2Fn8n--mcp-green.svg)](https://github.com/czlonkowski/n8n-mcp/pkgs/container/n8n-mcp)
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/n8n-mcp?referralCode=n8n-mcp)
 
@@ -16,7 +16,7 @@ A Model Context Protocol (MCP) server that provides AI assistants with comprehen
 
 n8n-MCP serves as a bridge between n8n's workflow automation platform and AI models, enabling them to understand and work with n8n nodes effectively. It provides structured access to:
 
-- 📚 **535 n8n nodes** from both n8n-nodes-base and @n8n/n8n-nodes-langchain
+- 📚 **536 n8n nodes** from both n8n-nodes-base and @n8n/n8n-nodes-langchain
 - 🔧 **Node properties** - 99% coverage with detailed schemas
 - ⚡ **Node operations** - 63.6% coverage of available actions
 - 📄 **Documentation** - 90% coverage from official n8n docs (including AI nodes)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.12.2] - 2025-01-22
+
+### Changed
+- Updated n8n dependencies to latest versions:
+  - n8n: 1.111.0 → 1.112.3
+  - n8n-core: 1.110.0 → 1.111.0
+  - n8n-workflow: 1.108.0 → 1.109.0
+  - @n8n/n8n-nodes-langchain: 1.110.0 → 1.111.1
+- Rebuilt node database with 536 nodes (438 from n8n-nodes-base, 98 from langchain)
+
+## [2.12.1] - 2025-01-21
 
 ### Added
 - **Comprehensive Expression Format Validation System**: Three-tier validation strategy for n8n expressions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "n8n-mcp",
-  "version": "2.11.3",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.11.3",
+      "version": "2.12.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",
-        "@n8n/n8n-nodes-langchain": "^1.110.0",
+        "@n8n/n8n-nodes-langchain": "^1.111.1",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "lru-cache": "^11.2.1",
-        "n8n": "^1.111.0",
-        "n8n-core": "^1.110.0",
-        "n8n-workflow": "^1.108.0",
+        "n8n": "^1.112.3",
+        "n8n-core": "^1.111.0",
+        "n8n-workflow": "^1.109.0",
         "openai": "^4.77.0",
         "sql.js": "^1.13.0",
         "uuid": "^10.0.0",
@@ -9377,9 +9377,9 @@
       }
     },
     "node_modules/@n8n/ai-workflow-builder": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@n8n/ai-workflow-builder/-/ai-workflow-builder-0.21.0.tgz",
-      "integrity": "sha512-pfHJwgqjAi09jsJrZOZy4+LrV/6djgBUG4AuNMxYoTzFJliDYCx8p6ooTs+rYFBMyBEKHBDWkJasQSg8ViggUQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@n8n/ai-workflow-builder/-/ai-workflow-builder-0.22.0.tgz",
+      "integrity": "sha512-KJDyyDbx3Auuu/5VcZhABYXDY5sMKpwI1WgW11eu7qQ6XceBV/69fgG8mAfpqNvaBGoU8zLIpaaGYpAWRmGYVQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@langchain/anthropic": "0.3.26",
@@ -9387,49 +9387,13 @@
         "@langchain/langgraph": "0.2.74",
         "@langchain/openai": "0.6.7",
         "@n8n_io/ai-assistant-sdk": "1.15.0",
-        "@n8n/backend-common": "^0.21.0",
-        "@n8n/config": "1.54.0",
+        "@n8n/backend-common": "^0.22.0",
+        "@n8n/config": "1.55.0",
         "@n8n/di": "0.9.0",
         "langsmith": "^0.3.45",
         "lodash": "4.17.21",
-        "n8n-workflow": "1.108.0",
+        "n8n-workflow": "1.109.0",
         "picocolors": "1.0.1",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/ai-workflow-builder/node_modules/@n8n/config": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-1.54.0.tgz",
-      "integrity": "sha512-ftmh4ca0uF6wV2iQYI425LX2J6wsuiMdbgKMs8gOT8qLn0zVEB8g8/sgGRvjrBfXYVnh/IsyVprtQnw4aha5UQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/di": "0.9.0",
-        "reflect-metadata": "0.2.2",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/ai-workflow-builder/node_modules/n8n-workflow": {
-      "version": "1.108.0",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-1.108.0.tgz",
-      "integrity": "sha512-e3hSBUr1qTUgZolxHpT8RZmrrixVqum4rKGv7D0BcXRIKYGnsmg3CcrpFpLKxEBZDYFvTFUq68tvuMDoEwH6dg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "^0.5.0",
-        "@n8n/tournament": "1.0.6",
-        "ast-types": "0.15.2",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.0",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.2",
-        "jssha": "3.3.1",
-        "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "xml2js": "0.6.2",
         "zod": "3.25.67"
       }
     },
@@ -9449,41 +9413,16 @@
       }
     },
     "node_modules/@n8n/api-types": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-0.45.0.tgz",
-      "integrity": "sha512-Xzaar8oymJzZiLZ8CPAh0mixW6oEhKGB7zP05DUqzENXy08heDdOUfFKwu98GNkgtG6/HsUZS+qPrMx9EnN9dg==",
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-0.46.0.tgz",
+      "integrity": "sha512-aY75QfIRzmZZQEo8yUgNx2lxJkYVOgO8slbiLLY6tehKdzeTHOms52PldarWmoY7eTncPcoRzNjmag0TBi9n0A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/permissions": "0.34.0",
-        "n8n-workflow": "1.108.0",
+        "@n8n/permissions": "0.35.0",
+        "n8n-workflow": "1.109.0",
         "xss": "1.0.15",
         "zod": "3.25.67",
         "zod-class": "0.0.16"
-      }
-    },
-    "node_modules/@n8n/api-types/node_modules/n8n-workflow": {
-      "version": "1.108.0",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-1.108.0.tgz",
-      "integrity": "sha512-e3hSBUr1qTUgZolxHpT8RZmrrixVqum4rKGv7D0BcXRIKYGnsmg3CcrpFpLKxEBZDYFvTFUq68tvuMDoEwH6dg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "^0.5.0",
-        "@n8n/tournament": "1.0.6",
-        "ast-types": "0.15.2",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.0",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.2",
-        "jssha": "3.3.1",
-        "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
       }
     },
     "node_modules/@n8n/api-types/node_modules/zod": {
@@ -9496,17 +9435,17 @@
       }
     },
     "node_modules/@n8n/backend-common": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-0.21.0.tgz",
-      "integrity": "sha512-sKSd9mk026UTNnfQ0TeYOHoEAO3t9FpPfbr8aXF5n5z6TVifmYqchQXL30zQ0SvtNj3INOaBqKha29i+ALg9Cw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-0.22.0.tgz",
+      "integrity": "sha512-qH9X+NTXTmqtkzdKH+yYEmZZ+FQZB3yuQbLUOesjWGlwLu3YyHSfLutsKk5tds++v1njNE+0qsKl8CX6LdAS/A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/config": "^1.54.0",
+        "@n8n/config": "^1.55.0",
         "@n8n/constants": "^0.12.0",
-        "@n8n/decorators": "^0.21.0",
+        "@n8n/decorators": "^0.22.0",
         "@n8n/di": "^0.9.0",
         "callsites": "3.1.0",
-        "n8n-workflow": "^1.108.0",
+        "n8n-workflow": "^1.109.0",
         "picocolors": "1.0.1",
         "reflect-metadata": "0.2.2",
         "winston": "3.14.2",
@@ -9556,20 +9495,20 @@
       }
     },
     "node_modules/@n8n/backend-test-utils": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@n8n/backend-test-utils/-/backend-test-utils-0.14.1.tgz",
-      "integrity": "sha512-sUEy3oermMbJApasbXjQ9al0eAG1yyM/ktSOnGKO9oEkIt7ei5tZ58DGJzvU76n7eEQ1IRTcTJQldaKBiZZ4KQ==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@n8n/backend-test-utils/-/backend-test-utils-0.15.1.tgz",
+      "integrity": "sha512-G8cW1d0QGJpfA6KmZunhnptVtpswaSEb+ZUdCAML4nqhLFX5RN1QS3l5uESRMZpYQWHNdVWG5hqtHssEsOZucg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/backend-common": "^0.21.0",
-        "@n8n/config": "^1.54.0",
+        "@n8n/backend-common": "^0.22.0",
+        "@n8n/config": "^1.55.0",
         "@n8n/constants": "^0.12.0",
-        "@n8n/db": "^0.22.1",
+        "@n8n/db": "^0.23.1",
         "@n8n/di": "^0.9.0",
-        "@n8n/permissions": "^0.34.0",
+        "@n8n/permissions": "^0.35.0",
         "@n8n/typeorm": "0.3.20-12",
         "jest-mock-extended": "^3.0.4",
-        "n8n-workflow": "^1.108.0",
+        "n8n-workflow": "^1.109.0",
         "reflect-metadata": "0.2.2",
         "uuid": "10.0.0"
       }
@@ -10533,24 +10472,24 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@n8n/db": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@n8n/db/-/db-0.22.1.tgz",
-      "integrity": "sha512-22FWH07N8/u230442zjst9f6kkmlFdECy39HilUVeTVd5UyaeLa1Gb+/Hog92kd8nd5URL2R7iSATIUPe5w8lg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@n8n/db/-/db-0.23.1.tgz",
+      "integrity": "sha512-ovcSdzkHKssL2DBX1W+zREqn7W1NiYmo2fWrmZiBNgZgGM8lCyURDXyKcFYuDtPLYolXbGpKG2J1HREhJMI2Lw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/api-types": "^0.45.0",
-        "@n8n/backend-common": "^0.21.0",
-        "@n8n/config": "^1.54.0",
+        "@n8n/api-types": "^0.46.0",
+        "@n8n/backend-common": "^0.22.0",
+        "@n8n/config": "^1.55.0",
         "@n8n/constants": "^0.12.0",
-        "@n8n/decorators": "^0.21.0",
+        "@n8n/decorators": "^0.22.0",
         "@n8n/di": "^0.9.0",
-        "@n8n/permissions": "^0.34.0",
+        "@n8n/permissions": "^0.35.0",
         "@n8n/typeorm": "0.3.20-12",
         "class-validator": "0.14.0",
         "flatted": "3.2.7",
         "lodash": "4.17.21",
-        "n8n-core": "^1.110.0",
-        "n8n-workflow": "^1.108.0",
+        "n8n-core": "^1.111.0",
+        "n8n-workflow": "^1.109.0",
         "nanoid": "3.3.8",
         "p-lazy": "3.1.0",
         "reflect-metadata": "0.2.2",
@@ -11487,16 +11426,16 @@
       }
     },
     "node_modules/@n8n/decorators": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-0.21.0.tgz",
-      "integrity": "sha512-x/PJOI9Z3K0z7O+Wvy9Ze5y7cijCmmbVVHNKJA8ocjZ9EqD97C11syD7ZzXbgHSAJ6mMSXvZdtR2Je4YTHw1NA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-0.22.0.tgz",
+      "integrity": "sha512-MgPIdn6RxElzHV/OEw8KsIzQIctdZ6sr3tJvnJ++Z1IhNlTPecYpbmgySEbTrqDFQBsULQLDRVIo4UaLayTD3g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@n8n/constants": "^0.12.0",
         "@n8n/di": "^0.9.0",
-        "@n8n/permissions": "^0.34.0",
+        "@n8n/permissions": "^0.35.0",
         "lodash": "4.17.21",
-        "n8n-workflow": "^1.108.0"
+        "n8n-workflow": "^1.109.0"
       }
     },
     "node_modules/@n8n/di": {
@@ -12607,9 +12546,9 @@
       "license": "MIT"
     },
     "node_modules/@n8n/permissions": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.34.0.tgz",
-      "integrity": "sha512-C+wm62NN7ofQZCTns46j+ME+cwMIjuFaVxrt8PizKgFnNMJu0gU0v3lI9VL+rHanVxGZXKTX71+LRyQRwq5wCw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.35.0.tgz",
+      "integrity": "sha512-VSfCdikOH+IbHl4tsYbi/rIoxL1wJUJlu/rguZ3oR8SaoDaa4bbIf9H8o3NhAyiFsWabWRU57ct941kGoxzT6Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "zod": "3.25.67"
@@ -12625,12 +12564,12 @@
       }
     },
     "node_modules/@n8n/task-runner": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@n8n/task-runner/-/task-runner-1.47.0.tgz",
-      "integrity": "sha512-fYWco3HRp2lCM22E5IskcjKDDLFlzjWbZfMV8BDqpoSvUxGrxnT1C4MJT99y7zBUvuWhBU1Fe2NC4AOinEALyw==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@n8n/task-runner/-/task-runner-1.48.0.tgz",
+      "integrity": "sha512-m9JT8CLxBfCAi31Ldq5a/kQII1wUrou3vdKDzeJzZLtFec0XJZ7XlBcussjZHtMmL/mymt2eOD9ZG6+h4rXJxA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/config": "1.54.0",
+        "@n8n/config": "1.55.0",
         "@n8n/di": "0.9.0",
         "@n8n/errors": "^0.5.0",
         "@sentry/node": "^9.42.1",
@@ -12638,21 +12577,10 @@
         "acorn-walk": "8.3.4",
         "lodash": "4.17.21",
         "luxon": "3.4.4",
-        "n8n-core": "1.110.0",
-        "n8n-workflow": "1.108.0",
+        "n8n-core": "1.111.0",
+        "n8n-workflow": "1.109.0",
         "nanoid": "3.3.8",
         "ws": "^8.18.0"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/@n8n/config": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-1.54.0.tgz",
-      "integrity": "sha512-ftmh4ca0uF6wV2iQYI425LX2J6wsuiMdbgKMs8gOT8qLn0zVEB8g8/sgGRvjrBfXYVnh/IsyVprtQnw4aha5UQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/di": "0.9.0",
-        "reflect-metadata": "0.2.2",
-        "zod": "3.25.67"
       }
     },
     "node_modules/@n8n/task-runner/node_modules/acorn": {
@@ -12665,202 +12593,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/axios": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
-      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/n8n-core": {
-      "version": "1.110.0",
-      "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-1.110.0.tgz",
-      "integrity": "sha512-NUhjXcSkUUNKvhbb30WYIe/6mZoe9kpwl+b++FRazDtXUfPZlEem6suz/lzBqPkWIk+QnCZBkQX5F6q6ChcdYg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@aws-sdk/client-s3": "3.808.0",
-        "@langchain/core": "0.3.68",
-        "@n8n/backend-common": "^0.21.0",
-        "@n8n/client-oauth2": "0.29.0",
-        "@n8n/config": "1.54.0",
-        "@n8n/constants": "0.12.0",
-        "@n8n/decorators": "0.21.0",
-        "@n8n/di": "0.9.0",
-        "@sentry/node": "^9.42.1",
-        "@sentry/node-native": "^9.42.1",
-        "axios": "1.8.3",
-        "callsites": "3.1.0",
-        "chardet": "2.0.0",
-        "cron": "3.1.7",
-        "fast-glob": "3.2.12",
-        "file-type": "16.5.4",
-        "form-data": "4.0.0",
-        "htmlparser2": "^10.0.0",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "iconv-lite": "0.6.3",
-        "jsonwebtoken": "9.0.2",
-        "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "mime-types": "2.1.35",
-        "n8n-workflow": "1.108.0",
-        "nanoid": "3.3.8",
-        "oauth-1.0a": "2.2.6",
-        "p-cancelable": "2.1.1",
-        "picocolors": "1.0.1",
-        "pretty-bytes": "5.6.0",
-        "proxy-from-env": "^1.1.0",
-        "qs": "6.11.0",
-        "ssh2": "1.15.0",
-        "uuid": "10.0.0",
-        "winston": "3.14.2",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
-      },
-      "bin": {
-        "n8n-copy-static-files": "bin/copy-static-files",
-        "n8n-generate-metadata": "bin/generate-metadata",
-        "n8n-generate-translations": "bin/generate-translations"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/n8n-workflow": {
-      "version": "1.108.0",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-1.108.0.tgz",
-      "integrity": "sha512-e3hSBUr1qTUgZolxHpT8RZmrrixVqum4rKGv7D0BcXRIKYGnsmg3CcrpFpLKxEBZDYFvTFUq68tvuMDoEwH6dg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "^0.5.0",
-        "@n8n/tournament": "1.0.6",
-        "ast-types": "0.15.2",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.0",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.2",
-        "jssha": "3.3.1",
-        "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "license": "ISC"
-    },
-    "node_modules/@n8n/task-runner/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/winston": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
-      "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@n8n/task-runner/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@n8n/tournament": {
@@ -24642,9 +24374,9 @@
       }
     },
     "node_modules/libphonenumber-js": {
-      "version": "1.12.17",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.17.tgz",
-      "integrity": "sha512-bsxi8FoceAYR/bjHcLYc2ShJ/aVAzo5jaxAYiMHF0BD+NTp47405CGuPNKYpw+lHadN9k/ClFGc9X5vaZswIrA==",
+      "version": "1.12.18",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.18.tgz",
+      "integrity": "sha512-k0pdkX8DXHqVrby7yJ23WBcHMCX1lhwvX/Uazh0vf3wfGQa0qDIyRB2Z2C01JREGGt8Assfwl1yZduq59OjXXQ==",
       "license": "MIT"
     },
     "node_modules/libqp": {
@@ -25929,9 +25661,9 @@
       }
     },
     "node_modules/n8n": {
-      "version": "1.111.1",
-      "resolved": "https://registry.npmjs.org/n8n/-/n8n-1.111.1.tgz",
-      "integrity": "sha512-qblldBO08kxyzHAaamAIEgHv93RfWLvLxl2SRmeWzet0/0NZv2tyGk1tPes9fFWllxnp4/2PkAFHaz+nh2NsTg==",
+      "version": "1.112.3",
+      "resolved": "https://registry.npmjs.org/n8n/-/n8n-1.112.3.tgz",
+      "integrity": "sha512-8pbQ1/CBPNIFoT9+JAOHTk4X2F1oQfxYpUMI2H1hUkPvmegGZ3aKzQ+xFKJU323xmh7nVNCxfs00hHrTYDPmZQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "3.808.0",
@@ -25940,27 +25672,27 @@
         "@google-cloud/secret-manager": "5.6.0",
         "@n8n_io/ai-assistant-sdk": "1.15.0",
         "@n8n_io/license-sdk": "2.23.0",
-        "@n8n/ai-workflow-builder": "0.21.0",
-        "@n8n/api-types": "0.45.0",
-        "@n8n/backend-common": "^0.21.0",
-        "@n8n/backend-test-utils": "^0.14.1",
+        "@n8n/ai-workflow-builder": "0.22.0",
+        "@n8n/api-types": "0.46.0",
+        "@n8n/backend-common": "^0.22.0",
+        "@n8n/backend-test-utils": "^0.15.1",
         "@n8n/client-oauth2": "0.29.0",
-        "@n8n/config": "1.54.0",
+        "@n8n/config": "1.55.0",
         "@n8n/constants": "^0.12.0",
-        "@n8n/db": "^0.22.1",
-        "@n8n/decorators": "0.21.0",
+        "@n8n/db": "^0.23.1",
+        "@n8n/decorators": "0.22.0",
         "@n8n/di": "0.9.0",
         "@n8n/errors": "0.5.0",
         "@n8n/localtunnel": "3.0.0",
-        "@n8n/n8n-nodes-langchain": "1.110.0",
-        "@n8n/permissions": "0.34.0",
-        "@n8n/task-runner": "1.47.0",
+        "@n8n/n8n-nodes-langchain": "1.111.1",
+        "@n8n/permissions": "0.35.0",
+        "@n8n/task-runner": "1.48.0",
         "@n8n/typeorm": "0.3.20-12",
         "@parcel/watcher": "^2.5.1",
         "@rudderstack/rudder-sdk-node": "2.1.4",
         "@sentry/node": "^9.42.1",
         "aws4": "1.11.0",
-        "axios": "1.8.3",
+        "axios": "1.12.0",
         "bcryptjs": "2.4.3",
         "bull": "4.16.4",
         "cache-manager": "5.2.3",
@@ -25994,10 +25726,10 @@
         "lodash": "4.17.21",
         "luxon": "3.4.4",
         "mysql2": "3.11.0",
-        "n8n-core": "1.110.0",
-        "n8n-editor-ui": "1.111.0",
-        "n8n-nodes-base": "1.109.0",
-        "n8n-workflow": "1.108.0",
+        "n8n-core": "1.111.0",
+        "n8n-editor-ui": "1.112.1",
+        "n8n-nodes-base": "1.110.1",
+        "n8n-workflow": "1.109.0",
         "nanoid": "3.3.8",
         "nodemailer": "6.9.9",
         "oauth-1.0a": "2.2.6",
@@ -26018,7 +25750,7 @@
         "samlify": "2.10.0",
         "semver": "7.5.4",
         "shelljs": "0.8.5",
-        "simple-git": "3.17.0",
+        "simple-git": "3.28.0",
         "source-map-support": "0.5.21",
         "sqlite3": "5.1.7",
         "sshpk": "1.18.0",
@@ -26090,46 +25822,6 @@
         "n8n-copy-static-files": "bin/copy-static-files",
         "n8n-generate-metadata": "bin/generate-metadata",
         "n8n-generate-translations": "bin/generate-translations"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@n8n/backend-common": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-0.22.0.tgz",
-      "integrity": "sha512-qH9X+NTXTmqtkzdKH+yYEmZZ+FQZB3yuQbLUOesjWGlwLu3YyHSfLutsKk5tds++v1njNE+0qsKl8CX6LdAS/A==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/config": "^1.55.0",
-        "@n8n/constants": "^0.12.0",
-        "@n8n/decorators": "^0.22.0",
-        "@n8n/di": "^0.9.0",
-        "callsites": "3.1.0",
-        "n8n-workflow": "^1.109.0",
-        "picocolors": "1.0.1",
-        "reflect-metadata": "0.2.2",
-        "winston": "3.14.2",
-        "yargs-parser": "21.1.1"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@n8n/decorators": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-0.22.0.tgz",
-      "integrity": "sha512-MgPIdn6RxElzHV/OEw8KsIzQIctdZ6sr3tJvnJ++Z1IhNlTPecYpbmgySEbTrqDFQBsULQLDRVIo4UaLayTD3g==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/constants": "^0.12.0",
-        "@n8n/di": "^0.9.0",
-        "@n8n/permissions": "^0.35.0",
-        "lodash": "4.17.21",
-        "n8n-workflow": "^1.109.0"
-      }
-    },
-    "node_modules/n8n-core/node_modules/@n8n/permissions": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.35.0.tgz",
-      "integrity": "sha512-VSfCdikOH+IbHl4tsYbi/rIoxL1wJUJlu/rguZ3oR8SaoDaa4bbIf9H8o3NhAyiFsWabWRU57ct941kGoxzT6Q==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "zod": "3.25.67"
       }
     },
     "node_modules/n8n-core/node_modules/axios": {
@@ -26269,9 +25961,9 @@
       }
     },
     "node_modules/n8n-editor-ui": {
-      "version": "1.111.0",
-      "resolved": "https://registry.npmjs.org/n8n-editor-ui/-/n8n-editor-ui-1.111.0.tgz",
-      "integrity": "sha512-WqCxLQe5hqTBsUrTvDPcIJMXCSok3QyoVhW5TQdnnUQqk27E7QjUq/YXxRwJBb7u5isc8Z0i0H0klc6Pgxc7IQ==",
+      "version": "1.112.1",
+      "resolved": "https://registry.npmjs.org/n8n-editor-ui/-/n8n-editor-ui-1.112.1.tgz",
+      "integrity": "sha512-+6+PsA2ttwIFMhXjEpNVnidYmK36c6Rl7gxCUFDrgugwEJZIX6JyZ8TKqiU/fOPsjBsbWg/j6LxLqN13OP9rtg==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/n8n-nodes-base": {
@@ -26620,21 +26312,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/n8n-nodes-base/node_modules/simple-git": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
-      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@kwsites/file-exists": "^1.1.1",
-        "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.4.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/steveukx/git-js?sponsor=1"
-      }
-    },
     "node_modules/n8n-workflow": {
       "version": "1.109.0",
       "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-1.109.0.tgz",
@@ -26667,349 +26344,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/n8n/node_modules/@langchain/google-genai": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-0.2.13.tgz",
-      "integrity": "sha512-ReZe4oNUhPNEijYo9CGA3/CJUwVPaaoYnyplZyYTbUNPAwwRH5aR1e6bppKFBb+ZZeTRCR25JFDIPnXJFfjaBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@google/generative-ai": "^0.24.0",
-        "uuid": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@langchain/core": ">=0.3.58 <0.4.0"
-      }
-    },
-    "node_modules/n8n/node_modules/@langchain/google-genai/node_modules/@google/generative-ai": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
-      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/n8n/node_modules/@langchain/google-genai/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/n8n/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.0.tgz",
-      "integrity": "sha512-m//7RlINx1F3sz3KqwY1WWzVgTcYX52HYk4bJ1hkBXV3zccAEth+jRvG8DBRrdaQuRsPAJOx2MH3zaHNCKL7Zg==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.6",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/config": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-1.54.0.tgz",
-      "integrity": "sha512-ftmh4ca0uF6wV2iQYI425LX2J6wsuiMdbgKMs8gOT8qLn0zVEB8g8/sgGRvjrBfXYVnh/IsyVprtQnw4aha5UQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/di": "0.9.0",
-        "reflect-metadata": "0.2.2",
-        "zod": "3.25.67"
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain": {
-      "version": "1.110.0",
-      "resolved": "https://registry.npmjs.org/@n8n/n8n-nodes-langchain/-/n8n-nodes-langchain-1.110.0.tgz",
-      "integrity": "sha512-eRWXNWwdCZ2yOvBGgIrFshiYpDk/Fl26/xrIwUpWDgFQbuRfh9/FffsWeZ6MfRSZnikoZmPrDqpagfWkzn5Iyw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.808.0",
-        "@azure/identity": "4.3.0",
-        "@getzep/zep-cloud": "1.0.12",
-        "@getzep/zep-js": "0.9.0",
-        "@google-ai/generativelanguage": "2.6.0",
-        "@google-cloud/resource-manager": "5.3.0",
-        "@google/generative-ai": "0.21.0",
-        "@huggingface/inference": "4.0.5",
-        "@langchain/anthropic": "0.3.26",
-        "@langchain/aws": "0.1.11",
-        "@langchain/cohere": "0.3.4",
-        "@langchain/community": "0.3.50",
-        "@langchain/core": "0.3.68",
-        "@langchain/google-genai": "0.2.13",
-        "@langchain/google-vertexai": "0.2.13",
-        "@langchain/groq": "0.2.3",
-        "@langchain/mistralai": "0.2.1",
-        "@langchain/mongodb": "^0.1.0",
-        "@langchain/ollama": "0.2.3",
-        "@langchain/openai": "0.6.7",
-        "@langchain/pinecone": "0.2.0",
-        "@langchain/qdrant": "0.1.2",
-        "@langchain/redis": "0.1.1",
-        "@langchain/textsplitters": "0.1.0",
-        "@langchain/weaviate": "0.2.0",
-        "@modelcontextprotocol/sdk": "1.12.0",
-        "@mozilla/readability": "0.6.0",
-        "@n8n/client-oauth2": "0.29.0",
-        "@n8n/errors": "^0.5.0",
-        "@n8n/json-schema-to-zod": "1.5.0",
-        "@n8n/typeorm": "0.3.20-12",
-        "@n8n/typescript-config": "1.3.0",
-        "@n8n/vm2": "3.9.25",
-        "@pinecone-database/pinecone": "^5.0.2",
-        "@qdrant/js-client-rest": "1.14.1",
-        "@supabase/supabase-js": "2.49.9",
-        "@xata.io/client": "0.28.4",
-        "@zilliz/milvus2-sdk-node": "^2.5.7",
-        "basic-auth": "2.0.1",
-        "cheerio": "1.0.0",
-        "cohere-ai": "7.14.0",
-        "d3-dsv": "2.0.0",
-        "epub2": "3.0.2",
-        "form-data": "4.0.0",
-        "generate-schema": "2.6.0",
-        "html-to-text": "9.0.5",
-        "https-proxy-agent": "7.0.6",
-        "ignore": "^5.2.0",
-        "js-tiktoken": "^1.0.12",
-        "jsdom": "23.0.1",
-        "langchain": "0.3.30",
-        "lodash": "4.17.21",
-        "mammoth": "1.7.2",
-        "mime-types": "2.1.35",
-        "mongodb": "6.11.0",
-        "n8n-nodes-base": "1.109.0",
-        "n8n-workflow": "1.108.0",
-        "openai": "5.12.2",
-        "pdf-parse": "1.1.1",
-        "pg": "8.12.0",
-        "proxy-from-env": "^1.1.0",
-        "redis": "4.6.12",
-        "sanitize-html": "2.12.1",
-        "sqlite3": "5.1.7",
-        "temp": "0.9.4",
-        "tmp-promise": "3.0.3",
-        "undici": "^6.21.0",
-        "weaviate-client": "3.6.2",
-        "zod": "3.25.67",
-        "zod-to-json-schema": "3.23.3"
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain/node_modules/langchain": {
-      "version": "0.3.30",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.30.tgz",
-      "integrity": "sha512-UyVsfwHDpHbrnWrjWuhJHqi8Non+Zcsf2kdpDTqyJF8NXrHBOpjdHT5LvPuW9fnE7miDTWf5mLcrWAGZgcrznQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@langchain/openai": ">=0.1.0 <0.7.0",
-        "@langchain/textsplitters": ">=0.0.0 <0.2.0",
-        "js-tiktoken": "^1.0.12",
-        "js-yaml": "^4.1.0",
-        "jsonpointer": "^5.0.1",
-        "langsmith": "^0.3.33",
-        "openapi-types": "^12.1.3",
-        "p-retry": "4",
-        "uuid": "^10.0.0",
-        "yaml": "^2.2.1",
-        "zod": "^3.25.32"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@langchain/anthropic": "*",
-        "@langchain/aws": "*",
-        "@langchain/cerebras": "*",
-        "@langchain/cohere": "*",
-        "@langchain/core": ">=0.3.58 <0.4.0",
-        "@langchain/deepseek": "*",
-        "@langchain/google-genai": "*",
-        "@langchain/google-vertexai": "*",
-        "@langchain/google-vertexai-web": "*",
-        "@langchain/groq": "*",
-        "@langchain/mistralai": "*",
-        "@langchain/ollama": "*",
-        "@langchain/xai": "*",
-        "axios": "*",
-        "cheerio": "*",
-        "handlebars": "^4.7.8",
-        "peggy": "^3.0.2",
-        "typeorm": "*"
-      },
-      "peerDependenciesMeta": {
-        "@langchain/anthropic": {
-          "optional": true
-        },
-        "@langchain/aws": {
-          "optional": true
-        },
-        "@langchain/cerebras": {
-          "optional": true
-        },
-        "@langchain/cohere": {
-          "optional": true
-        },
-        "@langchain/deepseek": {
-          "optional": true
-        },
-        "@langchain/google-genai": {
-          "optional": true
-        },
-        "@langchain/google-vertexai": {
-          "optional": true
-        },
-        "@langchain/google-vertexai-web": {
-          "optional": true
-        },
-        "@langchain/groq": {
-          "optional": true
-        },
-        "@langchain/mistralai": {
-          "optional": true
-        },
-        "@langchain/ollama": {
-          "optional": true
-        },
-        "@langchain/xai": {
-          "optional": true
-        },
-        "axios": {
-          "optional": true
-        },
-        "cheerio": {
-          "optional": true
-        },
-        "handlebars": {
-          "optional": true
-        },
-        "peggy": {
-          "optional": true
-        },
-        "typeorm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain/node_modules/mongodb": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.11.0.tgz",
-      "integrity": "sha512-yVbPw0qT268YKhG241vAMLaDQAPbRyTgo++odSgGc9kXnzOujQI60Iyj23B9sQQFPSvmNPvMZ3dsFz0aN55KgA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.0",
-        "mongodb-connection-string-url": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain/node_modules/openai": {
-      "version": "5.12.2",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
-      "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/n8n/node_modules/@n8n/n8n-nodes-langchain/node_modules/zod-to-json-schema": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
-      "integrity": "sha512-TYWChTxKQbRJp5ST22o/Irt9KC5nj7CdBKYB/AosCRdj/wxEMvv4NNaj9XVUHDOIp53ZxArGhnw5HMZziPFjog==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.23.3"
       }
     },
     "node_modules/n8n/node_modules/@n8n/typeorm": {
@@ -27153,38 +26487,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/n8n/node_modules/@qdrant/js-client-rest": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.14.1.tgz",
-      "integrity": "sha512-CkCCTDc4gCXq+hhjB3yDw9Hs/PxCJ0bKqk/LjAAmuL9+nDm/RPue4C/tGOIMlzouTQ2l6J6t+JPeM//j38VFug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@qdrant/openapi-typescript-fetch": "1.2.6",
-        "@sevinf/maybe": "0.5.0",
-        "undici": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=18.17.0",
-        "pnpm": ">=8"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.7"
-      }
-    },
-    "node_modules/n8n/node_modules/@redis/client": {
-      "version": "1.5.16",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.16.tgz",
-      "integrity": "sha512-X1a3xQ5kEMvTib5fBrHKh6Y+pXbeKXqziYuxOUo1ojQNECg4M5Etd1qqyhMap+lFUOAh8S7UYevgJHOm4A+NOg==",
-      "license": "MIT",
-      "dependencies": {
-        "cluster-key-slot": "1.1.2",
-        "generic-pool": "3.9.0",
-        "yallist": "4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/n8n/node_modules/@types/whatwg-url": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
@@ -27198,13 +26500,13 @@
       }
     },
     "node_modules/n8n/node_modules/axios": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
-      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+      "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -27221,132 +26523,15 @@
         "prebuild-install": "^7.1.1"
       }
     },
-    "node_modules/n8n/node_modules/cheerio-select": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
-      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "css-select": "^4.3.0",
-        "css-what": "^6.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/n8n/node_modules/cheerio-select/node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
+    "node_modules/n8n/node_modules/bson": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/cheerio-select/node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/n8n/node_modules/css-select/node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/css-select/node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/dom-serializer/node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+        "node": ">=14.20.1"
       }
     },
     "node_modules/n8n/node_modules/dotenv": {
@@ -27356,18 +26541,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/n8n/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/n8n/node_modules/express-rate-limit": {
@@ -27385,17 +26558,27 @@
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
-    "node_modules/n8n/node_modules/fflate": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
-      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
-      "license": "MIT"
-    },
     "node_modules/n8n/node_modules/flatted": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "license": "ISC"
+    },
+    "node_modules/n8n/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/n8n/node_modules/glob": {
       "version": "10.4.5",
@@ -27415,25 +26598,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/n8n/node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
       }
     },
     "node_modules/n8n/node_modules/iconv-lite": {
@@ -27527,18 +26691,7 @@
         }
       }
     },
-    "node_modules/n8n/node_modules/mongodb/node_modules/bson": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
-      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14.20.1"
-      }
-    },
-    "node_modules/n8n/node_modules/mongodb/node_modules/mongodb-connection-string-url": {
+    "node_modules/n8n/node_modules/mongodb-connection-string-url": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
       "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
@@ -27548,308 +26701,6 @@
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-core": {
-      "version": "1.110.0",
-      "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-1.110.0.tgz",
-      "integrity": "sha512-NUhjXcSkUUNKvhbb30WYIe/6mZoe9kpwl+b++FRazDtXUfPZlEem6suz/lzBqPkWIk+QnCZBkQX5F6q6ChcdYg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@aws-sdk/client-s3": "3.808.0",
-        "@langchain/core": "0.3.68",
-        "@n8n/backend-common": "^0.21.0",
-        "@n8n/client-oauth2": "0.29.0",
-        "@n8n/config": "1.54.0",
-        "@n8n/constants": "0.12.0",
-        "@n8n/decorators": "0.21.0",
-        "@n8n/di": "0.9.0",
-        "@sentry/node": "^9.42.1",
-        "@sentry/node-native": "^9.42.1",
-        "axios": "1.8.3",
-        "callsites": "3.1.0",
-        "chardet": "2.0.0",
-        "cron": "3.1.7",
-        "fast-glob": "3.2.12",
-        "file-type": "16.5.4",
-        "form-data": "4.0.0",
-        "htmlparser2": "^10.0.0",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "iconv-lite": "0.6.3",
-        "jsonwebtoken": "9.0.2",
-        "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "mime-types": "2.1.35",
-        "n8n-workflow": "1.108.0",
-        "nanoid": "3.3.8",
-        "oauth-1.0a": "2.2.6",
-        "p-cancelable": "2.1.1",
-        "picocolors": "1.0.1",
-        "pretty-bytes": "5.6.0",
-        "proxy-from-env": "^1.1.0",
-        "qs": "6.11.0",
-        "ssh2": "1.15.0",
-        "uuid": "10.0.0",
-        "winston": "3.14.2",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
-      },
-      "bin": {
-        "n8n-copy-static-files": "bin/copy-static-files",
-        "n8n-generate-metadata": "bin/generate-metadata",
-        "n8n-generate-translations": "bin/generate-translations"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base": {
-      "version": "1.109.0",
-      "resolved": "https://registry.npmjs.org/n8n-nodes-base/-/n8n-nodes-base-1.109.0.tgz",
-      "integrity": "sha512-72va2U8r4MZUyxnLnKifS4MeiUNqBZXqrSR0vW4Gm+itOwFq3kp0fNVhw2iq4r/npqilmO3rPkfguk5EA338tg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.808.0",
-        "@kafkajs/confluent-schema-registry": "3.8.0",
-        "@mozilla/readability": "0.6.0",
-        "@n8n/config": "1.54.0",
-        "@n8n/di": "0.9.0",
-        "@n8n/errors": "^0.5.0",
-        "@n8n/imap": "0.15.0",
-        "@n8n/vm2": "3.9.25",
-        "alasql": "4.4.0",
-        "amqplib": "0.10.6",
-        "aws4": "1.11.0",
-        "basic-auth": "2.0.1",
-        "change-case": "4.1.2",
-        "cheerio": "1.0.0-rc.6",
-        "chokidar": "4.0.3",
-        "cron": "3.1.7",
-        "csv-parse": "5.5.0",
-        "currency-codes": "2.1.0",
-        "eventsource": "2.0.2",
-        "fast-glob": "3.2.12",
-        "fastest-levenshtein": "^1.0.16",
-        "fflate": "0.7.4",
-        "generate-schema": "2.6.0",
-        "get-system-fonts": "2.0.2",
-        "gm": "1.25.1",
-        "html-to-text": "9.0.5",
-        "iconv-lite": "0.6.3",
-        "ics": "2.40.0",
-        "isbot": "3.6.13",
-        "iso-639-1": "2.1.15",
-        "js-nacl": "1.4.0",
-        "jsdom": "23.0.1",
-        "jsonwebtoken": "9.0.2",
-        "kafkajs": "2.2.4",
-        "ldapts": "4.2.6",
-        "lodash": "4.17.21",
-        "lossless-json": "1.0.5",
-        "luxon": "3.4.4",
-        "mailparser": "3.6.7",
-        "minifaker": "1.34.1",
-        "moment-timezone": "0.5.48",
-        "mongodb": "6.11.0",
-        "mqtt": "5.7.2",
-        "mssql": "10.0.2",
-        "mysql2": "3.11.0",
-        "n8n-workflow": "1.108.0",
-        "node-html-markdown": "1.2.0",
-        "node-ssh": "13.2.0",
-        "nodemailer": "6.9.9",
-        "otpauth": "9.1.1",
-        "pdfjs-dist": "5.3.31",
-        "pg": "8.12.0",
-        "pg-promise": "11.9.1",
-        "promise-ftp": "1.3.5",
-        "pyodide": "0.28.0",
-        "redis": "4.6.14",
-        "rfc2047": "4.0.1",
-        "rhea": "3.0.4",
-        "rrule": "2.8.1",
-        "rss-parser": "3.13.0",
-        "sanitize-html": "2.12.1",
-        "semver": "7.5.4",
-        "showdown": "2.1.0",
-        "simple-git": "3.17.0",
-        "snowflake-sdk": "2.1.0",
-        "ssh2-sftp-client": "12.0.1",
-        "tmp-promise": "3.0.3",
-        "ts-ics": "1.2.2",
-        "uuid": "10.0.0",
-        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
-        "xml2js": "0.6.2",
-        "xmlhttprequest-ssl": "3.1.0"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/cheerio": {
-      "version": "1.0.0-rc.6",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.6.tgz",
-      "integrity": "sha512-hjx1XE1M/D5pAtMgvWwE21QClmAEeGHOIDfycgmndisdNgI6PE1cGRQkMGBcsbUbmEQyWu5PJLUcAOjtQS8DWw==",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^1.3.0",
-        "dom-serializer": "^1.3.1",
-        "domhandler": "^4.1.0",
-        "htmlparser2": "^6.1.0",
-        "parse5": "^6.0.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/eventsource": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
-      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/mongodb": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.11.0.tgz",
-      "integrity": "sha512-yVbPw0qT268YKhG241vAMLaDQAPbRyTgo++odSgGc9kXnzOujQI60Iyj23B9sQQFPSvmNPvMZ3dsFz0aN55KgA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.0",
-        "mongodb-connection-string-url": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        },
-        "socks": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-nodes-base/node_modules/redis": {
-      "version": "4.6.14",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-4.6.14.tgz",
-      "integrity": "sha512-GrNg/e33HtsQwNXL7kJT+iNFPSwE1IPmd7wzV3j4f2z0EYxZfZE7FVTmUysgAtqQQtg5NXF5SNLR9OdO/UHOfw==",
-      "license": "MIT",
-      "workspaces": [
-        "./packages/*"
-      ],
-      "dependencies": {
-        "@redis/bloom": "1.2.0",
-        "@redis/client": "1.5.16",
-        "@redis/graph": "1.1.1",
-        "@redis/json": "1.0.6",
-        "@redis/search": "1.1.6",
-        "@redis/time-series": "1.0.5"
-      }
-    },
-    "node_modules/n8n/node_modules/n8n-workflow": {
-      "version": "1.108.0",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-1.108.0.tgz",
-      "integrity": "sha512-e3hSBUr1qTUgZolxHpT8RZmrrixVqum4rKGv7D0BcXRIKYGnsmg3CcrpFpLKxEBZDYFvTFUq68tvuMDoEwH6dg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@n8n/errors": "^0.5.0",
-        "@n8n/tournament": "1.0.6",
-        "ast-types": "0.15.2",
-        "callsites": "3.1.0",
-        "esprima-next": "5.8.4",
-        "form-data": "4.0.0",
-        "jmespath": "0.16.0",
-        "js-base64": "3.7.2",
-        "jssha": "3.3.1",
-        "lodash": "4.17.21",
-        "luxon": "3.4.4",
-        "md5": "2.3.0",
-        "recast": "0.22.0",
-        "title-case": "3.0.3",
-        "transliteration": "2.3.5",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
       }
     },
     "node_modules/n8n/node_modules/open": {
@@ -27866,21 +26717,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/n8n/node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "license": "MIT"
-    },
-    "node_modules/n8n/node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^6.0.1"
       }
     },
     "node_modules/n8n/node_modules/path-scurry": {
@@ -27905,21 +26741,6 @@
       "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "license": "ISC"
     },
-    "node_modules/n8n/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/n8n/node_modules/raw-body": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
@@ -27933,20 +26754,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/n8n/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/n8n/node_modules/semver": {
@@ -28003,28 +26810,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/n8n/node_modules/winston": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.14.2.tgz",
-      "integrity": "sha512-CO8cdpBB2yqzEf8v895L+GNKYJiEq8eKlHU38af3snQBQ+sdAIUepjMSguOIJC7ICbzm0ZI+Af2If4vIJrtmOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/n8n/node_modules/ws": {
@@ -31513,14 +30298,14 @@
       }
     },
     "node_modules/simple-git": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.17.0.tgz",
-      "integrity": "sha512-JozI/s8jr3nvLd9yn2jzPVHnhVzt7t7QWfcIoDcqRIGN+f1IINGv52xoZti2kkYfoRhhRvzMSNPfogHMp97rlw==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
+      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.4"
+        "debug": "^4.4.0"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "bin": {
@@ -128,13 +128,13 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.2",
-    "@n8n/n8n-nodes-langchain": "^1.110.0",
+    "@n8n/n8n-nodes-langchain": "^1.111.1",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "lru-cache": "^11.2.1",
-    "n8n": "^1.111.0",
-    "n8n-core": "^1.110.0",
-    "n8n-workflow": "^1.108.0",
+    "n8n": "^1.112.3",
+    "n8n-core": "^1.111.0",
+    "n8n-workflow": "^1.109.0",
     "openai": "^4.77.0",
     "sql.js": "^1.13.0",
     "uuid": "^10.0.0",


### PR DESCRIPTION
## Summary
Updates n8n and related packages to their latest versions for compatibility and bug fixes.

## Changes
### Dependency Updates
- **n8n**: `1.111.0` → `1.112.3`
- **n8n-core**: `1.110.0` → `1.111.0`
- **n8n-workflow**: `1.108.0` → `1.109.0`
- **@n8n/n8n-nodes-langchain**: `1.110.0` → `1.111.1`

### Database Update
- Rebuilt node database with **536 nodes**:
  - 438 from n8n-nodes-base
  - 98 from @n8n/n8n-nodes-langchain
- All 2,598 workflow templates preserved intact

### Version Bump
- Package version: `2.12.1` → `2.12.2`
- Updated README badges to reflect n8n v1.112.3 compatibility

## Testing
- ✅ Unit tests passing
- ✅ Integration tests passing
- ✅ Critical nodes validated (httpRequest, slack, code)
- ✅ Database integrity verified
- ✅ Templates preserved (100% with workflow data, 97.5% with metadata)

## Type of Change
- [ ] Bug fix
- [x] Dependency update
- [ ] New feature
- [ ] Breaking change

🤖 Generated with [Claude Code](https://claude.ai/code)