### PR TITLE
fix: add structuredContent to HTTP wrapper for validation tools

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -404,16 +404,25 @@ export async function startFixedHTTPServer() {
               
               try {
                 const result = await mcpServer.executeTool(toolName, toolArgs);
+                
+                // Build MCP-compliant response with structuredContent for validation tools
+                const mcpResult: any = {
+                  content: [
+                    {
+                      type: 'text',
+                      text: JSON.stringify(result, null, 2)
+                    }
+                  ]
+                };
+                
+                // Add structuredContent for validation tools (they have outputSchema)
+                if (toolName.startsWith('validate_')) {
+                  mcpResult.structuredContent = result;
+                }
+                
                 response = {
                   jsonrpc: '2.0',
-                  result: {
-                    content: [
-                      {
-                        type: 'text',
-                        text: JSON.stringify(result, null, 2)
-                      }
-                    ]
-                  },
+                  result: mcpResult,
                   id: jsonRpcRequest.id
                 };
               } catch (error) {


### PR DESCRIPTION
# 🐛 MCP error -32600 for validation tools via HTTP transport

## 📋 Summary

When using validation tools (`validate_node_minimal`, `validate_node_operation`, `validate_workflow`) via HTTP transport with the `n8n-nodes-mcp` community node, the MCP client throws error `-32600`.

**Error message:**
```
MCP error -32600: Tool validate_node_minimal has an output schema but did not return structured content
```

This error **does NOT occur** when:
- ✅ Using STDIO transport
- ✅ Calling the HTTP endpoint directly with `curl`
- ✅ Using tools without `outputSchema` (e.g., `search_nodes`, `get_node_essentials`)

---

## 🧪 How to Reproduce

**Environment:**
- n8n-mcp: v2.20.2 (Docker: `ghcr.io/czlonkowski/n8n-mcp:latest`)
- n8n: v1.115.3
- Transport: HTTP Streamable (`http://n8n-mcp:3000/mcp`)
- Client: `n8n-nodes-mcp` community node in n8n UI

**Steps:**
1. Install `n8n-nodes-mcp` community node in n8n
2. Configure MCP Client with HTTP Streamable transport
3. Use operation "Call Tool" with `validate_node_minimal`:
   ```json
   {
     "nodeType": "n8n-nodes-base.if",
     "config": {}
   }
   ```
4. Execute workflow

**Expected:** Returns validation response with `structuredContent`

**Actual:** Error `-32600` thrown by MCP client

---

## 🔬 Root Cause

The **HTTP wrapper** (`src/http-server.ts`) calls `mcpServer.executeTool()` but only returns the result in `content.text`, **failing to include the `structuredContent` field** required by MCP protocol for tools with `outputSchema`.

The **STDIO server** (`src/mcp/server.ts`) correctly generates `structuredContent` for validation tools (lines 496-537), but the HTTP wrapper doesn't replicate this behavior.

### Code comparison:

**STDIO server (✅ correct):**
```typescript
// Lines 496-537 in src/mcp/server.ts
if (name.startsWith('validate_') && structuredContent !== null) {
  mcpResponse.structuredContent = structuredContent; // ✅ Added
}
```

**HTTP wrapper (❌ missing):**
```typescript
// Lines 406-418 in src/http-server.ts
response = {
  jsonrpc: '2.0',
  result: {
    content: [
      {
        type: 'text',
        text: JSON.stringify(result, null, 2)  // ❌ No structuredContent
      }
    ]
  },
  id: jsonRpcRequest.id
};
```

---

## ✅ Proposed Fix

Modify `src/http-server.ts` (lines 406-418) to include `structuredContent` for validation tools:

```typescript
const result = await mcpServer.executeTool(toolName, toolArgs);

// Build MCP-compliant response with structuredContent for validation tools
const mcpResult: any = {
  content: [
    {
      type: 'text',
      text: JSON.stringify(result, null, 2)
    }
  ]
};

// Add structuredContent for validation tools (they have outputSchema)
if (toolName.startsWith('validate_')) {
  mcpResult.structuredContent = result;
}

response = {
  jsonrpc: '2.0',
  result: mcpResult,
  id: jsonRpcRequest.id
};
```

---

## ✅ Verification

Tested locally after applying the fix:

| Tool | Status | Result |
|------|--------|--------|
| `validate_node_minimal` | ✅ | `structuredContent` present, no error |
| `validate_node_operation` | ✅ | Full validation works |
| `validate_workflow` | ✅ | Workflow validation works |
| `search_nodes` | ✅ | Still works (no regression) |
| `get_node_essentials` | ✅ | Still works (no regression) |
| `list_ai_tools` | ✅ | Returns 270 AI nodes |
| `n8n_health_check` | ✅ | API connected (316ms) |

All 7 tools tested successfully via HTTP transport with n8n-nodes-mcp community node.

---

## 📦 Affected Tools

All validation tools with `outputSchema`:
- `validate_node_minimal`
- `validate_node_operation`
- `validate_workflow`
- `validate_workflow_connections`
- `validate_workflow_expressions`

---

## 🔧 Current Workaround

Users can:
1. Use **STDIO transport** instead of HTTP (no bug there)
2. Build locally with the fix applied

---

## 💡 Additional Notes

- This bug only affects **HTTP transport** (STDIO works correctly)
- The fix is **minimal** (5 lines of code) and aligns HTTP behavior with STDIO
- No breaking changes or API modifications required
- All existing functionality preserved

---

**Tested on:** n8n-mcp v2.20.2, n8n v1.115.3, Linux (Docker)

