### PR TITLE
fix: sync package.runtime.json to match package.json version 2.22.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.22.3",
+  "version": "2.22.4",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.22.0",
+  "version": "2.22.4",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary
Fixes version desynchronization between package.json and package.runtime.json that has been blocking npm releases since v2.21.1.

## Problem
- `package.json` was at 2.22.3
- `package.runtime.json` was stuck at 2.22.0
- Release workflow detected this mismatch and failed to publish
- Versions 2.22.0-2.22.3 were never published to npm

## Solution
- Bumped `package.json` to 2.22.4 for a clean release
- Ran sync script to update `package.runtime.json` to 2.22.4
- Both files now synchronized

## Expected Outcome
Once merged:
- Release workflow will detect version change (2.22.3 → 2.22.4)
- npm package v2.22.4 will be published automatically
- Docker images will be built and tagged
- GitHub release v2.22.4 will be created

## Testing
- [x] Version sync verified in package.json, package.runtime.json
- [x] TypeScript compilation passes
- [x] Commit follows project standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Conceived by Romuald Członkowski - www.aiadvisors.pl/en