### PR TITLE
chore: bump version to 2.19.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.18.11] - 2025-10-14
+## [2.19.6] - 2025-10-14
 
 ### 📦 Dependency Updates
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.18.11",
+  "version": "2.19.6",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.18.11",
+  "version": "2.19.6",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary

Bump version from 2.18.11 to 2.19.6 to resolve automated release workflow failure.

## Issue

The previous version 2.18.11 was lower than the npm registry version (2.19.5), causing the automated release workflow to fail.

## Changes

- Updated `package.json` version: 2.18.11 → 2.19.6
- Updated `package.runtime.json` version: 2.18.11 → 2.19.6
- Updated `CHANGELOG.md` version number to 2.19.6

## Why 2.19.6?

Previous versions 2.19.0-2.19.5 were published to npm but later rolled back in the repository. To maintain proper version progression and allow automated releases to work, we need to bump to a version higher than what's currently on npm.

🤖 Generated with [Claude Code](https://claude.ai/code)