### PR TITLE
fix(mcp-http): keep streamable sessions alive on GET

### DIFF
--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -1065,6 +1065,9 @@ export class SingleSessionHTTPServer {
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
       const existingTransport = sessionId ? this.transports[sessionId] : undefined;
       if (existingTransport && existingTransport instanceof StreamableHTTPServerTransport) {
+        // Refresh lastAccess so the idle-session reaper does not prune a client
+        // that is holding a long-lived GET stream without POST.
+        this.updateSessionAccess(sessionId!);
         // Let the StreamableHTTPServerTransport handle the GET request
         try {
           await existingTransport.handleRequest(req, res, undefined);
@@ -1111,7 +1114,19 @@ export class SingleSessionHTTPServer {
         });
         return;
       }
-      
+
+      // A stale mcp-session-id that didn't match any live StreamableHTTP
+      // transport (and isn't an SSE or n8n-mode request) gets a 404 so the
+      // client knows to reinitialize rather than spin in a reconnect loop.
+      if (sessionId && !existingTransport) {
+        res.status(404).json({
+          jsonrpc: '2.0',
+          error: { code: -32001, message: 'Session not found or expired' },
+          id: null
+        });
+        return;
+      }
+
       // Standard response for non-n8n mode
       res.json({
         description: 'n8n Documentation MCP Server',

--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -1121,7 +1121,7 @@ export class SingleSessionHTTPServer {
       if (sessionId && !existingTransport) {
         res.status(404).json({
           jsonrpc: '2.0',
-          error: { code: -32001, message: 'Session not found or expired' },
+          error: { code: -32000, message: 'Session not found or expired' },
           id: null
         });
         return;

--- a/tests/unit/http-server-session-management.test.ts
+++ b/tests/unit/http-server-session-management.test.ts
@@ -1540,4 +1540,74 @@ describe('HTTP Server Session Management', () => {
       expect(res.status).toHaveBeenCalledWith(404);
     });
   });
+
+  describe('GET /mcp keepalive and unknown-session handling', () => {
+    it('GET /mcp refreshes lastAccess for an existing StreamableHTTP session', async () => {
+      server = new SingleSessionHTTPServer();
+      await server.start();
+
+      const handler = findHandler('get', '/mcp');
+      expect(handler).toBeTruthy();
+
+      const sessionId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+      // Import the mocked StreamableHTTPServerTransport so we can create an
+      // object that passes the instanceof check inside the GET handler.
+      const { StreamableHTTPServerTransport } = await import(
+        '@modelcontextprotocol/sdk/server/streamableHttp.js'
+      );
+      const transport = {
+        handleRequest: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+        sessionId
+      };
+      // Make the plain object satisfy `instanceof StreamableHTTPServerTransport`
+      // so the handler enters the keepalive branch.
+      Object.setPrototypeOf(transport, (StreamableHTTPServerTransport as any).prototype);
+
+      const oldDate = new Date(Date.now() - 60_000);
+      (server as any).transports[sessionId] = transport;
+      (server as any).sessionMetadata[sessionId] = {
+        lastAccess: oldDate,
+        createdAt: new Date(Date.now() - 120_000)
+      };
+
+      const { req, res } = createMockReqRes();
+      req.headers = {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        'mcp-session-id': sessionId
+      };
+
+      await handler(req, res);
+
+      expect(transport.handleRequest).toHaveBeenCalled();
+      // lastAccess must be newer than before the GET — the keepalive fired.
+      expect((server as any).sessionMetadata[sessionId].lastAccess.getTime()).toBeGreaterThan(
+        oldDate.getTime()
+      );
+    });
+
+    it('GET /mcp returns 404 for a stale session ID (non-SSE, non-n8n)', async () => {
+      server = new SingleSessionHTTPServer();
+      await server.start();
+
+      const handler = findHandler('get', '/mcp');
+      expect(handler).toBeTruthy();
+
+      const { req, res } = createMockReqRes();
+      req.headers = {
+        authorization: `Bearer ${TEST_AUTH_TOKEN}`,
+        'mcp-session-id': 'stale-session-that-does-not-exist'
+      };
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({ message: 'Session not found or expired' })
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Keep StreamableHTTP sessions alive by refreshing access time on GET /mcp when a session ID is provided.
- Return 404 for missing StreamableHTTP sessions to avoid SSE fallback and session churn.
- Reduces repeated reconnect loops observed with MCP client tools.

## Reproduction
- Start the MCP server in HTTP (streamable) mode.
- Connect from an MCP client(e.g. n8n AI Agent MCP Client) that uses StreamableHTTP.
- Wait 5–10 minutes to confirm the session does not churn.
- Observe repeated GET /mcp calls and frequent session churn.
