### PR TITLE
refactor(integration): Update Phase 2 tests to use MCP handlers

### DIFF
--- a/tests/integration/n8n-api/utils/fixtures.ts
+++ b/tests/integration/n8n-api/utils/fixtures.ts
@@ -222,6 +222,7 @@ export const ERROR_HANDLING_WORKFLOW: Partial<Workflow> = {
       main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]]
     },
     'HTTP Request': {
+      main: [[{ node: 'Handle Error', type: 'main', index: 0 }]],
       error: [[{ node: 'Handle Error', type: 'main', index: 0 }]]
     }
   },

--- a/tests/integration/n8n-api/utils/mcp-context.ts
+++ b/tests/integration/n8n-api/utils/mcp-context.ts
@@ -1,0 +1,14 @@
+import { InstanceContext } from '../../../../src/types/instance-context';
+import { getN8nCredentials } from './credentials';
+
+/**
+ * Creates MCP context for testing MCP handlers against real n8n instance
+ * This is what gets passed to MCP handlers (handleCreateWorkflow, etc.)
+ */
+export function createMcpContext(): InstanceContext {
+  const creds = getN8nCredentials();
+  return {
+    n8nApiUrl: creds.url,
+    n8nApiKey: creds.apiKey
+  };
+}

--- a/tests/integration/n8n-api/workflows/create-workflow.test.ts
+++ b/tests/integration/n8n-api/workflows/create-workflow.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
 import { createTestContext, TestContext, createTestWorkflowName } from '../utils/test-context';
 import { getTestN8nClient } from '../utils/n8n-client';
 import { N8nApiClient } from '../../../../src/services/n8n-api-client';
