### PR TITLE
fix: sync package.runtime.json version in Docker builds (v2.33.1)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -53,13 +53,24 @@ jobs:
     permissions:
       contents: read
       packages: write
-      
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           lfs: true
-        
+
+      - name: Sync runtime version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.runtime.json'));
+            pkg.version = '$VERSION';
+            fs.writeFileSync('package.runtime.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "✅ Synced package.runtime.json to version $VERSION"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         
@@ -144,13 +155,24 @@ jobs:
     permissions:
       contents: read
       packages: write
-      
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           lfs: true
-        
+
+      - name: Sync runtime version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.runtime.json'));
+            pkg.version = '$VERSION';
+            fs.writeFileSync('package.runtime.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "✅ Synced package.runtime.json to version $VERSION"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,7 +427,18 @@ jobs:
             exit 1
           fi
           echo "✅ Sufficient disk space: ${AVAILABLE_GB}GB available"
-      
+
+      - name: Sync runtime version for Docker
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.runtime.json'));
+            pkg.version = '$VERSION';
+            fs.writeFileSync('package.runtime.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "✅ Synced package.runtime.json to version $VERSION"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Based on hands-on testing with n8n-mcp-tester agent
 - Overall experience rating improved from 4.5/10 to estimated 6/10
 
+## [2.33.1] - 2026-01-12
+
+### Fixed
+- **Docker image version mismatch bug**: Docker images were built with stale `package.runtime.json` (v2.29.5) while npm package was at v2.33.0
+  - Root cause: `build-docker` job in `release.yml` did not sync `package.runtime.json` version before building
+  - The `publish-npm` job synced the version, but both jobs ran in parallel, so Docker got the stale version
+  - Added "Sync runtime version" step to `release.yml` `build-docker` job
+  - Added "Sync runtime version" step to `docker-build.yml` `build` and `build-railway` jobs
+  - All Docker builds now sync `package.runtime.json` version from `package.json` before building
+
 ## [2.14.4] - 2025-09-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.33.0",
+  "version": "2.33.1",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.29.5",
+  "version": "2.33.1",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Summary

- Fix Docker image version mismatch bug where images were built with stale `package.runtime.json` (v2.29.5) while npm was at v2.33.0
- Add version sync step to all Docker build workflows
- Bump version to 2.33.1 to trigger release with fix

## Problem

Docker images were reporting version 2.29.5 instead of 2.33.0 because:

1. The `build-docker` job in `release.yml` did **NOT** sync `package.runtime.json` before building
2. The `publish-npm` job **DID** sync the version
3. Both jobs ran **in parallel** after `build-and-verify` completed
4. Docker build used the stale version from the repository

## Solution

Added a lightweight "Sync runtime version" step to all Docker build jobs:

```yaml
- name: Sync runtime version
  run: |
    VERSION=$(node -p "require('./package.json').version")
    node -e "
      const fs = require('fs');
      const pkg = JSON.parse(fs.readFileSync('package.runtime.json'));
      pkg.version = '$VERSION';
      fs.writeFileSync('package.runtime.json', JSON.stringify(pkg, null, 2) + '\n');
    "
    echo "✅ Synced package.runtime.json to version $VERSION"
```

This uses Node.js directly (pre-installed on GitHub runners) - no npm install required.

## Files Changed

| File | Change |
|------|--------|
| `package.json` | Version bumped to 2.33.1 |
| `package.runtime.json` | Version synced to 2.33.1 |
| `.github/workflows/release.yml` | Added sync step to `build-docker` job |
| `.github/workflows/docker-build.yml` | Added sync step to `build` and `build-railway` jobs |
| `docs/CHANGELOG.md` | Added v2.33.1 release notes |

## Test plan

- [ ] Merge PR and monitor release workflow
- [ ] Verify Docker image version matches npm version:
  ```bash
  docker pull ghcr.io/czlonkowski/n8n-mcp:latest
  docker run --rm ghcr.io/czlonkowski/n8n-mcp:latest node -p "require('./package.json').version"
  # Should output: 2.33.1
  ```

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.ai/code)