### PR TITLE
fix: remove historical migration info from tools documentation (v2.26.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.26.5] - 2025-11-27
+
+### 🔧 Fixed
+
+- **Tools Documentation: Runtime Token Optimization**
+  - Removed historical migration information from tool descriptions (e.g., "Replaces X, Y, Z...")
+  - Removed version-specific references (v2.21.1, issue #357) that are not needed at runtime
+  - Cleaned up consolidation comments in index.ts
+  - Documentation now starts directly with functional content for better AI agent efficiency
+  - Estimated savings: ~128 tokens per full documentation request
+  - Affected tools: `get_node`, `validate_node`, `search_templates`, `n8n_executions`, `n8n_get_workflow`, `n8n_update_partial_workflow`
+
+**Conceived by Romuald Członkowski - [AiAdvisors](https://www.aiadvisors.pl/en)**
+
 ## [2.26.4] - 2025-11-26
 
 ### 🔧 Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.26.4",
+  "version": "2.26.5",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/mcp/tool-docs/configuration/get-node.ts
+++ b/src/mcp/tool-docs/configuration/get-node.ts
@@ -17,9 +17,7 @@ export const getNodeDoc: ToolDocumentation = {
     ]
   },
   full: {
-    description: `Unified tool for all node information needs. Replaces get_node_info, get_node_essentials, get_node_documentation, and search_node_properties with a single versatile API.
-
-**Detail Levels (mode="info", default):**
+    description: `**Detail Levels (mode="info", default):**
 - minimal (~200 tokens): Basic metadata only - nodeType, displayName, description, category
 - standard (~1-2K tokens): Essential properties + operations - recommended for most tasks
 - full (~3-8K tokens): Complete node schema - use only when standard insufficient

--- a/src/mcp/tool-docs/index.ts
+++ b/src/mcp/tool-docs/index.ts
@@ -25,7 +25,6 @@ import {
 } from './workflow_management';
 
 // Combine all tool documentations into a single object
-// Total: 19 tools after v2.26.0 consolidation
 export const toolsDocumentation: Record<string, ToolDocumentation> = {
   // System tools
   tools_documentation: toolsDocumentationDoc,
@@ -37,20 +36,20 @@ export const toolsDocumentation: Record<string, ToolDocumentation> = {
   // Discovery tools
   search_nodes: searchNodesDoc,
 
-  // Configuration tools (consolidated)
-  get_node: getNodeDoc,  // Replaces: get_node_info, get_node_essentials, get_node_documentation, search_node_properties
+  // Configuration tools
+  get_node: getNodeDoc,
 
-  // Validation tools (consolidated)
-  validate_node: validateNodeDoc,  // Replaces: validate_node_operation, validate_node_minimal
-  validate_workflow: validateWorkflowDoc,  // Options replace: validate_workflow_connections, validate_workflow_expressions
+  // Validation tools
+  validate_node: validateNodeDoc,
+  validate_workflow: validateWorkflowDoc,
 
-  // Template tools (consolidated)
+  // Template tools
   get_template: getTemplateDoc,
-  search_templates: searchTemplatesDoc,  // Modes replace: list_node_templates, search_templates_by_metadata, get_templates_for_task
+  search_templates: searchTemplatesDoc,
 
   // Workflow Management tools (n8n API)
   n8n_create_workflow: n8nCreateWorkflowDoc,
-  n8n_get_workflow: n8nGetWorkflowDoc,  // Modes replace: n8n_get_workflow_details, n8n_get_workflow_structure, n8n_get_workflow_minimal
+  n8n_get_workflow: n8nGetWorkflowDoc,
   n8n_update_full_workflow: n8nUpdateFullWorkflowDoc,
   n8n_update_partial_workflow: n8nUpdatePartialWorkflowDoc,
   n8n_delete_workflow: n8nDeleteWorkflowDoc,
@@ -58,8 +57,8 @@ export const toolsDocumentation: Record<string, ToolDocumentation> = {
   n8n_validate_workflow: n8nValidateWorkflowDoc,
   n8n_autofix_workflow: n8nAutofixWorkflowDoc,
   n8n_trigger_webhook_workflow: n8nTriggerWebhookWorkflowDoc,
-  n8n_executions: n8nExecutionsDoc,  // Actions replace: n8n_get_execution, n8n_list_executions, n8n_delete_execution
-  n8n_workflow_versions: n8nWorkflowVersionsDoc  // Modes: list, get, rollback, delete, prune, truncate
+  n8n_executions: n8nExecutionsDoc,
+  n8n_workflow_versions: n8nWorkflowVersionsDoc
 };
 
 // Re-export types

--- a/src/mcp/tool-docs/templates/search-templates.ts
+++ b/src/mcp/tool-docs/templates/search-templates.ts
@@ -16,9 +16,7 @@ export const searchTemplatesDoc: ToolDocumentation = {
     ]
   },
   full: {
-    description: `Unified template search tool with four search modes. Replaces search_templates, list_node_templates, search_templates_by_metadata, and get_templates_for_task.
-
-**Search Modes:**
+    description: `**Search Modes:**
 - keyword (default): Full-text search across template names and descriptions
 - by_nodes: Find templates that use specific node types
 - by_task: Get curated templates for predefined task categories

--- a/src/mcp/tool-docs/validation/validate-node.ts
+++ b/src/mcp/tool-docs/validation/validate-node.ts
@@ -16,9 +16,7 @@ export const validateNodeDoc: ToolDocumentation = {
     ]
   },
   full: {
-    description: `Unified node configuration validator. Replaces validate_node_operation and validate_node_minimal with a single tool.
-
-**Validation Modes:**
+    description: `**Validation Modes:**
 - full (default): Comprehensive validation with errors, warnings, suggestions, and automatic structure validation
 - minimal: Quick check for required fields only - fast but less thorough
 

--- a/src/mcp/tool-docs/workflow_management/n8n-executions.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-executions.ts
@@ -16,9 +16,7 @@ export const n8nExecutionsDoc: ToolDocumentation = {
     ]
   },
   full: {
-    description: `Unified execution management tool. Replaces n8n_get_execution, n8n_list_executions, and n8n_delete_execution.
-
-**Actions:**
+    description: `**Actions:**
 - get: Retrieve execution details by ID with configurable detail level
 - list: List executions with filtering and pagination
 - delete: Remove an execution record from history

--- a/src/mcp/tool-docs/workflow_management/n8n-get-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-get-workflow.ts
@@ -16,9 +16,7 @@ export const n8nGetWorkflowDoc: ToolDocumentation = {
     ]
   },
   full: {
-    description: `Unified workflow retrieval with configurable detail levels. Replaces n8n_get_workflow, n8n_get_workflow_details, n8n_get_workflow_structure, and n8n_get_workflow_minimal.
-
-**Modes:**
+    description: `**Modes:**
 - full (default): Complete workflow including all nodes with parameters, connections, and settings
 - details: Full workflow plus execution statistics (success/error counts, last execution time)
 - structure: Nodes and connections only - useful for topology analysis

--- a/src/mcp/tool-docs/workflow_management/n8n-update-partial-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-update-partial-workflow.ts
@@ -90,7 +90,6 @@ Full support for all 8 AI connection types used in n8n AI workflows:
 
 **Important Notes**:
 - **AI nodes do NOT require main connections**: Nodes like OpenAI Chat Model, Postgres Chat Memory, Embeddings OpenAI, and Supabase Vector Store use AI-specific connection types exclusively. They should ONLY have connections like \`ai_languageModel\`, \`ai_memory\`, \`ai_embedding\`, or \`ai_tool\` - NOT \`main\` connections.
-- **Fixed in v2.21.1**: Validation now correctly recognizes AI nodes that only have AI-specific connections without requiring \`main\` connections (resolves issue #357).
 
 **Best Practices**:
 - Always specify \`sourceOutput\` for AI connections (defaults to "main" if omitted)


### PR DESCRIPTION
## Summary
- Remove "Replaces X, Y, Z..." sentences from `full.description` in 5 consolidated tools
- Remove version/issue references (`v2.21.1`, `issue #357`) from `n8n_update_partial_workflow`  
- Clean up consolidation comments in `index.ts`
- Documentation now starts directly with functional content for better AI agent efficiency

## Changes
| File | Change |
|------|--------|
| `get-node.ts` | Removed "Replaces..." sentence |
| `validate-node.ts` | Removed "Replaces..." sentence |
| `search-templates.ts` | Removed "Replaces..." sentence |
| `n8n-executions.ts` | Removed "Replaces..." sentence |
| `n8n-get-workflow.ts` | Removed "Replaces..." sentence |
| `n8n-update-partial-workflow.ts` | Removed version/issue refs |
| `index.ts` | Cleaned up consolidation comments |

## Impact
- **Token savings**: ~128 tokens per full documentation request
- **Improved clarity**: Documentation starts with actionable content, not historical context
- **Runtime-focused**: AI agents get only the information they need

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Tested with n8n-mcp-tester agent - all 6 tools verified

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)