### PR TITLE
fix: prevent context switch race and clear warning interval on shutdown

### DIFF
--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -115,6 +115,7 @@ export class SingleSessionHTTPServer {
   ) * 60 * 1000;
   private authToken: string | null = null;
   private cleanupTimer: NodeJS.Timeout | null = null;
+  private warningTimer: NodeJS.Timeout | null = null;
   
   constructor() {
     // Validate environment on construction
@@ -304,9 +305,12 @@ export class SingleSessionHTTPServer {
     // Check if there's already a switch in progress for this session
     const existingLock = this.contextSwitchLocks.get(sessionId);
     if (existingLock) {
-      // Wait for the existing switch to complete
+      // Wait for the existing switch to complete, then re-enter
+      // to perform our own switch (the previous switch may have been
+      // for a different context than what we need)
       await existingLock;
-      return;
+      // Re-enter instead of returning — our context may differ from what was just set
+      return this.switchSessionContext(sessionId, newContext);
     }
 
     // Create a promise for this switch operation
@@ -1376,7 +1380,7 @@ export class SingleSessionHTTPServer {
       
       // Start periodic warning timer if using default token
       if (isDefaultToken && !isProduction) {
-        setInterval(() => {
+        this.warningTimer = setInterval(() => {
           logger.warn('⚠️ Still using default AUTH_TOKEN - security risk!');
           if (process.env.MCP_MODE === 'http') {
             console.warn('⚠️ REMINDER: Still using default AUTH_TOKEN - please change it!');
@@ -1416,6 +1420,12 @@ export class SingleSessionHTTPServer {
       clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;
       logger.info('Session cleanup timer stopped');
+    }
+    
+    // Stop default token warning timer
+    if (this.warningTimer) {
+      clearInterval(this.warningTimer);
+      this.warningTimer = null;
     }
     
     // Close all active transports (SDK pattern)


### PR DESCRIPTION
## Problem

Two issues in the HTTP server session management:

### 1. Context Switch Race Condition (HIGH)

When concurrent HTTP requests trigger `switchSessionContext` for the same session with different contexts:

- Request A acquires the lock and begins switching
- Request B finds the lock, `await`s it, then **returns without performing its own switch**
- B's context update is silently discarded
- The session operates against A's context — B's request reads/writes to the wrong n8n instance

This is a data integrity issue in multi-tenant deployments where requests for different n8n instances can interleave on the same session.

### 2. Warning Interval Leak (LOW)

When using the default auth token in non-production, a `setInterval` (every 5 minutes) was started but the handle was never stored or cleared. On `shutdown()`, this timer continues firing, holding references to the logger and server instance, preventing garbage collection.

## Fix

1. **Context switch**: After awaiting the existing lock, re-enter `switchSessionContext` instead of returning. The re-entered call will check if the context still differs (via `JSON.stringify` comparison in `performContextSwitch`) and apply B's switch if needed. This is safe because the lock is released before re-entry.

2. **Interval leak**: Store the interval handle in `this.warningTimer` and clear it in `shutdown()` alongside the existing cleanup timer.

## Validation

- HTTP server unit tests: 30 passed, 12 skipped, 0 failures
- TypeScript compilation: only pre-existing module declaration warnings
- Changes limited to `src/http-server-single-session.ts` (13 insertions, 3 deletions)
