### PR TITLE
fix: MCP Apps rendering in Claude - MIME type + useApp hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.34.3] - 2026-02-07
+
+### Fixed
+
+- **MCP Apps: Use correct MIME type for ext-apps spec**: Changed resource MIME type from `text/html` to `text/html;profile=mcp-app` (the `RESOURCE_MIME_TYPE` constant from `@modelcontextprotocol/ext-apps`). Without this profile parameter, Claude Desktop/web fails to recognize resources as MCP Apps and shows "Failed to load MCP App: the resource may exceed the 5 MB size limit."
+
+Conceived by Romuald Czlonkowski - https://www.aiadvisors.pl/en
+
 ## [2.34.2] - 2026-02-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.34.2",
+  "version": "2.34.3",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/mcp/ui/app-configs.ts
+++ b/src/mcp/ui/app-configs.ts
@@ -6,7 +6,7 @@ export const UI_APP_CONFIGS: UIAppConfig[] = [
     displayName: 'Operation Result',
     description: 'Visual summary of workflow operations (create, update, delete, test)',
     uri: 'ui://n8n-mcp/operation-result',
-    mimeType: 'text/html',
+    mimeType: 'text/html;profile=mcp-app',
     toolPatterns: [
       'n8n_create_workflow',
       'n8n_update_full_workflow',
@@ -22,7 +22,7 @@ export const UI_APP_CONFIGS: UIAppConfig[] = [
     displayName: 'Validation Summary',
     description: 'Visual summary of node and workflow validation results',
     uri: 'ui://n8n-mcp/validation-summary',
-    mimeType: 'text/html',
+    mimeType: 'text/html;profile=mcp-app',
     toolPatterns: [
       'validate_node',
       'validate_workflow',

--- a/tests/unit/mcp/ui/app-configs.test.ts
+++ b/tests/unit/mcp/ui/app-configs.test.ts
@@ -65,9 +65,9 @@ describe('UI_APP_CONFIGS', () => {
     }
   });
 
-  it('should have consistent mimeType of text/html', () => {
+  it('should have consistent mimeType of text/html;profile=mcp-app', () => {
     for (const config of UI_APP_CONFIGS) {
-      expect(config.mimeType).toBe('text/html');
+      expect(config.mimeType).toBe('text/html;profile=mcp-app');
     }
   });
 


### PR DESCRIPTION
## Summary

### Commit 1: Fix MIME type
- Changed resource MIME type from `text/html` to `text/html;profile=mcp-app` per the `RESOURCE_MIME_TYPE` constant from `@modelcontextprotocol/ext-apps`
- Without the `profile=mcp-app` parameter, Claude fails with "Failed to load MCP App: the resource may exceed the 5 MB size limit"

### Commit 2: Fix blank UI rendering
- Rewrote `useToolData` hook to use the official `useApp` hook from `@modelcontextprotocol/ext-apps/react` instead of manually managing `App` lifecycle
- Proper initialization handshake with host via `appInfo` and `capabilities`
- Handlers registered via `onAppCreated` callback (before `connect()`) to avoid race conditions
- Removed `app.close()` on unmount which caused issues with React Strict Mode
- Added visible error and connection states with inline colors for debugging

### Version bump
- 2.34.2 → 2.34.4

## Test plan

- [x] `npm run build` — compiles successfully
- [x] `cd ui-apps && npm run build` — UI apps build successfully
- [x] `npx vitest run tests/unit/mcp/ui/` — all 61 tests pass
- [ ] Deploy to staging, call `validate_node` — verify UI renders (or shows visible error/connection state)
- [ ] Deploy to staging, call `n8n_create_workflow` — verify UI renders

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)