### PR TITLE
feat: Add credentials management MCP tools

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1054,6 +1054,23 @@ export class N8NDocumentationMCPServer {
         this.validateToolParams(name, args, ['mode']);
         return n8nHandlers.handleWorkflowVersions(args, this.repository!, this.instanceContext);
 
+      // Credential Management Tools
+      case 'n8n_create_credential':
+        this.validateToolParams(name, args, ['name', 'type', 'data']);
+        return n8nHandlers.handleCreateCredential(args, this.instanceContext);
+      case 'n8n_get_credential':
+        this.validateToolParams(name, args, ['id']);
+        return n8nHandlers.handleGetCredential(args, this.instanceContext);
+      case 'n8n_list_credentials':
+        // No required parameters
+        return n8nHandlers.handleListCredentials(args, this.instanceContext);
+      case 'n8n_update_credential':
+        this.validateToolParams(name, args, ['id']);
+        return n8nHandlers.handleUpdateCredential(args, this.instanceContext);
+      case 'n8n_delete_credential':
+        this.validateToolParams(name, args, ['id']);
+        return n8nHandlers.handleDeleteCredential(args, this.instanceContext);
+
       default:
         throw new Error(`Unknown tool: ${name}`);
     }

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -516,5 +516,102 @@ Examples:
       },
       required: ['mode']
     }
+  },
+
+  // Credential Management Tools
+  {
+    name: 'n8n_create_credential',
+    description: `Create a new credential in n8n. Credentials store authentication information for services like APIs, databases, etc.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Credential name (required)'
+        },
+        type: {
+          type: 'string',
+          description: 'Credential type (required). Examples: httpHeaderAuth, oAuth2Api, postgres, telegramApi, openAiApi'
+        },
+        data: {
+          type: 'object',
+          description: 'Credential data (required). Structure depends on credential type. For httpHeaderAuth: {name: "Authorization", value: "Bearer token"}. For postgres: {host, port, database, user, password}'
+        }
+      },
+      required: ['name', 'type', 'data']
+    }
+  },
+  {
+    name: 'n8n_get_credential',
+    description: `Get a credential by ID. Returns credential details including name, type, and configuration.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Credential ID'
+        }
+      },
+      required: ['id']
+    }
+  },
+  {
+    name: 'n8n_list_credentials',
+    description: `List all credentials with optional pagination. Returns paginated list of credentials.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        cursor: {
+          type: 'string',
+          description: 'Pagination cursor from previous response'
+        },
+        limit: {
+          type: 'number',
+          minimum: 1,
+          maximum: 100,
+          description: 'Number of credentials to return (1-100)'
+        }
+      }
+    }
+  },
+  {
+    name: 'n8n_update_credential',
+    description: `Update an existing credential. Can update name, type, or data fields.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Credential ID (required)'
+        },
+        name: {
+          type: 'string',
+          description: 'New credential name (optional)'
+        },
+        type: {
+          type: 'string',
+          description: 'New credential type (optional)'
+        },
+        data: {
+          type: 'object',
+          description: 'New credential data (optional)'
+        }
+      },
+      required: ['id']
+    }
+  },
+  {
+    name: 'n8n_delete_credential',
+    description: `Delete a credential by ID. This action cannot be undone. Note: Cannot delete credentials currently in use by workflows.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Credential ID to delete'
+        }
+      },
+      required: ['id']
+    }
   }
 ];


### PR DESCRIPTION
## Summary

This PR adds complete **credentials management support** to the n8n MCP server, enabling AI assistants to programmatically create, read, update, and delete n8n credentials.

## Changes

### New Handlers (5)
Added to `src/mcp/handlers-n8n-manager.ts`:
- `handleCreateCredential` - Create new credentials
- `handleGetCredential` - Get credential by ID
- `handleListCredentials` - List all credentials with pagination
- `handleUpdateCredential` - Update existing credentials
- `handleDeleteCredential` - Delete credentials

### New MCP Tools (5)
Added to `src/mcp/tools-n8n-manager.ts`:
- `n8n_create_credential` - Create new credential with type and data
- `n8n_get_credential` - Retrieve credential details
- `n8n_list_credentials` - List credentials with optional pagination
- `n8n_update_credential` - Update credential name/type/data
- `n8n_delete_credential` - Delete credential by ID

### Server Integration
- Registered all credential tools in MCP server (`src/mcp/server.ts`)
- Added credential tools category to `n8n_list_available_tools` output
- All handlers use existing `N8nApiClient` credential methods (no new dependencies)

## API Support

The changes leverage existing credential management methods in `N8nApiClient`:
```typescript
- listCredentials(params)
- getCredential(id)
- createCredential(credential)
- updateCredential(id, credential)
- deleteCredential(id)
```

## Use Cases

AI assistants can now:
1. **Create credentials** for APIs, databases, OAuth services
2. **List credentials** to verify configuration
3. **Update credentials** when keys rotate
4. **Delete credentials** to clean up unused auth
5. **Get credential details** for debugging

## Example Usage

```javascript
// Create HTTP Header Auth credential
mcp__n8n-mcp__n8n_create_credential({
  name: "API Key",
  type: "httpHeaderAuth",
  data: {
    name: "x-api-key",
    value: "sk-1234567890"
  }
})

// List all credentials
mcp__n8n-mcp__n8n_list_credentials({ limit: 50 })
```

## Testing

- ✅ TypeScript interfaces validated
- ✅ Zod schema validation for all handlers
- ✅ Error handling for N8nNotFoundError and validation errors
- ✅ Telemetry integration for all tools

## Breaking Changes

None - this is purely additive functionality.

## Related Issues

This complements the existing workflow management tools and addresses the need for programmatic credential management through MCP.

---

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en