### PR TITLE
Fix Docker healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,8 @@ Want to use n8n-MCP with your n8n instance? Check out our comprehensive [n8n Dep
 - Cloud deployment on Hetzner, AWS, and other providers
 - Troubleshooting and security best practices
 
+> **Note on Docker healthchecks**: When using `docker-compose.n8n.yml`, n8n-mcp runs as a stdio-based MCP server (Node process) and does not expose an HTTP server on port 3000. Avoid curl-based healthchecks such as `curl 127.0.0.1:3000`, as they will always fail. The provided docker-compose file uses a process-based healthcheck that verifies the MCP Node process is running.
+
 ## 💻 Connect your IDE
 
 n8n-MCP works with multiple AI-powered IDEs and tools. Choose your preferred development environment:

--- a/docker-compose.n8n.yml
+++ b/docker-compose.n8n.yml
@@ -56,10 +56,14 @@ services:
     depends_on:
       n8n:
         condition: service_healthy
+    # Healthcheck: ensure MCP Node process is running
+    # n8n-mcp is a stdio-based MCP server, not an HTTP server on port 3000.
+    # curl-based healthchecks to 127.0.0.1:3000 always fail and mark the
+    # container unhealthy even when MCP is working as expected.
     healthcheck:
-      test: ["CMD", "sh", "-c", "curl -f http://localhost:$${MCP_PORT:-3000}/health"]
+      test: ["CMD-SHELL", "ps aux | grep 'dist/mcp/index.js' | grep -v grep || exit 1"]
       interval: 30s
-      timeout: 10s
+      timeout: 5s
       retries: 3
       start_period: 40s
 


### PR DESCRIPTION
This PR fixes Docker healthcheck behavior for the n8n-mcp container.

n8n-mcp runs as a stdio-based MCP server (node dist/mcp/index.js) and does not expose an HTTP server on port 3000. A curl-based healthcheck to http://127.0.0.1:3000 always fails and causes Docker to mark the container as unhealthy even though the MCP server is working correctly.

Changes:
- Replace the curl-based healthcheck in docker-compose.n8n.yml with a simple process-based healthcheck
- Add a short note in the README explaining that n8n-mcp is not an HTTP server