### PR TITLE
fix: pass context parameter to handleGetWorkflow in handleValidateWorkflow (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.28.8] - 2025-12-07
+
+### Bug Fixes
+
+**Multi-tenant: handleValidateWorkflow missing context parameter (#474)**
+
+Fixed `n8n_validate_workflow` tool failing in multi-tenant mode with error:
+`"n8n API not configured. Please set N8N_API_URL and N8N_API_KEY environment variables."`
+
+- **Root Cause**: `handleValidateWorkflow` called `handleGetWorkflow` without passing the `context` parameter
+- **Impact**: Multi-tenant deployments could not use the `n8n_validate_workflow` tool
+- **Solution**: Pass `context` parameter to `handleGetWorkflow` call (line 987)
+
+**Conceived by Romuald Członkowski - [AiAdvisors](https://www.aiadvisors.pl/en)**
+
 ## [2.28.7] - 2025-12-05
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.28.7",
+  "version": "2.28.8",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -984,7 +984,7 @@ export async function handleValidateWorkflow(
     const input = validateWorkflowSchema.parse(args);
     
     // First, fetch the workflow from n8n
-    const workflowResponse = await handleGetWorkflow({ id: input.id });
+    const workflowResponse = await handleGetWorkflow({ id: input.id }, context);
     
     if (!workflowResponse.success) {
       return workflowResponse; // Return the error from fetching


### PR DESCRIPTION
## Summary

- Fixed `n8n_validate_workflow` tool failing in multi-tenant mode
- Root cause: `handleValidateWorkflow` called `handleGetWorkflow` without passing the `context` parameter
- The fix adds `context` as the second argument to the `handleGetWorkflow` call

## Test plan

- [x] Build passes (`npm run build`)
- [x] TypeScript check passes (`npm run typecheck`)
- [ ] Manual test: Call `n8n_validate_workflow` in multi-tenant mode

Closes #474

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)