### PR TITLE
fix: use official ext-apps useApp hook to fix blank MCP App rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.34.4] - 2026-02-07
+
+### Fixed
+
+- **MCP Apps: Fix blank UI rendering in Claude**: Rewrote `useToolData` hook to use the official `useApp` hook from `@modelcontextprotocol/ext-apps/react` instead of manually managing `App` lifecycle
+  - Proper initialization handshake with host via `appInfo` and `capabilities`
+  - Handlers registered via `onAppCreated` callback (before `connect()`) to avoid race conditions
+  - Removed `app.close()` on unmount which caused issues with React Strict Mode
+  - Added visible error and connection states with inline colors for debugging
+
+Conceived by Romuald Czlonkowski - https://www.aiadvisors.pl/en
+
 ## [2.34.3] - 2026-02-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.34.3",
+  "version": "2.34.4",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/ui-apps/src/apps/operation-result/App.tsx
+++ b/ui-apps/src/apps/operation-result/App.tsx
@@ -5,10 +5,18 @@ import { useToolData } from '@shared/hooks/useToolData';
 import type { OperationResultData } from '@shared/types';
 
 export default function App() {
-  const data = useToolData<OperationResultData>();
+  const { data, error, isConnected } = useToolData<OperationResultData>();
+
+  if (error) {
+    return <div style={{ padding: '16px', color: '#ef4444' }}>Error: {error}</div>;
+  }
+
+  if (!isConnected) {
+    return <div style={{ padding: '16px', color: '#9ca3af' }}>Connecting...</div>;
+  }
 
   if (!data) {
-    return <div style={{ padding: '16px', color: 'var(--n8n-text-muted)' }}>Loading...</div>;
+    return <div style={{ padding: '16px', color: '#9ca3af' }}>Waiting for data...</div>;
   }
 
   const isSuccess = data.status === 'success';

--- a/ui-apps/src/apps/validation-summary/App.tsx
+++ b/ui-apps/src/apps/validation-summary/App.tsx
@@ -5,10 +5,18 @@ import { useToolData } from '@shared/hooks/useToolData';
 import type { ValidationSummaryData } from '@shared/types';
 
 export default function App() {
-  const data = useToolData<ValidationSummaryData>();
+  const { data, error, isConnected } = useToolData<ValidationSummaryData>();
+
+  if (error) {
+    return <div style={{ padding: '16px', color: '#ef4444' }}>Error: {error}</div>;
+  }
+
+  if (!isConnected) {
+    return <div style={{ padding: '16px', color: '#9ca3af' }}>Connecting...</div>;
+  }
 
   if (!data) {
-    return <div style={{ padding: '16px', color: 'var(--n8n-text-muted)' }}>Loading...</div>;
+    return <div style={{ padding: '16px', color: '#9ca3af' }}>Waiting for data...</div>;
   }
 
   return (


### PR DESCRIPTION
## Summary

- Rewrote `useToolData` hook to use the official `useApp` hook from `@modelcontextprotocol/ext-apps/react` instead of manually managing `App` lifecycle
- Proper initialization handshake with host via `appInfo` and `capabilities`
- Handlers registered via `onAppCreated` callback (before `connect()`) to avoid race conditions where the host sends tool result before the handler is ready
- Removed `app.close()` on unmount which caused issues with React Strict Mode (ext-apps SDK explicitly warns against this)
- Added visible error and connection states (`Error:`, `Connecting...`, `Waiting for data...`) with inline colors for debugging
- Bumped version to 2.34.4

## Test plan

- [x] `npm run build` — TypeScript compiles
- [x] `cd ui-apps && npm run build` — UI apps build (587KB each)
- [x] `npx vitest run tests/unit/mcp/ui/` — all 61 tests pass
- [ ] Deploy to staging, call `validate_node` — verify UI renders or shows visible state
- [ ] Deploy to staging, call `n8n_create_workflow` — verify UI renders or shows visible state

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)