### PR TITLE
Critical: Fix stack overflow in session removal (#427)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,6 +1114,13 @@ Current database coverage (n8n v1.117.2):
 
 ## 🔄 Recent Updates
 
+### v2.22.19 - Critical Bug Fix
+**Fixed:** Stack overflow in session removal (Issue #427)
+- Eliminated infinite recursion in HTTP server session cleanup
+- Transport resources now deleted before closing to prevent circular event handler chain
+- Production logs no longer show "RangeError: Maximum call stack size exceeded"
+- All session cleanup operations now complete successfully without crashes
+
 See [CHANGELOG.md](./docs/CHANGELOG.md) for full version history and recent changes.
 
 ## ⚠️ Known Issues

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.22.18",
+  "version": "2.22.19",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Fixes #427 - Eliminates critical stack overflow bug in HTTP server session cleanup that was causing production crashes every 5 minutes.

## Problem

Production logs showed recurring `RangeError: Maximum call stack size exceeded` errors during session cleanup, causing the session removal process to crash:

```
[2025-11-18T15:26:16.797Z] [n8n-mcp] [WARN] Error removing session {
  error: RangeError: Maximum call stack size exceeded
}
```

### Root Cause

Infinite recursion caused by circular event handler chain:

1. `removeSession()` called `transport.close()`
2. `transport.close()` triggered `onclose` event handler
3. `onclose` handler called `removeSession()` again
4. Loop continued until stack overflow

## Solution

Implemented the recommended fix from the issue (Option 1): **Delete transport BEFORE closing**

### Code Changes

**File:** `src/http-server-single-session.ts:156-178`

**Before:**
```typescript
if (this.transports[sessionId]) {
  await this.transports[sessionId].close();  // ← Triggers onclose
  delete this.transports[sessionId];
}
```

**After:**
```typescript
// Store reference to transport before deletion
const transport = this.transports[sessionId];

// Delete transport FIRST to prevent onclose handler from triggering recursion
delete this.transports[sessionId];
delete this.servers[sessionId];
delete this.sessionMetadata[sessionId];
delete this.sessionContexts[sessionId];

// Close transport AFTER deletion
// When onclose handler fires, it won't find the transport anymore
if (transport) {
  await transport.close();
}
```

**Why this works:**
- When `transport.close()` triggers the `onclose` handler
- Handler checks `if (this.transports[sessionId])`
- Transport is already deleted, so condition is false
- No recursive call to `removeSession()`

## Changes Made

1. ✅ **Fixed infinite recursion** in `removeSession()` method
2. ✅ **Added regression test** to prevent future occurrences
3. ✅ **Updated version** to 2.22.19
4. ✅ **Updated README** with fix details

## Testing

- ✅ Added comprehensive regression test that simulates the actual SDK behavior
- ✅ Verifies `close()` is called exactly once (not multiple times)
- ✅ Confirms no stack overflow or infinite recursion
- ✅ Ensures all session data is cleaned up properly
- ✅ All 39 session management tests pass
- ✅ Build and typecheck succeed

## Impact

- **Severity:** Critical - was causing crashes in production
- **Frequency:** Every session cleanup cycle (5-minute intervals)
- **Affected:** Production n8n-mcp hosted service
- **Fix:** Eliminates all stack overflow errors in session cleanup
- **Benefit:** Prevents memory leaks from failed cleanup operations

## Version

- Bumped from `2.22.18` → `2.22.19`

---

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en