### PR TITLE
fix: remove debug console.logs and use logger in library modules

### DIFF
--- a/src/loaders/node-loader.ts
+++ b/src/loaders/node-loader.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { logger } from '../utils/logger';
 
 export interface LoadedNode {
   packageName: string;
@@ -17,14 +18,14 @@ export class N8nNodeLoader {
     
     for (const pkg of this.CORE_PACKAGES) {
       try {
-        console.log(`\n📦 Loading package: ${pkg.name} from ${pkg.path}`);
+        logger.info(`Loading package: ${pkg.name} from ${pkg.path}`);
         // Use the path property to locate the package
         const packageJson = require(`${pkg.path}/package.json`);
-        console.log(`  Found ${Object.keys(packageJson.n8n?.nodes || {}).length} nodes in package.json`);
+        logger.info(`Found ${Object.keys(packageJson.n8n?.nodes || {}).length} nodes in package.json`);
         const nodes = await this.loadPackageNodes(pkg.name, pkg.path, packageJson);
         results.push(...nodes);
       } catch (error) {
-        console.error(`Failed to load ${pkg.name}:`, error);
+        logger.error(`Failed to load ${pkg.name}: ${error}`);
       }
     }
     
@@ -73,12 +74,12 @@ export class N8nNodeLoader {
           const NodeClass = nodeModule.default || nodeModule[nodeName] || Object.values(nodeModule)[0];
           if (NodeClass) {
             nodes.push({ packageName, nodeName, NodeClass });
-            console.log(`  ✓ Loaded ${nodeName} from ${packageName}`);
+            logger.debug(`Loaded ${nodeName} from ${packageName}`);
           } else {
-            console.warn(`  ⚠ No valid export found for ${nodeName} in ${packageName}`);
+            logger.warn(`No valid export found for ${nodeName} in ${packageName}`);
           }
         } catch (error) {
-          console.error(`  ✗ Failed to load node from ${packageName}/${nodePath}:`, (error as Error).message);
+          logger.error(`Failed to load node from ${packageName}/${nodePath}: ${(error as Error).message}`);
         }
       }
     } else {
@@ -92,12 +93,12 @@ export class N8nNodeLoader {
           const NodeClass = nodeModule.default || nodeModule[nodeName] || Object.values(nodeModule)[0];
           if (NodeClass) {
             nodes.push({ packageName, nodeName, NodeClass });
-            console.log(`  ✓ Loaded ${nodeName} from ${packageName}`);
+            logger.debug(`Loaded ${nodeName} from ${packageName}`);
           } else {
-            console.warn(`  ⚠ No valid export found for ${nodeName} in ${packageName}`);
+            logger.warn(`No valid export found for ${nodeName} in ${packageName}`);
           }
         } catch (error) {
-          console.error(`  ✗ Failed to load node ${nodeName} from ${packageName}:`, (error as Error).message);
+          logger.error(`Failed to load node ${nodeName} from ${packageName}: ${(error as Error).message}`);
         }
       }
     }

--- a/src/mappers/docs-mapper.ts
+++ b/src/mappers/docs-mapper.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { logger } from '../utils/logger';
 
 export class DocsMapper {
   private docsPath = path.join(process.cwd(), 'n8n-docs');
@@ -24,11 +25,11 @@ export class DocsMapper {
     // Extract node name
     const nodeName = fixedType.split('.').pop()?.toLowerCase();
     if (!nodeName) {
-      console.log(`⚠️  Could not extract node name from: ${nodeType}`);
+      logger.warn(`Could not extract node name from: ${nodeType}`);
       return null;
     }
     
-    console.log(`📄 Looking for docs for: ${nodeType} -> ${nodeName}`);
+    logger.debug(`Looking for docs for: ${nodeType} -> ${nodeName}`);
     
     // Try different documentation paths - both files and directories
     const possiblePaths = [
@@ -51,7 +52,7 @@ export class DocsMapper {
       try {
         const fullPath = path.join(this.docsPath, relativePath);
         let content = await fs.readFile(fullPath, 'utf-8');
-        console.log(`  ✓ Found docs at: ${relativePath}`);
+        logger.debug(`Found docs at: ${relativePath}`);
         
         // Inject special guidance for loop nodes
         content = this.enhanceLoopNodeDocumentation(nodeType, content);
@@ -63,7 +64,7 @@ export class DocsMapper {
       }
     }
     
-    console.log(`  ✗ No docs found for ${nodeName}`);
+    logger.debug(`No docs found for ${nodeName}`);
     return null;
   }
 

--- a/src/services/config-validator.ts
+++ b/src/services/config-validator.ts
@@ -892,12 +892,6 @@ export class ConfigValidator {
     
     // Check return format for Python
     if (language === 'python' && hasReturn) {
-      // DEBUG: Log to see if we're entering this block
-      if (code.includes('result = {"data": "value"}')) {
-        console.log('DEBUG: Processing Python code with result variable');
-        console.log('DEBUG: Language:', language);
-        console.log('DEBUG: Has return:', hasReturn);
-      }
       // Check for common incorrect patterns
       if (/return\s+items\s*$/.test(code) && !code.includes('json') && !code.includes('dict')) {
         warnings.push({


### PR DESCRIPTION
## Summary

Remove leftover debug `console.log` statements and replace bare `console.log`/`warn`/`error` calls with the project's `logger` utility in library modules.

## Problem

- `config-validator.ts` contained 3 leftover `console.log('DEBUG: ...')` statements inside a conditional block. In stdio mode, any direct `console.log` output corrupts the JSON-RPC transport stream.
- `docs-mapper.ts` and `node-loader.ts` used bare `console.log`/`warn`/`error` for operational logging instead of the project's `logger` utility, which properly suppresses output in stdio mode via the `MCP_MODE` environment variable check.

## Changes

| File | Change |
|------|--------|
| `src/services/config-validator.ts` | Removed 3 `console.log('DEBUG: ...')` statements and their containing conditional block |
| `src/mappers/docs-mapper.ts` | Replaced 4 `console.log` calls with `logger.warn`/`logger.debug` |
| `src/loaders/node-loader.ts` | Replaced 7 `console.log`/`warn`/`error` calls with `logger.info`/`debug`/`warn`/`error` |

## Testing

- The `logger` utility is already well-tested and used throughout the codebase (18+ existing imports)
- In stdio mode: logger suppresses all output, preventing JSON-RPC corruption
- In HTTP mode: logger suppresses output during active MCP requests
- In rebuild/validate scripts: logger outputs normally since `MCP_MODE` is not set
