### PR TITLE
fix: await async session removal in cleanupExpiredSessions

### DIFF
--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -147,7 +147,7 @@ export class SingleSessionHTTPServer {
   /**
    * Clean up expired sessions based on last access time
    */
-  private cleanupExpiredSessions(): void {
+  private async cleanupExpiredSessions(): Promise<void> {
     const now = Date.now();
     const expiredSessions: string[] = [];
 
@@ -170,7 +170,7 @@ export class SingleSessionHTTPServer {
 
     // Remove expired sessions
     for (const sessionId of expiredSessions) {
-      this.removeSession(sessionId, 'expired');
+      await this.removeSession(sessionId, 'expired');
     }
 
     if (expiredSessions.length > 0) {


### PR DESCRIPTION
## Problem

`cleanupExpiredSessions()` calls `removeSession()` — an async method — without awaiting it. This creates fire-and-forget promises that silently swallow errors and allow race conditions when multiple sessions expire simultaneously.

## Fix

- Changed `cleanupExpiredSessions()` from `void` to `async Promise<void>`
- Added `await` before each `removeSession()` call in the cleanup loop

This ensures each expired session is properly removed (and errors surfaced) before proceeding to the next one.

## Validation

- TypeCheck: 0 new errors
- Unit tests: all http-server tests pass (30 passed, 12 skipped)