### PR TITLE
fix: redirect INFO/DEBUG logs to stderr for MCP protocol compliance

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -87,7 +87,7 @@ export class Logger {
           console.warn(formattedMessage, ...args);
           break;
         default:
-          console.log(formattedMessage, ...args);
+          console.error(formattedMessage, ...args);
       }
     }
   }


### PR DESCRIPTION
## Problem\nINFO/DEBUG log messages were written to stdout via "console.log()", which violates MCP's requirement that stdout contain only JSON-RPC messages. This caused JSON parse errors in Claude Desktop.\n\n## Solution\nRoute the default logger output to stderr instead of stdout by using "console.error()" in the logger's default case.\n\n## Testing\n- Verified stdout contains only JSON-RPC: \n  "echo '{"jsonrpc":"2.0",...}' | node dist/mcp/index.js 2>/dev/null"\n- Verified log output appears on stderr: \n  "echo '{"jsonrpc":"2.0",...}' | node dist/mcp/index.js 2>&1 1>/dev/null"