### PR TITLE
fix: memory leak in SSE session reset (#542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.33.4] - 2026-01-21
+
+### Fixed
+
+- **Memory leak in SSE session reset** (Issue #542): Fixed memory leak when SSE sessions are recreated every 5 minutes
+  - Root cause: `resetSessionSSE()` only closed the transport but not the MCP server
+  - This left the SimpleCache cleanup timer (60-second interval) running indefinitely
+  - Database connections and cached data (~50-100MB per session) persisted in memory
+  - Fix: Added `server.close()` call before `transport.close()`, mirroring the existing cleanup pattern in `removeSession()`
+  - Impact: Prevents ~288 leaked server instances per day in long-running HTTP deployments
+
 ## [2.33.3] - 2026-01-21
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.33.3",
+  "version": "2.33.4",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Fixes memory leak when SSE sessions are recreated every 5 minutes (Issue #542).

**Root Cause:** `resetSessionSSE()` only closed the transport but not the MCP server, leaving:
- SimpleCache cleanup timer (60-second interval) running indefinitely
- Database connections open
- Cached data (~50-100MB per session) persisting in memory
- ~288 leaked server instances per day in long-running HTTP deployments

**Fix:** Added `server.close()` call before `transport.close()` in `resetSessionSSE()`, mirroring the existing cleanup pattern in `removeSession()`.

## Changes

- `src/http-server-single-session.ts`: Added server cleanup in `resetSessionSSE()` (4 lines)
- `package.json`: Bump version to 2.33.4
- `CHANGELOG.md`: Document the fix

## Test plan

- [x] Build passes (`npm run build`)
- [x] TypeScript check passes (`npm run typecheck`)
- [x] Unit tests pass (4427 passed)
- [ ] Manual verification: Monitor memory usage over time with HTTP server running

Fixes #542

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.ai/code)