### PR TITLE
feat: add support for cookie-based authentication in n8n API client

### DIFF
--- a/src/config/n8n-api.ts
+++ b/src/config/n8n-api.ts
@@ -6,6 +6,8 @@ import { logger } from '../utils/logger';
 const n8nApiConfigSchema = z.object({
   N8N_API_URL: z.string().url().optional(),
   N8N_API_KEY: z.string().min(1).optional(),
+  /** Session cookie for browser-session-based authentication (alternative to N8N_API_KEY) */
+  N8N_API_COOKIE: z.string().min(1).optional(),
   N8N_API_TIMEOUT: z.coerce.number().positive().default(30000),
   N8N_API_MAX_RETRIES: z.coerce.number().positive().default(3),
 });
@@ -29,14 +31,15 @@ export function getN8nApiConfig() {
   
   const config = result.data;
   
-  // Check if both URL and API key are provided
-  if (!config.N8N_API_URL || !config.N8N_API_KEY) {
+  // Require URL and at least one credential (API key or cookie)
+  if (!config.N8N_API_URL || (!config.N8N_API_KEY && !config.N8N_API_COOKIE)) {
     return null;
   }
   
   return {
     baseUrl: config.N8N_API_URL,
     apiKey: config.N8N_API_KEY,
+    cookie: config.N8N_API_COOKIE,
     timeout: config.N8N_API_TIMEOUT,
     maxRetries: config.N8N_API_MAX_RETRIES,
   };
@@ -55,16 +58,18 @@ export function isN8nApiConfigured(): boolean {
 export function getN8nApiConfigFromContext(context: {
   n8nApiUrl?: string;
   n8nApiKey?: string;
+  n8nApiCookie?: string;
   n8nApiTimeout?: number;
   n8nApiMaxRetries?: number;
 }): N8nApiConfig | null {
-  if (!context.n8nApiUrl || !context.n8nApiKey) {
+  if (!context.n8nApiUrl || (!context.n8nApiKey && !context.n8nApiCookie)) {
     return null;
   }
 
   return {
     baseUrl: context.n8nApiUrl,
     apiKey: context.n8nApiKey,
+    cookie: context.n8nApiCookie,
     timeout: context.n8nApiTimeout ?? 30000,
     maxRetries: context.n8nApiMaxRetries ?? 3,
   };

--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -37,6 +37,8 @@ const DEFAULT_PROTOCOL_VERSION = STANDARD_PROTOCOL_VERSION;
 interface MultiTenantHeaders {
   'x-n8n-url'?: string;
   'x-n8n-key'?: string;
+  /** Session cookie for browser-session-based n8n authentication (alternative to x-n8n-key) */
+  'x-n8n-cookie'?: string;
   'x-instance-id'?: string;
   'x-session-id'?: string;
 }
@@ -68,6 +70,7 @@ function extractMultiTenantHeaders(req: express.Request): MultiTenantHeaders {
   return {
     'x-n8n-url': req.headers['x-n8n-url'] as string | undefined,
     'x-n8n-key': req.headers['x-n8n-key'] as string | undefined,
+    'x-n8n-cookie': req.headers['x-n8n-cookie'] as string | undefined,
     'x-instance-id': req.headers['x-instance-id'] as string | undefined,
     'x-session-id': req.headers['x-session-id'] as string | undefined,
   };
@@ -1260,13 +1263,15 @@ export class SingleSessionHTTPServer {
         const headers = extractMultiTenantHeaders(req);
         const hasUrl = headers['x-n8n-url'];
         const hasKey = headers['x-n8n-key'];
+        const hasCookie = headers['x-n8n-cookie'];
 
-        if (!hasUrl && !hasKey) return undefined;
+        if (!hasUrl && !hasKey && !hasCookie) return undefined;
 
         // Create context with proper type handling
         const context: InstanceContext = {
           n8nApiUrl: hasUrl || undefined,
           n8nApiKey: hasKey || undefined,
+          n8nApiCookie: hasCookie || undefined,
           instanceId: headers['x-instance-id'] || undefined,
           sessionId: headers['x-session-id'] || undefined
         };
@@ -1285,7 +1290,7 @@ export class SingleSessionHTTPServer {
           logger.warn('Invalid instance context from headers', {
             errors: validation.errors,
             hasUrl: !!hasUrl,
-            hasKey: !!hasKey
+            hasCredentials: !!(hasKey || hasCookie)
           });
           return undefined;
         }
@@ -1295,10 +1300,11 @@ export class SingleSessionHTTPServer {
 
       // Log context extraction for debugging (only if context exists)
       if (instanceContext) {
-        // Use sanitized logging for security
+        // Use sanitized logging for security — never log credential values
         logger.debug('Instance context extracted from headers', {
           hasUrl: !!instanceContext.n8nApiUrl,
-          hasKey: !!instanceContext.n8nApiKey,
+          hasCredentials: !!(instanceContext.n8nApiKey || instanceContext.n8nApiCookie),
+          authMethod: instanceContext.n8nApiKey ? 'api-key' : instanceContext.n8nApiCookie ? 'cookie' : 'none',
           instanceId: instanceContext.instanceId ? instanceContext.instanceId.substring(0, 8) + '...' : undefined,
           sessionId: instanceContext.sessionId ? instanceContext.sessionId.substring(0, 8) + '...' : undefined,
           urlDomain: instanceContext.n8nApiUrl ? new URL(instanceContext.n8nApiUrl).hostname : undefined
@@ -1550,8 +1556,8 @@ export class SingleSessionHTTPServer {
       const context = this.sessionContexts[sessionId];
 
       // Skip sessions without context - these can't be restored meaningfully
-      // (Context is required to reconnect to the correct n8n instance)
-      if (!context || !context.n8nApiUrl || !context.n8nApiKey) {
+      // (Context with URL and at least one credential is required to reconnect)
+      if (!context || !context.n8nApiUrl || (!context.n8nApiKey && !context.n8nApiCookie)) {
         logger.debug(`Skipping session ${sessionId} - missing required context`);
         continue;
       }
@@ -1566,6 +1572,7 @@ export class SingleSessionHTTPServer {
         context: {
           n8nApiUrl: context.n8nApiUrl,
           n8nApiKey: context.n8nApiKey,
+          n8nApiCookie: context.n8nApiCookie,
           instanceId: context.instanceId || sessionId, // Use sessionId as fallback
           sessionId: context.sessionId,
           metadata: context.metadata
@@ -1673,6 +1680,7 @@ export class SingleSessionHTTPServer {
         this.sessionContexts[sessionState.sessionId] = {
           n8nApiUrl: sessionState.context.n8nApiUrl,
           n8nApiKey: sessionState.context.n8nApiKey,
+          n8nApiCookie: sessionState.context.n8nApiCookie,
           instanceId: sessionState.context.instanceId,
           sessionId: sessionState.context.sessionId,
           metadata: sessionState.context.metadata

--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -151,6 +151,7 @@ interface DiagnosticResponseData {
   environment: {
     N8N_API_URL: string | null;
     N8N_API_KEY: string | null;
+    N8N_API_COOKIE: string | null;
     NODE_ENV: string;
     MCP_MODE: string;
     isDocker: boolean;
@@ -271,7 +272,7 @@ export function clearInstanceCache(): void {
 
 export function getN8nApiClient(context?: InstanceContext): N8nApiClient | null {
   // If context provided with n8n config, use instance-specific client
-  if (context?.n8nApiUrl && context?.n8nApiKey) {
+  if (context?.n8nApiUrl && (context?.n8nApiKey || context?.n8nApiCookie)) {
     // Validate context before using
     const validation = validateInstanceContext(context);
     if (!validation.valid) {
@@ -282,8 +283,10 @@ export function getN8nApiClient(context?: InstanceContext): N8nApiClient | null 
       return null;
     }
     // Create secure hash of credentials for cache key using memoization
+    // Include cookie (if any) in the hash so different cookies get different clients
+    const credential = context.n8nApiKey ?? context.n8nApiCookie ?? '';
     const cacheKey = createCacheKey(
-      `${context.n8nApiUrl}:${context.n8nApiKey}:${context.instanceId || ''}`
+      `${context.n8nApiUrl}:${credential}:${context.instanceId || ''}`
     );
 
     // Check cache first
@@ -361,9 +364,9 @@ function ensureApiConfigured(context?: InstanceContext): N8nApiClient {
   const client = getN8nApiClient(context);
   if (!client) {
     if (context?.instanceId) {
-      throw new Error(`n8n API not configured for instance ${context.instanceId}. Please provide n8nApiUrl and n8nApiKey in the instance context.`);
+      throw new Error(`n8n API not configured for instance ${context.instanceId}. Please provide n8nApiUrl and n8nApiKey or n8nApiCookie in the instance context.`);
     }
-    throw new Error('n8n API not configured. Please set N8N_API_URL and N8N_API_KEY environment variables.');
+    throw new Error('n8n API not configured. Please set N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) environment variables.');
   }
   return client;
 }
@@ -1941,6 +1944,7 @@ export async function handleDiagnostic(request: any, context?: InstanceContext):
   const envVars = {
     N8N_API_URL: process.env.N8N_API_URL || null,
     N8N_API_KEY: process.env.N8N_API_KEY ? '***configured***' : null,
+    N8N_API_COOKIE: process.env.N8N_API_COOKIE ? '***configured***' : null,
     NODE_ENV: process.env.NODE_ENV || 'production',
     MCP_MODE: mcpMode,
     isDocker,
@@ -2015,7 +2019,7 @@ export async function handleDiagnostic(request: any, context?: InstanceContext):
         enabled: apiConfigured,
         description: apiConfigured ?
           'Management tools are ENABLED - create, update, execute workflows' :
-          'Management tools are DISABLED - configure N8N_API_URL and N8N_API_KEY to enable'
+          'Management tools are DISABLED - configure N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) to enable'
       },
       totalAvailable: totalTools
     },
@@ -2071,7 +2075,7 @@ export async function handleDiagnostic(request: any, context?: InstanceContext):
         '1. Verify n8n instance is running and accessible',
         '2. Check N8N_API_URL is correct (currently: ' + apiConfig?.baseUrl + ')',
         '3. Test URL in browser: ' + apiConfig?.baseUrl + '/healthz',
-        '4. Verify N8N_API_KEY has proper permissions',
+        '4. Verify N8N_API_KEY (or N8N_API_COOKIE) has proper permissions',
         '5. Check firewall/network settings if using remote n8n',
         '6. Try running n8n_health_check again after fixes'
       ],
@@ -2121,9 +2125,10 @@ export async function handleDiagnostic(request: any, context?: InstanceContext):
       howToEnable: {
         steps: [
           '1. Get your n8n API key: [Your n8n instance]/settings/api',
+          '   (Or use a session cookie from your browser login as N8N_API_COOKIE)',
           '2. Set environment variables:',
           '   N8N_API_URL=https://your-n8n-instance.com',
-          '   N8N_API_KEY=your_api_key_here',
+          '   N8N_API_KEY=your_api_key_here  (or N8N_API_COOKIE=your_session_cookie)',
           '3. Restart the MCP server',
           '4. Run n8n_health_check with mode="diagnostic" to verify',
           '5. All 19 tools will be available!'

--- a/src/mcp/handlers-workflow-diff.ts
+++ b/src/mcp/handlers-workflow-diff.ts
@@ -122,7 +122,7 @@ export async function handleUpdatePartialWorkflow(
     if (!client) {
       return {
         success: false,
-        error: 'n8n API not configured. Please set N8N_API_URL and N8N_API_KEY environment variables.'
+        error: 'n8n API not configured. Please set N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) environment variables.'
       };
     }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -605,7 +605,7 @@ export class N8NDocumentationMCPServer {
       // 2. Instance context (multi-tenant support)
       // 3. Multi-tenant mode enabled (always show tools, runtime checks will handle auth)
       const hasEnvConfig = isN8nApiConfigured();
-      const hasInstanceConfig = !!(this.instanceContext?.n8nApiUrl && this.instanceContext?.n8nApiKey);
+      const hasInstanceConfig = !!(this.instanceContext?.n8nApiUrl && (this.instanceContext?.n8nApiKey || this.instanceContext?.n8nApiCookie));
       const isMultiTenantEnabled = process.env.ENABLE_MULTI_TENANT === 'true';
 
       const shouldIncludeManagementTools = hasEnvConfig || hasInstanceConfig || isMultiTenantEnabled;

--- a/src/mcp/tool-docs/system/n8n-diagnostic.ts
+++ b/src/mcp/tool-docs/system/n8n-diagnostic.ts
@@ -20,7 +20,7 @@ export const n8nDiagnosticDoc: ToolDocumentation = {
     description: `Comprehensive diagnostic tool for troubleshooting n8n API configuration and management tool availability.
 
 This tool performs a detailed check of:
-- Environment variable configuration (N8N_API_URL, N8N_API_KEY)
+- Environment variable configuration (N8N_API_URL, N8N_API_KEY or N8N_API_COOKIE)
 - API connectivity and authentication
 - Tool availability status
 - Common configuration issues
@@ -40,7 +40,7 @@ The diagnostic is essential when:
     returns: `Comprehensive diagnostic report containing:
 - timestamp: ISO timestamp of diagnostic run
 - environment: Enhanced environment variables
-  - N8N_API_URL, N8N_API_KEY (masked), NODE_ENV, MCP_MODE
+  - N8N_API_URL, N8N_API_KEY (masked), N8N_API_COOKIE (masked), NODE_ENV, MCP_MODE
   - isDocker: Boolean indicating if running in Docker
   - cloudPlatform: Detected cloud platform (railway/render/fly/etc.) or null
   - nodeVersion: Node.js version
@@ -68,7 +68,7 @@ The diagnostic is essential when:
       'n8n_diagnostic({verbose: false}) - Standard diagnostic without sensitive data'
     ],
     useCases: [
-      'Initial setup verification after configuring N8N_API_URL and N8N_API_KEY',
+      'Initial setup verification after configuring N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE)',
       'Troubleshooting when n8n management tools are not available',
       'Debugging API connection failures or authentication errors',
       'Verifying n8n instance compatibility and feature availability',

--- a/src/mcp/tool-docs/system/n8n-health-check.ts
+++ b/src/mcp/tool-docs/system/n8n-health-check.ts
@@ -90,7 +90,7 @@ Health checks are crucial for:
       'Use health status to implement circuit breaker patterns'
     ],
     pitfalls: [
-      'Requires N8N_API_URL and N8N_API_KEY to be configured',
+      'Requires N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) to be configured',
       'Network issues may cause false negatives',
       'Does not check individual workflow health',
       'Health endpoint might be cached - not real-time for all metrics'

--- a/src/mcp/tool-docs/system/n8n-list-available-tools.ts
+++ b/src/mcp/tool-docs/system/n8n-list-available-tools.ts
@@ -11,7 +11,7 @@ export const n8nListAvailableToolsDoc: ToolDocumentation = {
     tips: [
       'Shows only tools available with current API configuration',
       'If no n8n tools appear, run n8n_diagnostic to troubleshoot',
-      'Tool availability depends on N8N_API_URL and N8N_API_KEY being set'
+      'Tool availability depends on N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) being set'
     ]
   },
   full: {
@@ -24,7 +24,7 @@ This tool provides:
 - Dynamic availability based on API configuration
 
 The tool list is dynamic:
-- Shows 14+ management tools when N8N_API_URL and N8N_API_KEY are configured
+- Shows 14+ management tools when N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) are configured
 - Shows only documentation tools when API is not configured
 - Helps discover available functionality
 - Provides quick reference for tool names and purposes`,
@@ -63,7 +63,7 @@ The tool list is dynamic:
       'Cache results as tool list only changes with configuration'
     ],
     pitfalls: [
-      'Tool list is empty if N8N_API_URL and N8N_API_KEY are not set',
+      'Tool list is empty if N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) are not set',
       'Does not validate if tools will actually work - just shows availability',
       'Tool names must be used exactly as returned',
       'Does not show tool parameters - use tools_documentation for details'

--- a/src/mcp/tool-docs/workflow_management/n8n-autofix-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-autofix-workflow.ts
@@ -61,7 +61,7 @@ The tool uses a confidence-based system to ensure safe fixes:
 - **Medium (70-89%)**: Generally safe but review recommended
 - **Low (<70%)**: Manual review strongly recommended
 
-Requires N8N_API_URL and N8N_API_KEY environment variables to be configured.`,
+Requires N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) environment variables to be configured.`,
     parameters: {
       id: {
         type: 'string',

--- a/src/mcp/tool-docs/workflow_management/n8n-create-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-create-workflow.ts
@@ -87,7 +87,7 @@ n8n_create_workflow({
       'Test with n8n_test_workflow'
     ],
     pitfalls: [
-      '**REQUIRES N8N_API_URL and N8N_API_KEY environment variables** - tool unavailable without n8n API access',
+      '**REQUIRES N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) environment variables** - tool unavailable without n8n API access',
       'Workflows created in INACTIVE state - must activate separately',
       'Node IDs must be unique within workflow',
       'Credentials must be configured separately in n8n',

--- a/src/mcp/tool-docs/workflow_management/n8n-delete-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-delete-workflow.ts
@@ -39,7 +39,7 @@ export const n8nDeleteWorkflowDoc: ToolDocumentation = {
       'Export workflow before deletion for backup'
     ],
     pitfalls: [
-      'Requires N8N_API_URL and N8N_API_KEY configured',
+      'Requires N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) configured',
       'Cannot be undone - permanent deletion',
       'Deletes all execution history',
       'Active workflows can be deleted',

--- a/src/mcp/tool-docs/workflow_management/n8n-deploy-template.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-deploy-template.ts
@@ -60,7 +60,7 @@ n8n_deploy_template({
       'Test workflow before connecting to production systems'
     ],
     pitfalls: [
-      '**REQUIRES N8N_API_URL and N8N_API_KEY environment variables** - tool unavailable without n8n API access',
+      '**REQUIRES N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) environment variables** - tool unavailable without n8n API access',
       'Workflows created in INACTIVE state - must configure credentials and activate in n8n',
       'Templates may reference services you do not have (Slack, Google, etc.)',
       'Template database must be populated - run npm run fetch:templates if templates not found',

--- a/src/mcp/tool-docs/workflow_management/n8n-executions.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-executions.ts
@@ -96,7 +96,7 @@ export const n8nExecutionsDoc: ToolDocumentation = {
       'Delete old executions to save storage'
     ],
     pitfalls: [
-      'Requires N8N_API_URL and N8N_API_KEY configured',
+      'Requires N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) configured',
       'mode="full" can return very large responses for complex workflows',
       'mode="error" fetches workflow by default (adds ~50-100ms), disable with fetchWorkflow=false',
       'Execution must exist or returns 404',

--- a/src/mcp/tool-docs/workflow_management/n8n-get-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-get-workflow.ts
@@ -56,7 +56,7 @@ export const n8nGetWorkflowDoc: ToolDocumentation = {
       'Validate workflow after retrieval if planning modifications'
     ],
     pitfalls: [
-      'Requires N8N_API_URL and N8N_API_KEY configured',
+      'Requires N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) configured',
       'mode="details" adds database queries for execution stats',
       'Workflow must exist or returns 404 error',
       'Credentials are referenced by ID but values not included'

--- a/src/mcp/tool-docs/workflow_management/n8n-list-workflows.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-list-workflows.ts
@@ -45,7 +45,7 @@ export const n8nListWorkflowsDoc: ToolDocumentation = {
       'Iterate with cursor until hasMore is false for complete list'
     ],
     pitfalls: [
-      'Requires N8N_API_URL and N8N_API_KEY configured',
+      'Requires N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) configured',
       'Maximum 100 workflows per request',
       'Server may return fewer than requested limit',
       'returned field is count of current page only, not system total'

--- a/src/mcp/tool-docs/workflow_management/n8n-update-full-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-update-full-workflow.ts
@@ -48,7 +48,7 @@ export const n8nUpdateFullWorkflowDoc: ToolDocumentation = {
       'Test updates in non-production first'
     ],
     pitfalls: [
-      'Requires N8N_API_URL and N8N_API_KEY configured',
+      'Requires N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) configured',
       'Must include ALL nodes/connections',
       'Missing nodes will be deleted',
       'Can break active workflows',

--- a/src/mcp/tool-docs/workflow_management/n8n-update-partial-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-update-partial-workflow.ts
@@ -389,7 +389,7 @@ n8n_update_partial_workflow({
       'Batch multiple property removals in a single updateNode operation for efficiency'
     ],
     pitfalls: [
-      '**REQUIRES N8N_API_URL and N8N_API_KEY environment variables** - will not work without n8n API access',
+      '**REQUIRES N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) environment variables** - will not work without n8n API access',
       'Atomic mode (default): all operations must succeed or none are applied',
       'continueOnError breaks atomic guarantees - use with caution',
       'Order matters for dependent operations (e.g., must add node before connecting to it)',

--- a/src/mcp/tool-docs/workflow_management/n8n-validate-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-validate-workflow.ts
@@ -25,7 +25,7 @@ export const n8nValidateWorkflowDoc: ToolDocumentation = {
 
 The validation uses the same engine as validate_workflow but works with workflows already in n8n, making it perfect for validating existing workflows before execution.
 
-Requires N8N_API_URL and N8N_API_KEY environment variables to be configured.`,
+Requires N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) environment variables to be configured.`,
     parameters: {
       id: {
         type: 'string',

--- a/src/mcp/tools-documentation.ts
+++ b/src/mcp/tools-documentation.ts
@@ -179,7 +179,7 @@ ${tools.map(toolName => {
 - All node types require the "nodes-base." or "nodes-langchain." prefix
 - Use get_node() with detail='standard' first for most tasks (~95% smaller than detail='full')
 - Validation profiles: minimal (editing), runtime (default), strict (deployment)
-- n8n API tools only available when N8N_API_URL and N8N_API_KEY are configured
+- n8n API tools only available when N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) are configured
 
 For detailed documentation on any tool:
 tools_documentation({topic: "tool_name", depth: "full"})`;

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -4,7 +4,7 @@ import { ToolDefinition } from '../types';
  * n8n Management Tools
  * 
  * These tools enable AI agents to manage n8n workflows through the n8n API.
- * They require N8N_API_URL and N8N_API_KEY to be configured.
+ * They require N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) to be configured.
  */
 export const n8nManagementTools: ToolDefinition[] = [
   // Workflow Management Tools

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -33,7 +33,18 @@ import {
 
 export interface N8nApiClientConfig {
   baseUrl: string;
-  apiKey: string;
+  /**
+   * n8n API key sent as X-N8N-API-KEY header.
+   * When both apiKey and cookie are provided, apiKey takes precedence.
+   * At least one of apiKey or cookie must be provided.
+   */
+  apiKey?: string;
+  /**
+   * n8n session cookie sent as Cookie header.
+   * Used when apiKey is not available (e.g. browser-session-based authentication).
+   * At least one of apiKey or cookie must be provided.
+   */
+  cookie?: string;
   timeout?: number;
   maxRetries?: number;
 }
@@ -46,7 +57,7 @@ export class N8nApiClient {
   private versionPromise: Promise<N8nVersionInfo | null> | null = null;
 
   constructor(config: N8nApiClientConfig) {
-    const { baseUrl, apiKey, timeout = 30000, maxRetries = 3 } = config;
+    const { baseUrl, apiKey, cookie, timeout = 30000, maxRetries = 3 } = config;
 
     this.maxRetries = maxRetries;
     this.baseUrl = baseUrl;
@@ -56,11 +67,19 @@ export class N8nApiClient {
       ? baseUrl
       : `${baseUrl.replace(/\/$/, '')}/api/v1`;
 
+    // Prefer API key when both are provided; fall back to cookie auth
+    const authHeaders: Record<string, string> = {};
+    if (apiKey) {
+      authHeaders['X-N8N-API-KEY'] = apiKey;
+    } else if (cookie) {
+      authHeaders['Cookie'] = cookie;
+    }
+
     this.client = axios.create({
       baseURL: apiUrl,
       timeout,
       headers: {
-        'X-N8N-API-KEY': apiKey,
+        ...authHeaders,
         'Content-Type': 'application/json',
       },
     });

--- a/src/types/instance-context.ts
+++ b/src/types/instance-context.ts
@@ -13,6 +13,14 @@ export interface InstanceContext {
    */
   n8nApiUrl?: string;
   n8nApiKey?: string;
+  /**
+   * n8n session cookie for browser-session-based authentication.
+   * Use when you cannot obtain an API key (e.g. self-hosted instances without API key access).
+   * Obtain by inspecting the Cookie header after logging into the n8n UI.
+   * Treated as a secret — never log the value.
+   * When both n8nApiKey and n8nApiCookie are provided, n8nApiKey takes precedence.
+   */
+  n8nApiCookie?: string;
   n8nApiTimeout?: number;
   n8nApiMaxRetries?: number;
 
@@ -96,6 +104,16 @@ function isValidApiKey(key: string): boolean {
 }
 
 /**
+ * Validate cookie string format (basic check for non-empty string without placeholders)
+ */
+function isValidCookie(cookie: string): boolean {
+  return cookie.length > 0 &&
+         !cookie.toLowerCase().includes('your_cookie') &&
+         !cookie.toLowerCase().includes('placeholder') &&
+         !cookie.toLowerCase().includes('example');
+}
+
+/**
  * Type guard to check if an object is an InstanceContext
  */
 export function isInstanceContext(obj: any): obj is InstanceContext {
@@ -108,6 +126,9 @@ export function isInstanceContext(obj: any): obj is InstanceContext {
   const hasValidKey = obj.n8nApiKey === undefined ||
     (typeof obj.n8nApiKey === 'string' && isValidApiKey(obj.n8nApiKey));
 
+  const hasValidCookie = obj.n8nApiCookie === undefined ||
+    (typeof obj.n8nApiCookie === 'string' && isValidCookie(obj.n8nApiCookie));
+
   const hasValidTimeout = obj.n8nApiTimeout === undefined ||
     (typeof obj.n8nApiTimeout === 'number' && obj.n8nApiTimeout > 0);
 
@@ -119,7 +140,7 @@ export function isInstanceContext(obj: any): obj is InstanceContext {
   const hasValidMetadata = obj.metadata === undefined ||
     (typeof obj.metadata === 'object' && obj.metadata !== null);
 
-  return hasValidUrl && hasValidKey && hasValidTimeout && hasValidRetries &&
+  return hasValidUrl && hasValidKey && hasValidCookie && hasValidTimeout && hasValidRetries &&
          hasValidInstanceId && hasValidSessionId && hasValidMetadata;
 }
 
@@ -164,6 +185,23 @@ export function validateInstanceContext(context: InstanceContext): {
         errors.push(`Invalid n8nApiKey: contains example text - Please provide actual API key`);
       } else {
         errors.push(`Invalid n8nApiKey: format validation failed - Ensure key is valid`);
+      }
+    }
+  }
+
+  // Validate cookie if provided
+  if (context.n8nApiCookie !== undefined) {
+    if (context.n8nApiCookie === '') {
+      errors.push(`Invalid n8nApiCookie: empty string - cookie value is required when field is provided`);
+    } else if (!isValidCookie(context.n8nApiCookie)) {
+      if (context.n8nApiCookie.toLowerCase().includes('your_cookie')) {
+        errors.push(`Invalid n8nApiCookie: contains placeholder 'your_cookie' - Please provide actual cookie`);
+      } else if (context.n8nApiCookie.toLowerCase().includes('placeholder')) {
+        errors.push(`Invalid n8nApiCookie: contains placeholder text - Please provide actual cookie`);
+      } else if (context.n8nApiCookie.toLowerCase().includes('example')) {
+        errors.push(`Invalid n8nApiCookie: contains example text - Please provide actual cookie`);
+      } else {
+        errors.push(`Invalid n8nApiCookie: format validation failed - Ensure cookie is valid`);
       }
     }
   }

--- a/src/types/session-state.ts
+++ b/src/types/session-state.ts
@@ -55,8 +55,12 @@ export interface SessionState {
    * Contains the n8n API credentials and instance-specific settings.
    * This is the critical data needed to reconnect to the correct n8n instance.
    *
-   * Note: API keys are stored in plaintext. The downstream application
-   * MUST encrypt this data before persisting to disk.
+   * Note: Credentials are stored in plaintext. The downstream application
+   * MUST encrypt this data before persisting to disk. This applies to both
+   * API keys and session cookies.
+   *
+   * At least one of n8nApiKey or n8nApiCookie is required for management tools
+   * and session restore. When both are present, n8nApiKey takes precedence.
    */
   context: {
     /**
@@ -68,8 +72,16 @@ export interface SessionState {
     /**
      * n8n instance API key (plaintext - encrypt before storage!)
      * Example: "n8n_api_1234567890abcdef"
+     * At least one of n8nApiKey or n8nApiCookie must be provided.
      */
-    n8nApiKey: string;
+    n8nApiKey?: string;
+
+    /**
+     * n8n session cookie for browser-session-based authentication (plaintext - encrypt before storage!)
+     * Obtained from the Cookie header after logging into the n8n UI.
+     * At least one of n8nApiKey or n8nApiCookie must be provided.
+     */
+    n8nApiCookie?: string;
 
     /**
      * Instance identifier (optional)

--- a/tests/unit/http-server/session-persistence.test.ts
+++ b/tests/unit/http-server/session-persistence.test.ts
@@ -543,4 +543,112 @@ describe('SingleSessionHTTPServer - Session Persistence', () => {
       });
     });
   });
+
+  describe('Cookie-based authentication', () => {
+    it('should export sessions that use cookie auth instead of apiKey', () => {
+      const serverAny = server as any;
+      const sessionId = 'cookie-session';
+
+      serverAny.sessionMetadata[sessionId] = {
+        createdAt: new Date(),
+        lastAccess: new Date()
+      };
+      serverAny.sessionContexts[sessionId] = {
+        n8nApiUrl: 'https://n8n.example.com',
+        n8nApiCookie: 'n8n-auth=abc123; Path=/',
+        instanceId: 'cookie-instance'
+      };
+
+      const exported = server.exportSessionState();
+
+      expect(exported).toHaveLength(1);
+      expect(exported[0].context.n8nApiCookie).toBe('n8n-auth=abc123; Path=/');
+      expect(exported[0].context.n8nApiKey).toBeUndefined();
+    });
+
+    it('should skip sessions with neither apiKey nor cookie during export', () => {
+      const serverAny = server as any;
+
+      // Session with cookie - should be exported
+      serverAny.sessionMetadata['cookie-session'] = {
+        createdAt: new Date(),
+        lastAccess: new Date()
+      };
+      serverAny.sessionContexts['cookie-session'] = {
+        n8nApiUrl: 'https://n8n.example.com',
+        n8nApiCookie: 'n8n-auth=abc123',
+        instanceId: 'instance'
+      };
+
+      // Session with no credentials - should be skipped
+      serverAny.sessionMetadata['no-creds-session'] = {
+        createdAt: new Date(),
+        lastAccess: new Date()
+      };
+      serverAny.sessionContexts['no-creds-session'] = {
+        n8nApiUrl: 'https://n8n.example.com',
+        instanceId: 'instance2'
+      };
+
+      const exported = server.exportSessionState();
+      expect(exported).toHaveLength(1);
+      expect(exported[0].sessionId).toBe('cookie-session');
+    });
+
+    it('should restore sessions that use cookie auth', () => {
+      const sessions: SessionState[] = [
+        {
+          sessionId: 'cookie-restored',
+          metadata: {
+            createdAt: new Date().toISOString(),
+            lastAccess: new Date().toISOString()
+          },
+          context: {
+            n8nApiUrl: 'https://n8n.example.com',
+            n8nApiCookie: 'n8n-auth=abc123; Path=/',
+            instanceId: 'cookie-instance'
+          }
+        }
+      ];
+
+      const count = server.restoreSessionState(sessions);
+      expect(count).toBe(1);
+
+      const serverAny = server as any;
+      expect(serverAny.sessionContexts['cookie-restored']).toMatchObject({
+        n8nApiUrl: 'https://n8n.example.com',
+        n8nApiCookie: 'n8n-auth=abc123; Path=/',
+        instanceId: 'cookie-instance'
+      });
+    });
+
+    it('should preserve both apiKey and cookie in round-trip when both are present', () => {
+      const serverAny = server as any;
+      const sessionId = 'both-creds-session';
+
+      serverAny.sessionMetadata[sessionId] = {
+        createdAt: new Date(),
+        lastAccess: new Date()
+      };
+      serverAny.sessionContexts[sessionId] = {
+        n8nApiUrl: 'https://n8n.example.com',
+        n8nApiKey: 'my-api-key',
+        n8nApiCookie: 'n8n-auth=abc123',
+        instanceId: 'instance'
+      };
+
+      const exported = server.exportSessionState();
+      expect(exported[0].context.n8nApiKey).toBe('my-api-key');
+      expect(exported[0].context.n8nApiCookie).toBe('n8n-auth=abc123');
+
+      // Clear and restore
+      delete serverAny.sessionMetadata[sessionId];
+      delete serverAny.sessionContexts[sessionId];
+
+      const count = server.restoreSessionState(exported);
+      expect(count).toBe(1);
+      expect(serverAny.sessionContexts[sessionId].n8nApiKey).toBe('my-api-key');
+      expect(serverAny.sessionContexts[sessionId].n8nApiCookie).toBe('n8n-auth=abc123');
+    });
+  });
 });

--- a/tests/unit/mcp/handlers-n8n-manager.test.ts
+++ b/tests/unit/mcp/handlers-n8n-manager.test.ts
@@ -210,6 +210,35 @@ describe('handlers-n8n-manager', () => {
         maxRetries: 3,
       });
     });
+
+    it('should create client using cookie when context has only cookie credential', () => {
+      vi.mocked(getN8nApiConfig).mockReturnValue(null); // no env config
+      const context = {
+        n8nApiUrl: 'https://n8n.example.com',
+        n8nApiCookie: 'n8n-auth=abc123',
+        instanceId: 'cookie-instance'
+      };
+
+      const client = handlers.getN8nApiClient(context);
+      expect(client).toBeTruthy();
+      expect(N8nApiClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: 'https://n8n.example.com',
+          cookie: 'n8n-auth=abc123',
+        })
+      );
+    });
+
+    it('should return null when context has url but neither key nor cookie', () => {
+      vi.mocked(getN8nApiConfig).mockReturnValue(null);
+      const context = {
+        n8nApiUrl: 'https://n8n.example.com',
+        instanceId: 'no-creds'
+      };
+
+      const client = handlers.getN8nApiClient(context);
+      expect(client).toBeNull();
+    });
   });
 
   describe('handleCreateWorkflow', () => {
@@ -308,7 +337,7 @@ describe('handlers-n8n-manager', () => {
 
       expect(result).toEqual({
         success: false,
-        error: 'n8n API not configured. Please set N8N_API_URL and N8N_API_KEY environment variables.',
+        error: 'n8n API not configured. Please set N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) environment variables.',
       });
     });
 
@@ -787,7 +816,7 @@ describe('handlers-n8n-manager', () => {
 
       expect(result).toEqual({
         success: false,
-        error: 'n8n API not configured. Please set N8N_API_URL and N8N_API_KEY environment variables.',
+        error: 'n8n API not configured. Please set N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) environment variables.',
       });
     });
   });

--- a/tests/unit/mcp/handlers-workflow-diff.test.ts
+++ b/tests/unit/mcp/handlers-workflow-diff.test.ts
@@ -337,7 +337,7 @@ describe('handlers-workflow-diff', () => {
 
       expect(result).toEqual({
         success: false,
-        error: 'n8n API not configured. Please set N8N_API_URL and N8N_API_KEY environment variables.',
+        error: 'n8n API not configured. Please set N8N_API_URL and N8N_API_KEY (or N8N_API_COOKIE) environment variables.',
       });
     });
 

--- a/tests/unit/services/n8n-api-client.test.ts
+++ b/tests/unit/services/n8n-api-client.test.ts
@@ -185,6 +185,55 @@ describe('N8nApiClient', () => {
       expect(mockAxiosInstance.interceptors.request.use).toHaveBeenCalled();
       expect(mockAxiosInstance.interceptors.response.use).toHaveBeenCalled();
     });
+
+    it('should use Cookie header when only cookie is provided (no apiKey)', () => {
+      client = new N8nApiClient({
+        baseUrl: 'https://n8n.example.com',
+        cookie: 'n8n-auth=abc123; Path=/',
+      });
+
+      expect(axios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Cookie': 'n8n-auth=abc123; Path=/',
+            'Content-Type': 'application/json',
+          }),
+        })
+      );
+      // X-N8N-API-KEY should NOT be set
+      const callArgs = vi.mocked(axios.create).mock.calls[0][0] as any;
+      expect(callArgs.headers['X-N8N-API-KEY']).toBeUndefined();
+    });
+
+    it('should prefer X-N8N-API-KEY header when both apiKey and cookie are provided', () => {
+      client = new N8nApiClient({
+        baseUrl: 'https://n8n.example.com',
+        apiKey: 'my-api-key',
+        cookie: 'n8n-auth=abc123',
+      });
+
+      expect(axios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-N8N-API-KEY': 'my-api-key',
+            'Content-Type': 'application/json',
+          }),
+        })
+      );
+      // Cookie should NOT be set when apiKey is present
+      const callArgs = vi.mocked(axios.create).mock.calls[0][0] as any;
+      expect(callArgs.headers['Cookie']).toBeUndefined();
+    });
+
+    it('should use neither auth header when neither apiKey nor cookie is provided', () => {
+      client = new N8nApiClient({
+        baseUrl: 'https://n8n.example.com',
+      });
+
+      const callArgs = vi.mocked(axios.create).mock.calls[0][0] as any;
+      expect(callArgs.headers['X-N8N-API-KEY']).toBeUndefined();
+      expect(callArgs.headers['Cookie']).toBeUndefined();
+    });
   });
 
   describe('healthCheck', () => {

--- a/tests/unit/types/instance-context-coverage.test.ts
+++ b/tests/unit/types/instance-context-coverage.test.ts
@@ -371,4 +371,80 @@ describe('instance-context Coverage Tests', () => {
       expect(validation.valid).toBe(true);
     });
   });
+
+  describe('Cookie Authentication', () => {
+    it('should accept context with only cookie credential', () => {
+      const context: InstanceContext = {
+        n8nApiUrl: 'https://api.n8n.cloud',
+        n8nApiCookie: 'n8n-auth=abc123; Path=/'
+      };
+
+      expect(isInstanceContext(context)).toBe(true);
+      const validation = validateInstanceContext(context);
+      expect(validation.valid).toBe(true);
+    });
+
+    it('should accept context with both apiKey and cookie (apiKey takes precedence)', () => {
+      const context: InstanceContext = {
+        n8nApiUrl: 'https://api.n8n.cloud',
+        n8nApiKey: 'my-api-key',
+        n8nApiCookie: 'n8n-auth=abc123'
+      };
+
+      expect(isInstanceContext(context)).toBe(true);
+      const validation = validateInstanceContext(context);
+      expect(validation.valid).toBe(true);
+    });
+
+    it('should reject empty string cookie', () => {
+      const context: InstanceContext = {
+        n8nApiUrl: 'https://api.n8n.cloud',
+        n8nApiCookie: ''
+      };
+
+      const validation = validateInstanceContext(context);
+      expect(validation.valid).toBe(false);
+      expect(validation.errors?.[0]).toContain('Invalid n8nApiCookie:');
+      expect(validation.errors?.[0]).toContain('empty string');
+    });
+
+    it('should reject placeholder cookie values', () => {
+      const placeholderCookies = [
+        'your_cookie',
+        'YOUR_COOKIE',
+        'placeholder',
+        'example',
+      ];
+
+      placeholderCookies.forEach(cookie => {
+        const context: InstanceContext = {
+          n8nApiUrl: 'https://api.n8n.cloud',
+          n8nApiCookie: cookie
+        };
+
+        const validation = validateInstanceContext(context);
+        expect(validation.valid).toBe(false);
+        expect(validation.errors?.some(e => e.includes('Invalid n8nApiCookie:'))).toBe(true);
+      });
+    });
+
+    it('should reject invalid cookie in isInstanceContext type guard', () => {
+      const context = {
+        n8nApiUrl: 'https://api.n8n.cloud',
+        n8nApiCookie: 'placeholder'
+      };
+
+      expect(isInstanceContext(context)).toBe(false);
+    });
+
+    it('should accept context with no credentials (documentation-only usage)', () => {
+      const context: InstanceContext = {
+        n8nApiUrl: 'https://api.n8n.cloud'
+      };
+
+      expect(isInstanceContext(context)).toBe(true);
+      const validation = validateInstanceContext(context);
+      expect(validation.valid).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
- Introduced 'x-n8n-cookie' header for browser-session-based authentication.
- Updated instance context and API client to handle both API key and cookie.
- Enhanced validation for cookie format and added tests for cookie-based sessions.
- Updated documentation to reflect new authentication options and requirements.

This change allows users to authenticate using a session cookie as an alternative to the API key, improving flexibility for different deployment scenarios.