### PR TITLE
fix: resolve YAML syntax error in release.yml workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,8 +142,9 @@ jobs:
           if [ -z "$PREVIOUS_TAG" ]; then
             echo "ℹ️ No previous tag found, this might be the first release"
 
-            # Get all commits up to current commit
-            NOTES="### 🎉 Initial Release
+            # Get all commits up to current commit - use heredoc for multiline
+            NOTES=$(cat <<EOF
+### 🎉 Initial Release
 
 This is the initial release of n8n-mcp v$CURRENT_VERSION.
 
@@ -151,7 +152,9 @@ This is the initial release of n8n-mcp v$CURRENT_VERSION.
 
 **Release Statistics:**
 - Commit count: $(git rev-list --count HEAD)
-- First release setup"
+- First release setup
+EOF
+)
 
             echo "has-notes=true" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Fixes YAML syntax error in .github/workflows/release.yml that was blocking CI on main branch.

**CI Error:** You have an error in your yaml syntax on line 148
**Failing Run:** https://github.com/czlonkowski/n8n-mcp/actions/runs/18777697750

**Root Cause:** Multi-line bash string using quotes breaks YAML parsing (the --- inside the string is interpreted as YAML document separator)

**Solution:** Convert to heredoc syntax: NOTES=$(cat <<EOF ... EOF)

**Files Changed:** .github/workflows/release.yml - Fixed multi-line string syntax

Concieved by Romuald Członkowski - www.aiadvisors.pl/en