+import { Workflow } from '../../../../src/types/n8n-api';
 import {
   SIMPLE_WEBHOOK_WORKFLOW,
   SIMPLE_HTTP_WORKFLOW,
@@ -70,7 +71,7 @@ describe('Integration: handleCreateWorkflow', () => {
       // Create workflow using MCP handler
       const response = await handleCreateWorkflow({ ...workflow }, mcpContext);
       expect(response.success).toBe(true);
-      const result = response.data;
+      const result = response.data as Workflow;
 
       // Verify workflow created successfully
       expect(result).toBeDefined();
@@ -101,7 +102,7 @@ describe('Integration: handleCreateWorkflow', () => {
 
       const response = await handleCreateWorkflow({ ...workflow }, mcpContext);
       expect(response.success).toBe(true);
-      const result = response.data;
+      const result = response.data as Workflow;
 
       expect(result).toBeDefined();
       expect(result.id).toBeTruthy();
@@ -111,8 +112,8 @@ describe('Integration: handleCreateWorkflow', () => {
       expect(result.nodes).toHaveLength(2);
 
       // Verify both nodes created with FULL type format
-      const webhookNode = result.nodes.find(n => n.name === 'Webhook');
-      const httpNode = result.nodes.find(n => n.name === 'HTTP Request');
+      const webhookNode = result.nodes.find((n: any) => n.name === 'Webhook');
+      const httpNode = result.nodes.find((n: any) => n.name === 'HTTP Request');
 
       expect(webhookNode).toBeDefined();
       expect(webhookNode!.type).toBe('n8n-nodes-base.webhook');
@@ -134,7 +135,7 @@ describe('Integration: handleCreateWorkflow', () => {
 
       const response = await handleCreateWorkflow({ ...workflow }, mcpContext);
       expect(response.success).toBe(true);
-      const result = response.data;
+      const result = response.data as Workflow;
 
       expect(result).toBeDefined();
       expect(result.id).toBeTruthy();
@@ -144,7 +145,7 @@ describe('Integration: handleCreateWorkflow', () => {
       expect(result.nodes).toHaveLength(2);
 
       // Verify langchain node type format
-      const agentNode = result.nodes.find(n => n.name === 'AI Agent');
+      const agentNode = result.nodes.find((n: any) => n.name === 'AI Agent');
       expect(agentNode).toBeDefined();
       expect(agentNode!.type).toBe('@n8n/n8n-nodes-langchain.agent');
     });
@@ -158,7 +159,7 @@ describe('Integration: handleCreateWorkflow', () => {
 
       const response = await handleCreateWorkflow({ ...workflow }, mcpContext);
       expect(response.success).toBe(true);
-      const result = response.data;
+      const result = response.data as Workflow;
 
       expect(result).toBeDefined();
       expect(result.id).toBeTruthy();
@@ -168,7 +169,7 @@ describe('Integration: handleCreateWorkflow', () => {
       expect(result.nodes).toHaveLength(4);
 
       // Verify all node types preserved
-      const nodeTypes = result.nodes.map(n => n.type);
+      const nodeTypes = result.nodes.map((n: any) => n.type);
       expect(nodeTypes).toContain('n8n-nodes-base.webhook');
       expect(nodeTypes).toContain('n8n-nodes-base.set');
       expect(nodeTypes).toContain('n8n-nodes-base.merge');
@@ -192,7 +193,7 @@ describe('Integration: handleCreateWorkflow', () => {
 
       const response = await handleCreateWorkflow({ ...workflow }, mcpContext);
       expect(response.success).toBe(true);
-      const result = response.data;
+      const result = response.data as Workflow;
 
       expect(result).toBeDefined();
       expect(result.id).toBeTruthy();
@@ -231,7 +232,7 @@ describe('Integration: handleCreateWorkflow', () => {
 
       const response = await handleCreateWorkflow({ ...workflow }, mcpContext);
       expect(response.success).toBe(true);
-      const result = response.data;
+      const result = response.data as Workflow;
 
       expect(result).toBeDefined();
       expect(result.id).toBeTruthy();
@@ -250,7 +251,7 @@ describe('Integration: handleCreateWorkflow', () => {
 
       const response = await handleCreateWorkflow({ ...workflow }, mcpContext);
       expect(response.success).toBe(true);
-      const result = response.data;
+      const result = response.data as Workflow;
 
       expect(result).toBeDefined();
       expect(result.id).toBeTruthy();
@@ -259,7 +260,7 @@ describe('Integration: handleCreateWorkflow', () => {
       expect(result.nodes).toHaveLength(2);
 
       // Verify Set node with expressions
-      const setNode = result.nodes.find(n => n.name === 'Set Variables');
+      const setNode = result.nodes.find((n: any) => n.name === 'Set Variables');
       expect(setNode).toBeDefined();
       expect(setNode!.parameters.assignments).toBeDefined();
 
@@ -280,7 +281,7 @@ describe('Integration: handleCreateWorkflow', () => {
 
       const response = await handleCreateWorkflow({ ...workflow }, mcpContext);
       expect(response.success).toBe(true);
-      const result = response.data;
+      const result = response.data as Workflow;
 
       expect(result).toBeDefined();
       expect(result.id).toBeTruthy();
@@ -289,7 +290,7 @@ describe('Integration: handleCreateWorkflow', () => {
       expect(result.nodes).toHaveLength(3);
 
       // Verify HTTP node with error handling
-      const httpNode = result.nodes.find(n => n.name === 'HTTP Request');
+      const httpNode = result.nodes.find((n: any) => n.name === 'HTTP Request');
       expect(httpNode).toBeDefined();
       expect(httpNode!.continueOnFail).toBe(true);
       expect(httpNode!.onError).toBe('continueErrorOutput');


### PR DESCRIPTION
## Summary

**Critical Refactor**: Phase 2 integration tests now properly test the **MCP handler layer** (the actual product AI assistants interact with) instead of the raw n8n API client.

## Changes

### Core Updates
- ✅ All 15 tests now use `handleCreateWorkflow()` MCP handler
- ✅ Tests validate `McpToolResponse` structure (`success`, `data`, `error`)
- ✅ Created `mcp-context.ts` helper for configuring InstanceContext
- ✅ Fixed ERROR_HANDLING_WORKFLOW fixture (added main connection for MCP validation)

### Test Behavior Changes
- **Valid workflows (8 tests)**: Expect `success: true`
- **Invalid workflows (7 tests)**: Expect `success: false` with validation errors

### Documentation
- Updated error scenario tests to document that MCP validation is CORRECT behavior
- Edge case tests now reflect MCP handler's proper pre-validation
- Test comments explain why MCP handler catches errors early (vs raw API)

## Why This Matters

**Architecture**:
```
AI Assistant (Claude)
      ↓
  MCP Tools (What AI sees)
      ↓
  MCP Handlers (What we test) ← INTEGRATION TESTS TARGET THIS LAYER
      ↓
  N8nApiClient (Low-level HTTP)
      ↓
  n8n REST API
```

- MCP handlers wrap API responses in standardized format
- MCP handlers do pre-validation (catch errors before sending to n8n)
- Testing raw API client bypasses the product layer

## Test Results

✅ All 15 scenarios passing:
- 8 valid workflow creation tests
- 4 error scenario validation tests
- 3 edge case validation tests

## Related

- Addresses feedback from Phase 3 review
- Follows pattern established in Phase 3 (PR #257)
- Prerequisite for future phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)