### PR TITLE
fix: include UI apps build in CI release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,8 +283,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
-      - name: Build project
-        run: npm run build
+      - name: Build project (server + UI apps)
+        run: npm run build:all
 
       # Database is already built and committed during development
       # Rebuilding here causes segfault due to memory pressure (exit code 139)
@@ -322,8 +322,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
-      - name: Build project
-        run: npm run build
+      - name: Build project (server + UI apps)
+        run: npm run build:all
 
       # Database is already built and committed during development
       - name: Verify database exists
@@ -347,6 +347,8 @@ jobs:
           # Copy necessary files
           cp -r dist $PUBLISH_DIR/
           cp -r data $PUBLISH_DIR/
+          mkdir -p $PUBLISH_DIR/ui-apps
+          cp -r ui-apps/dist $PUBLISH_DIR/ui-apps/
           cp README.md $PUBLISH_DIR/
           cp LICENSE $PUBLISH_DIR/
           cp .env.example $PUBLISH_DIR/
@@ -377,7 +379,7 @@ jobs:
           pkg.license = 'MIT';
           pkg.bugs = { url: 'https://github.com/czlonkowski/n8n-mcp/issues' };
           pkg.homepage = 'https://github.com/czlonkowski/n8n-mcp#readme';
-          pkg.files = ['dist/**/*', 'data/nodes.db', '.env.example', 'README.md', 'LICENSE'];
+          pkg.files = ['dist/**/*', 'ui-apps/dist/**/*', 'data/nodes.db', '.env.example', 'README.md', 'LICENSE'];
           delete pkg.private;
           require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2));
           "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.34.2] - 2026-02-07
+
+### Fixed
+
+- **CI: UI apps missing from npm package**: Release pipeline only ran `npm run build` (TypeScript), so `ui-apps/dist/` was never built and excluded from published packages
+  - Changed build step to `npm run build:all` in `build-and-verify` and `publish-npm` jobs
+  - Added `ui-apps/dist/` to npm publish staging directory
+  - Added `ui-apps/dist/**/*` to published package files list
+
+Conceived by Romuald Czlonkowski - https://www.aiadvisors.pl/en
+
 ## [2.34.1] - 2026-02-07
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.34.1",
+  "version": "2.34.2",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- CI release workflow only ran `npm run build` (TypeScript), so `ui-apps/dist/` was never built and missing from npm packages
- Change build step to `npm run build:all` (builds UI apps then server) in both `build-and-verify` and `publish-npm` jobs
- Copy `ui-apps/dist/` into the npm publish staging directory
- Add `ui-apps/dist/**/*` to the published package `files` list

Without this fix, anyone installing via `npm install n8n-mcp` or `npx n8n-mcp` would get a server that has no UI app HTML files, so MCP Apps UIs would never render.

## Test plan

- [ ] Release workflow builds successfully with `npm run build:all`
- [ ] Published npm package includes `ui-apps/dist/operation-result/index.html` and `ui-apps/dist/validation-summary/index.html`
- [ ] `npx n8n-mcp` serves UI resources at `ui://n8n-mcp/*` URIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Conceived by Romuald Czlonkowski - https://www.aiadvisors.pl/en