### PR TITLE
fix: remove emoji from heredoc in release workflow to fix YAML parsing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
 
             # Get all commits up to current commit - use heredoc for multiline
             NOTES=$(cat <<EOF
-### 🎉 Initial Release
+### Initial Release
 
 This is the initial release of n8n-mcp v$CURRENT_VERSION.
 


### PR DESCRIPTION
The emoji (🎉) on line 147 inside the heredoc was causing GitHub Actions YAML parser to fail with "Invalid workflow file" error on line 149.

Root cause analysis:
- Emojis work fine in echo statements throughout workflows
- But emojis as literal content inside heredocs within YAML break the parser
- The UTF-8 bytes of the emoji confuse GitHub Actions' YAML interpreter
- Error was reported at line 149 but caused by emoji on line 147

Solution:
- Removed emoji from heredoc content in release notes generation
- Heredoc now contains plain ASCII text only
- This follows the same pattern as other heredocs in the workflow

Related: Previous similar fix in commit 952a97e which changed from quoted multi-line strings to heredocs. This fix completes that work by ensuring heredoc content is parser-safe.

Fixes: https://github.com/czlonkowski/n8n-mcp/actions/runs/18802795662

Concieved by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)