### PR TITLE
fix: add null safety guards in config-manager and cache-utils

### DIFF
--- a/src/telemetry/config-manager.ts
+++ b/src/telemetry/config-manager.ts
@@ -200,7 +200,14 @@ export class TelemetryConfigManager {
 
     try {
       const rawConfig = readFileSync(this.configPath, 'utf-8');
-      this.config = JSON.parse(rawConfig);
+      const parsed = JSON.parse(rawConfig);
+
+      // Guard against malformed config (e.g. null is valid JSON)
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error('Telemetry config is not a valid object');
+      }
+
+      this.config = parsed;
 
       // Ensure userId exists (for upgrades from older versions)
       if (!this.config!.userId) {

--- a/src/utils/cache-utils.ts
+++ b/src/utils/cache-utils.ts
@@ -349,7 +349,7 @@ export async function withRetry<T>(
   config: RetryConfig = DEFAULT_RETRY_CONFIG,
   context?: string
 ): Promise<T> {
-  let lastError: Error;
+  let lastError: Error = new Error('No retry attempts were made');
 
   for (let attempt = 0; attempt < config.maxAttempts; attempt++) {
     try {


### PR DESCRIPTION
Two null safety fixes:

**config-manager.ts**: After JSON.parse, the parsed result could be `null` (valid JSON). The code immediately accesses `this.config.userId` via non-null assertion, which would throw a TypeError. Added a guard to validate the parsed value is a non-null object before assignment, falling through to defaults on invalid config.

**cache-utils.ts**: `lastError` in `withRetry()` is declared but never initialized. If called with `maxAttempts: 0`, the for-loop never executes and `lastError.message` accesses undefined. Initialized with a sentinel Error for a meaningful message.