### PR TITLE
docs: fix connection keys documentation to say 'node names' not 'node IDs' (#510)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.31.3] - 2025-12-26
+
+### Fixed
+
+**Documentation Bug: Connection Keys Say "Node IDs" but Require "Node Names" (Issue #510)**
+
+Fixed documentation that incorrectly stated connection keys should be "node IDs" when n8n actually requires "node names".
+
+**Problem:**
+The `n8n_create_workflow` documentation and examples showed using node IDs (e.g., `"webhook_1"`) as connection keys, but the validator requires node names (e.g., `"Webhook"`). This caused workflow creation failures and contributed to low success rates for AI-generated workflows.
+
+**Changes:**
+- Updated `tools-n8n-manager.ts` parameter description: "Keys are source node names (the name field, not id)"
+- Updated `n8n-create-workflow.ts` documentation: "Keys are source node names (not IDs)"
+- Fixed example to use `"Webhook"` and `"Slack"` instead of `"webhook_1"` and `"slack_1"`
+- Clarified `get-template.ts` return description
+
+**Before (incorrect):**
+```javascript
+connections: {
+  "webhook_1": { "main": [[{node: "slack_1", ...}]] }  // WRONG
+}
+```
+
+**After (correct):**
+```javascript
+connections: {
+  "Webhook": { "main": [[{node: "Slack", ...}]] }  // CORRECT
+}
+```
+
+**Impact:**
+- AI models following documentation will now generate valid workflows
+- Clear distinction between node `id` (internal identifier) and `name` (connection key)
+- No breaking changes - validator behavior unchanged
+
 ## [2.31.2] - 2025-12-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.31.2",
+  "version": "2.31.3",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/mcp/tool-docs/templates/get-template.ts
+++ b/src/mcp/tool-docs/templates/get-template.ts
@@ -42,7 +42,7 @@ export const getTemplateDoc: ToolDocumentation = {
   - url: Link to template on n8n.io
   - workflow: Complete workflow JSON with structure:
     - nodes: Array of node objects (id, name, type, typeVersion, position, parameters)
-    - connections: Object mapping source nodes to targets
+    - connections: Object mapping source node names to targets
     - settings: Workflow configuration (timezone, error handling, etc.)
 - usage: Instructions for using the workflow`,
     examples: [

--- a/src/mcp/tool-docs/workflow_management/n8n-create-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-create-workflow.ts
@@ -20,7 +20,7 @@ export const n8nCreateWorkflowDoc: ToolDocumentation = {
     parameters: {
       name: { type: 'string', required: true, description: 'Workflow name' },
       nodes: { type: 'array', required: true, description: 'Array of nodes with id, name, type, typeVersion, position, parameters' },
-      connections: { type: 'object', required: true, description: 'Node connections. Keys are source node IDs' },
+      connections: { type: 'object', required: true, description: 'Node connections. Keys are source node names (not IDs)' },
       settings: { type: 'object', description: 'Optional workflow settings (timezone, error handling, etc.)' }
     },
     returns: 'Minimal summary (id, name, active, nodeCount) for token efficiency. Use n8n_get_workflow with mode "structure" to verify current state if needed.',
@@ -55,8 +55,8 @@ n8n_create_workflow({
     }
   ],
   connections: {
-    "webhook_1": {
-      "main": [[{node: "slack_1", type: "main", index: 0}]]
+    "Webhook": {
+      "main": [[{node: "Slack", type: "main", index: 0}]]
     }
   }
 })`,

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -46,9 +46,9 @@ export const n8nManagementTools: ToolDefinition[] = [
             }
           }
         },
-        connections: { 
-          type: 'object', 
-          description: 'Workflow connections object. Keys are source node IDs, values define output connections' 
+        connections: {
+          type: 'object',
+          description: 'Workflow connections object. Keys are source node names (the name field, not id), values define output connections'
         },
         settings: {
           type: 'object',


### PR DESCRIPTION
## Summary

- Fixed documentation bug where `n8n_create_workflow` stated connection keys should be "node IDs" when they actually require "node names"
- Updated examples to use correct format (`"Webhook"` instead of `"webhook_1"`)
- Clarified documentation in 3 files
- **Version: 2.31.3**

## Problem

The documentation incorrectly showed:
```javascript
connections: {
  "webhook_1": { "main": [[{node: "slack_1", ...}]] }  // WRONG - uses ID
}
```

When n8n actually requires:
```javascript
connections: {
  "Webhook": { "main": [[{node: "Slack", ...}]] }  // CORRECT - uses name
}
```

This caused AI models following the docs to generate invalid workflows, contributing to a 13% success rate for workflow generation tasks.

## Changes

| File | Change |
|------|--------|
| `src/mcp/tools-n8n-manager.ts:51` | "Keys are source node names (the name field, not id)" |
| `src/mcp/tool-docs/workflow_management/n8n-create-workflow.ts:23` | "Keys are source node names (not IDs)" |
| `src/mcp/tool-docs/workflow_management/n8n-create-workflow.ts:57-59` | Example uses `"Webhook"`/`"Slack"` |
| `src/mcp/tool-docs/templates/get-template.ts:45` | "source node names" |

## Test Plan

- [x] Verified with n8n-mcp-tester agent
- [x] Documentation now says "node names"
- [x] Name-based connections work correctly
- [x] ID-based connections fail with clear error message

Closes #510

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)