### PR TITLE
security: improve path validation and git command safety

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.18.6",
+  "version": "2.18.7",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "bin": {

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.18.1",
+  "version": "2.18.7",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Enhance input validation for documentation fetcher constructor and replace shell command execution with safer alternatives using argument arrays.

Changes:
- Add comprehensive path validation with sanitization
- Replace execSync with spawnSync using argument arrays
- Add HTTPS-only validation for repository URLs
- Extend security test coverage

Version: 2.18.6 → 2.18.7

Thanks to @ErbaZZ for responsible disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)