### PR TITLE
chore: bump version to 2.22.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.22.4",
+  "version": "2.22.5",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.22.4",
+  "version": "2.22.5",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Version bump to trigger automated release workflow and verify that the YAML syntax fix (commit 79ef853) works correctly.

Previous release attempt for 2.22.4 failed due to YAML syntax error (emoji in heredoc). This version bump will test the complete release pipeline end-to-end.

Concieved by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)