### PR TITLE
docs: Emphasize MCP_MODE=stdio requirement for Claude Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ npx n8n-mcp
 
 Add to Claude Desktop config:
 
+> ⚠️ **Important**: The `MCP_MODE: "stdio"` environment variable is **required** for Claude Desktop. Without it, you will see JSON parsing errors like `"Unexpected token..."` in the UI. This variable ensures that only JSON-RPC messages are sent to stdout, preventing debug logs from interfering with the protocol.
+
 **Basic configuration (documentation tools only):**
 ```json
 {


### PR DESCRIPTION
## Problem

Closes #376

Users encounter JSON parsing errors in Claude Desktop when using n8n-mcp:
- `Unexpected token 'h', "  hasOutputS"... is not valid JSON`
- `Unexpected token 'd', "  descriptio"... is not valid JSON`

These errors occur because debug logs are written to stdout, contaminating the JSON-RPC communication channel that Claude Desktop expects to contain only JSON-RPC 2.0 messages.

## Solution

Added a prominent warning in the Quick Start section (Option 1: npx) emphasizing that `MCP_MODE: "stdio"` is **required** for Claude Desktop.

### Changes

- Added warning box before the configuration examples
- Explains **why** the variable is needed (prevents debug logs on stdout)
- Explains **what happens** without it (JSON parse errors)
- Explains **how it works** (suppresses console output)

### Example Warning

> ⚠️ **Important**: The `MCP_MODE: "stdio"` environment variable is **required** for Claude Desktop. Without it, you will see JSON parsing errors like `"Unexpected token..."` in the UI. This variable ensures that only JSON-RPC messages are sent to stdout, preventing debug logs from interfering with the protocol.

## Testing

Tested on Windows with Claude Desktop 0.14.4:
- ✅ Without `MCP_MODE=stdio`: Multiple JSON parse errors in logs
- ✅ With `MCP_MODE=stdio`: Clean JSON-RPC communication, no errors
- ✅ All 42 tools available and functional

## Additional Context

The variable is already in the example config (line 62), but it wasn't clear that it's **mandatory** for Claude Desktop. This PR makes it impossible to miss.

---
Conceived by Romuald Członkowski - [AI Advisors](https://www.aiadvisors.pl/en)
