### PR TITLE
Fix n8n_update_partial_workflow tool to comply with MCP validation requirements

### DIFF
--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -138,7 +138,7 @@ export const n8nManagementTools: ToolDefinition[] = [
           description: 'Array of diff operations to apply. Each operation must have a "type" field and relevant properties for that operation type.',
           items: {
             type: 'object',
-            additionalProperties: true
+            additionalProperties: false
           }
         },
         validateOnly: {


### PR DESCRIPTION
This PR fixes MCP tool schema validation for the n8n_update_partial_workflow tool.

The n8n_update_partial_workflow tool was failing MCP schema validation with error: "400 Invalid schema for function 'n8n_update_partial_workflow': In context=('properties', 'operations', 'items'), 'additionalProperties' is required to be supplied and to be false."

The "items" param from "operations" object had ``"additionalProperties" : true` which violated MCP's strict schema requirements and caused the tool to be rejected during validation.

Changes:

-Changed additionalProperties from true to false in the items schema definition of the operations object