### PR TITLE
fix: use correct n8n operator names in unary operator detection

### DIFF
--- a/src/mcp/handlers-workflow-diff.ts
+++ b/src/mcp/handlers-workflow-diff.ts
@@ -236,7 +236,7 @@ export async function handleUpdatePartialWorkflow(
         if (errorTypes.has('operator_issues')) {
           recoverySteps.push('Operator structure issue detected. Use validate_node_operation to check specific nodes.');
           recoverySteps.push('Binary operators (equals, contains, greaterThan, etc.) must NOT have singleValue:true');
-          recoverySteps.push('Unary operators (isEmpty, isNotEmpty, true, false) REQUIRE singleValue:true');
+          recoverySteps.push('Unary operators (exists, notExists, empty, notEmpty, true, false) REQUIRE singleValue:true');
         }
         if (errorTypes.has('connection_issues')) {
           recoverySteps.push('Connection validation failed. Check all node connections reference existing nodes.');

--- a/src/mcp/tool-docs/workflow_management/n8n-update-partial-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-update-partial-workflow.ts
@@ -115,8 +115,8 @@ When ANY workflow update is made, ALL nodes in the workflow are automatically sa
 
 1. **Operator Structure Fixes**:
    - Binary operators (equals, contains, greaterThan, etc.) automatically have \`singleValue\` removed
-   - Unary operators (isEmpty, isNotEmpty, true, false) automatically get \`singleValue: true\` added
-   - Invalid operator structures (e.g., \`{type: "isNotEmpty"}\`) are corrected to \`{type: "boolean", operation: "isNotEmpty"}\`
+   - Unary operators (exists, notExists, empty, notEmpty, true, false) automatically get \`singleValue: true\` added
+   - Invalid operator structures (e.g., \`{type: "notEmpty"}\`) are corrected to \`{type: "boolean", operation: "notEmpty"}\`
 
 2. **Missing Metadata Added**:
    - IF nodes with conditions get complete \`conditions.options\` structure if missing
@@ -403,7 +403,7 @@ n8n_update_partial_workflow({
       '**CRITICAL**: For Switch nodes, ALWAYS use case=N instead of sourceIndex. Using same sourceIndex for multiple connections will put them on the same case output.',
       'cleanStaleConnections removes ALL broken connections - cannot be selective',
       'replaceConnections overwrites entire connections object - all previous connections lost',
-      '**Auto-sanitization behavior**: Binary operators (equals, contains) automatically have singleValue removed; unary operators (isEmpty, isNotEmpty) automatically get singleValue:true added',
+      '**Auto-sanitization behavior**: Binary operators (equals, contains) automatically have singleValue removed; unary operators (exists, notExists, empty, notEmpty, true, false) automatically get singleValue:true added',
       '**Auto-sanitization runs on ALL nodes**: When ANY update is made, ALL nodes in the workflow are sanitized (not just modified ones)',
       '**Auto-sanitization cannot fix everything**: It fixes operator structures and missing metadata, but cannot fix broken connections or branch mismatches',
       '**Corrupted workflows beyond repair**: Workflows in paradoxical states (API returns corrupt, API rejects updates) cannot be fixed via API - must be recreated',

--- a/src/services/n8n-validation.ts
+++ b/src/services/n8n-validation.ts
@@ -595,13 +595,13 @@ export function validateOperatorStructure(operator: any, path: string): string[]
   if (!operator.operation) {
     errors.push(
       `${path}: missing required field "operation". ` +
-      'Operation specifies the comparison type (e.g., "equals", "contains", "isNotEmpty")'
+      'Operation specifies the comparison type (e.g., "equals", "contains", "notEmpty")'
     );
   }
 
   // Check singleValue based on operator type
   if (operator.operation) {
-    const unaryOperators = ['isEmpty', 'isNotEmpty', 'true', 'false', 'isNumeric'];
+    const unaryOperators = ['exists', 'notExists', 'empty', 'notEmpty', 'true', 'false'];
     const isUnary = unaryOperators.includes(operator.operation);
 
     if (isUnary) {
@@ -617,7 +617,7 @@ export function validateOperatorStructure(operator: any, path: string): string[]
       if (operator.singleValue === true) {
         errors.push(
           `${path}: binary operator "${operator.operation}" should not have "singleValue: true". ` +
-          'Only unary operators (isEmpty, isNotEmpty, true, false, isNumeric) need this property.'
+          'Only unary operators (exists, notExists, empty, notEmpty, true, false) need this property.'
         );
       }
     }

--- a/src/services/node-sanitizer.ts
+++ b/src/services/node-sanitizer.ts
@@ -209,13 +209,13 @@ function isOperationName(value: string): boolean {
  */
 function inferDataType(operation: string): string {
   // Boolean operations
-  const booleanOps = ['true', 'false', 'isEmpty', 'isNotEmpty'];
+  const booleanOps = ['true', 'false', 'exists', 'notExists', 'empty', 'notEmpty'];
   if (booleanOps.includes(operation)) {
     return 'boolean';
   }
 
   // Number operations
-  const numberOps = ['isNumeric', 'gt', 'gte', 'lt', 'lte'];
+  const numberOps = ['gt', 'gte', 'lt', 'lte'];
   if (numberOps.some(op => operation.includes(op))) {
     return 'number';
   }
@@ -235,11 +235,12 @@ function inferDataType(operation: string): string {
  */
 function isUnaryOperator(operation: string): boolean {
   const unaryOps = [
-    'isEmpty',
-    'isNotEmpty',
+    'exists',
+    'notExists',
+    'empty',
+    'notEmpty',
     'true',
-    'false',
-    'isNumeric'
+    'false'
   ];
   return unaryOps.includes(operation);
 }

--- a/tests/unit/services/node-sanitizer.test.ts
+++ b/tests/unit/services/node-sanitizer.test.ts
@@ -25,7 +25,7 @@ describe('Node Sanitizer', () => {
                 rightValue: '',
                 operator: {
                   type: 'string',
-                  operation: 'isNotEmpty'
+                  operation: 'notEmpty'
                 }
               }
             ]
@@ -91,7 +91,7 @@ describe('Node Sanitizer', () => {
                 leftValue: '={{ $json.value }}',
                 rightValue: '',
                 operator: {
-                  type: 'isNotEmpty' // WRONG: type should be data type, not operation
+                  type: 'notEmpty' // WRONG: type should be data type, not operation
                 }
               }
             ]
@@ -103,39 +103,50 @@ describe('Node Sanitizer', () => {
       const condition = (sanitized.parameters.conditions as any).conditions[0];
 
       // Should fix operator structure
-      expect(condition.operator.type).toBe('boolean'); // Inferred data type (isEmpty/isNotEmpty are boolean ops)
-      expect(condition.operator.operation).toBe('isNotEmpty'); // Moved to operation field
+      expect(condition.operator.type).toBe('boolean'); // Inferred data type (empty/notEmpty are boolean ops)
+      expect(condition.operator.operation).toBe('notEmpty'); // Moved to operation field
     });
 
     it('should add singleValue for unary operators', () => {
-      const node: WorkflowNode = {
-        id: 'test-if-unary',
-        name: 'IF Unary',
-        type: 'n8n-nodes-base.if',
-        typeVersion: 2.2,
-        position: [0, 0],
-        parameters: {
-          conditions: {
-            conditions: [
-              {
-                id: 'condition1',
-                leftValue: '={{ $json.value }}',
-                rightValue: '',
-                operator: {
-                  type: 'string',
-                  operation: 'isNotEmpty'
-                  // Missing singleValue
+      const unaryOps = [
+        { type: 'string', operation: 'notEmpty' },
+        { type: 'string', operation: 'empty' },
+        { type: 'string', operation: 'exists' },
+        { type: 'string', operation: 'notExists' },
+        { type: 'boolean', operation: 'true' },
+        { type: 'boolean', operation: 'false' },
+      ];
+
+      for (const op of unaryOps) {
+        const node: WorkflowNode = {
+          id: 'test-if-unary',
+          name: 'IF Unary',
+          type: 'n8n-nodes-base.if',
+          typeVersion: 2.2,
+          position: [0, 0],
+          parameters: {
+            conditions: {
+              conditions: [
+                {
+                  id: 'condition1',
+                  leftValue: '={{ $json.value }}',
+                  rightValue: '',
+                  operator: {
+                    type: op.type,
+                    operation: op.operation
+                    // Missing singleValue
+                  }
                 }
-              }
-            ]
+              ]
+            }
           }
-        }
-      };
+        };
 
-      const sanitized = sanitizeNode(node);
-      const condition = (sanitized.parameters.conditions as any).conditions[0];
+        const sanitized = sanitizeNode(node);
+        const condition = (sanitized.parameters.conditions as any).conditions[0];
 
-      expect(condition.operator.singleValue).toBe(true);
+        expect(condition.operator.singleValue).toBe(true);
+      }
     });
 
     it('should sanitize Switch v3.2 node rules', () => {
@@ -334,8 +345,8 @@ describe('Node Sanitizer', () => {
                 leftValue: '={{ $json.value }}',
                 rightValue: '',
                 operator: {
-                  type: 'isNotEmpty', // WRONG: operation name, not data type
-                  operation: 'isNotEmpty'
+                  type: 'notEmpty', // WRONG: operation name, not data type
+                  operation: 'notEmpty'
                 }
               }
             ]
@@ -345,7 +356,7 @@ describe('Node Sanitizer', () => {
 
       const issues = validateNodeMetadata(node);
 
-      expect(issues.some(issue => issue.includes('invalid type "isNotEmpty"'))).toBe(true);
+      expect(issues.some(issue => issue.includes('invalid type "notEmpty"'))).toBe(true);
     });
 
     it('should detect missing singleValue for unary operators', () => {
@@ -370,7 +381,7 @@ describe('Node Sanitizer', () => {
                 rightValue: '',
                 operator: {
                   type: 'string',
-                  operation: 'isNotEmpty'
+                  operation: 'notEmpty'
                   // Missing singleValue: true
                 }
               }
@@ -444,7 +455,7 @@ describe('Node Sanitizer', () => {
                 rightValue: '',
                 operator: {
                   type: 'string',
-                  operation: 'isNotEmpty',
+                  operation: 'notEmpty',
                   singleValue: true
                 }
               }


### PR DESCRIPTION
## Summary

Fixes #592

The auto-sanitization system uses incorrect operator names (`isEmpty`, `isNotEmpty`, `isNumeric`) in `isUnaryOperator()` and `validateOperatorStructure()`. These operator names don't exist in n8n — the actual names are `empty`, `notEmpty`, `exists`, and `notExists`.

This causes two problems:
- **Silent data corruption**: `n8n_update_partial_workflow` strips `singleValue: true` from all `empty`/`notEmpty`/`exists`/`notExists` operators on every update (even unrelated ones like renaming a node), because it doesn't recognize them as unary
- **False rejections**: `n8n_update_full_workflow` and `n8n_create_workflow` reject valid IF v2.2+ configurations with: `binary operator "notEmpty" should not have "singleValue: true"`

Affected workflows crash at runtime with: `Wrong type: '' is a string but was expecting an object`

## Root Cause

Three hardcoded lists contained wrong operator names:

| Location | Before (wrong) | After (correct) |
|---|---|---|
| `node-sanitizer.ts` → `isUnaryOperator()` | `isEmpty, isNotEmpty, true, false, isNumeric` | `exists, notExists, empty, notEmpty, true, false` |
| `node-sanitizer.ts` → `inferDataType()` | `true, false, isEmpty, isNotEmpty` | `true, false, exists, notExists, empty, notEmpty` |
| `n8n-validation.ts` → `validateOperatorStructure()` | `isEmpty, isNotEmpty, true, false, isNumeric` | `exists, notExists, empty, notEmpty, true, false` |

`isNumeric` was also removed — it doesn't exist as an n8n filter operation.

Reference: [n8n source — FilterConditions constants](https://github.com/n8n-io/n8n/blob/4a2c06ea54c9501ea242866e78cf38dcb692b735/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/constants.ts#L252-L275)

## Changes

- **`src/services/node-sanitizer.ts`**: Fix `isUnaryOperator()` and `inferDataType()` to use correct n8n operator names; remove non-existent `isNumeric` from `numberOps`
- **`src/services/n8n-validation.ts`**: Fix `validateOperatorStructure()` unary operator list and error messages
- **`src/mcp/handlers-workflow-diff.ts`**: Update recovery guidance message
- **`src/mcp/tool-docs/workflow_management/n8n-update-partial-workflow.ts`**: Update auto-sanitization documentation
- **`tests/unit/services/node-sanitizer.test.ts`**: Update all operator name references; add test coverage for all 6 unary operators (`empty`, `notEmpty`, `exists`, `notExists`, `true`, `false`)

## Test plan

- [x] All 4514 unit tests pass (157 test files)
- [x] Verified `sanitizeNode()` correctly adds `singleValue: true` for all 6 unary operators
- [x] Verified `sanitizeNode()` correctly removes `singleValue` from binary operators like `equals`
- [x] Verified against live n8n instance: buggy MCP rejects valid IF v2.2+ nodes with `notEmpty` + `singleValue: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)