### PR TITLE
fix: disable MCP Apps that don't render in Claude.ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.35.2] - 2026-02-09
+
+### Changed
+
+- **MCP Apps: Disable non-rendering apps in Claude.ai**: Disabled 3 MCP Apps (workflow-list, execution-history, health-dashboard) that render as collapsed accordions in Claude.ai, and removed `n8n_deploy_template` tool mapping which renders blank content. The server sets `_meta` correctly on the wire but the Claude.ai host ignores it for these tools. The 2 working apps (operation-result for 6 tools, validation-summary for 3 tools) remain active. Disabled apps can be re-enabled once the host-side issue is resolved.
+
+Conceived by Romuald Czlonkowski - https://www.aiadvisors.pl/en
+
 ## [2.35.1] - 2026-02-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.35.1",
+  "version": "2.35.2",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/mcp/ui/app-configs.ts
+++ b/src/mcp/ui/app-configs.ts
@@ -14,7 +14,7 @@ export const UI_APP_CONFIGS: UIAppConfig[] = [
       'n8n_delete_workflow',
       'n8n_test_workflow',
       'n8n_autofix_workflow',
-      'n8n_deploy_template',
+      // n8n_deploy_template disabled: Claude.ai renders blank content for this tool
     ],
   },
   {
@@ -29,34 +29,8 @@ export const UI_APP_CONFIGS: UIAppConfig[] = [
       'n8n_validate_workflow',
     ],
   },
-  {
-    id: 'workflow-list',
-    displayName: 'Workflow List',
-    description: 'Compact table of workflows with status, tags, and metadata',
-    uri: 'ui://n8n-mcp/workflow-list',
-    mimeType: 'text/html;profile=mcp-app',
-    toolPatterns: [
-      'n8n_list_workflows',
-    ],
-  },
-  {
-    id: 'execution-history',
-    displayName: 'Execution History',
-    description: 'Execution history table with status summary bar',
-    uri: 'ui://n8n-mcp/execution-history',
-    mimeType: 'text/html;profile=mcp-app',
-    toolPatterns: [
-      'n8n_executions',
-    ],
-  },
-  {
-    id: 'health-dashboard',
-    displayName: 'Health Dashboard',
-    description: 'Connection status, versions, and performance metrics',
-    uri: 'ui://n8n-mcp/health-dashboard',
-    mimeType: 'text/html;profile=mcp-app',
-    toolPatterns: [
-      'n8n_health_check',
-    ],
-  },
+  // workflow-list, execution-history, health-dashboard disabled:
+  // Claude.ai does not render these apps (shows collapsed accordions).
+  // The server sets _meta correctly on the wire but the host ignores it.
+  // Re-enable once the host-side issue is resolved.
 ];

--- a/tests/unit/mcp/ui/app-configs.test.ts
+++ b/tests/unit/mcp/ui/app-configs.test.ts
@@ -86,7 +86,7 @@ describe('UI_APP_CONFIGS', () => {
     expect(config!.toolPatterns).toContain('n8n_update_full_workflow');
     expect(config!.toolPatterns).toContain('n8n_delete_workflow');
     expect(config!.toolPatterns).toContain('n8n_test_workflow');
-    expect(config!.toolPatterns).toContain('n8n_deploy_template');
+    expect(config!.toolPatterns).not.toContain('n8n_deploy_template');
   });
 
   it('should contain the validation-summary config', () => {
@@ -98,29 +98,14 @@ describe('UI_APP_CONFIGS', () => {
     expect(config!.toolPatterns).toContain('n8n_validate_workflow');
   });
 
-  it('should have exactly 5 configs', () => {
-    expect(UI_APP_CONFIGS.length).toBe(5);
+  it('should have exactly 2 configs', () => {
+    expect(UI_APP_CONFIGS.length).toBe(2);
   });
 
-  it('should contain the workflow-list config', () => {
-    const config = UI_APP_CONFIGS.find(c => c.id === 'workflow-list');
-    expect(config).toBeDefined();
-    expect(config!.displayName).toBe('Workflow List');
-    expect(config!.toolPatterns).toContain('n8n_list_workflows');
-  });
-
-  it('should contain the execution-history config', () => {
-    const config = UI_APP_CONFIGS.find(c => c.id === 'execution-history');
-    expect(config).toBeDefined();
-    expect(config!.displayName).toBe('Execution History');
-    expect(config!.toolPatterns).toContain('n8n_executions');
-  });
-
-  it('should contain the health-dashboard config', () => {
-    const config = UI_APP_CONFIGS.find(c => c.id === 'health-dashboard');
-    expect(config).toBeDefined();
-    expect(config!.displayName).toBe('Health Dashboard');
-    expect(config!.toolPatterns).toContain('n8n_health_check');
+  it('should not contain disabled apps', () => {
+    expect(UI_APP_CONFIGS.find(c => c.id === 'workflow-list')).toBeUndefined();
+    expect(UI_APP_CONFIGS.find(c => c.id === 'execution-history')).toBeUndefined();
+    expect(UI_APP_CONFIGS.find(c => c.id === 'health-dashboard')).toBeUndefined();
   });
 
   it('should have IDs that are valid URI path segments (no spaces or special chars)', () => {

--- a/tests/unit/mcp/ui/registry.test.ts
+++ b/tests/unit/mcp/ui/registry.test.ts
@@ -187,8 +187,11 @@ describe('UIAppRegistry', () => {
         expect(UIAppRegistry.getAppForTool('n8n_autofix_workflow')!.config.id).toBe('operation-result');
       });
 
-      it('should map n8n_deploy_template to operation-result', () => {
-        expect(UIAppRegistry.getAppForTool('n8n_deploy_template')!.config.id).toBe('operation-result');
+      it('should not map disabled tools', () => {
+        expect(UIAppRegistry.getAppForTool('n8n_deploy_template')).toBeNull();
+        expect(UIAppRegistry.getAppForTool('n8n_list_workflows')).toBeNull();
+        expect(UIAppRegistry.getAppForTool('n8n_executions')).toBeNull();
+        expect(UIAppRegistry.getAppForTool('n8n_health_check')).toBeNull();
       });
 
       it('should map validate_node to validation-summary', () => {


### PR DESCRIPTION
## Summary

- Disabled 3 MCP Apps (workflow-list, execution-history, health-dashboard) that render as collapsed accordions in Claude.ai
- Removed `n8n_deploy_template` tool mapping which renders blank content
- The server sets `_meta` correctly on the wire but the Claude.ai host ignores it for these tools
- 2 working apps remain active: operation-result (6 tools) and validation-summary (3 tools)
- Disabled apps can be re-enabled once the host-side rendering issue is resolved

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm test -- tests/unit/mcp/ui/` — all 62 UI tests pass
- [x] Wire format verified: disabled tools no longer have `_meta` set
- [ ] Verify in Claude.ai that operation-result and validation-summary still render correctly

Conceived by Romuald Czlonkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)