### PR TITLE
fix: data tables available on all n8n plans, not just enterprise/cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.40.4] - 2026-03-22
+
+### Fixed
+
+- **Incorrect data tables availability info**: Removed "enterprise/cloud only" restriction from tool description and documentation — data tables are available on all n8n plans including self-hosted
+- **Redundant pitfalls removed**: Removed "Requires N8N_API_URL and N8N_API_KEY" and "enterprise or cloud plans" pitfalls — the first is implicit for all n8n management tools, the second was incorrect
+
+Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en
+
 ## [2.40.3] - 2026-03-22
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.40.3",
+  "version": "2.40.4",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/mcp/tool-docs/workflow_management/n8n-manage-datatable.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-manage-datatable.ts
@@ -14,7 +14,7 @@ export const n8nManageDatatableDoc: ToolDocumentation = {
       'Use dryRun: true to preview update/upsert/delete before applying',
       'Filter supports: eq, neq, like, ilike, gt, gte, lt, lte conditions',
       'Use returnData: true to get affected rows back from update/upsert/delete',
-      'Requires n8n enterprise or cloud with data tables feature'
+      'Requires N8N_API_URL and N8N_API_KEY configured'
     ]
   },
   full: {
@@ -96,8 +96,6 @@ export const n8nManageDatatableDoc: ToolDocumentation = {
       'Use sortBy for deterministic row ordering',
     ],
     pitfalls: [
-      'Requires N8N_API_URL and N8N_API_KEY configured',
-      'Feature only available on n8n enterprise or cloud plans',
       'deleteTable permanently deletes all rows — cannot be undone',
       'deleteRows requires a filter — cannot delete all rows without one',
       'Column types cannot be changed after table creation via API',

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -609,7 +609,7 @@ export const n8nManagementTools: ToolDefinition[] = [
   },
   {
     name: 'n8n_manage_datatable',
-    description: `Manage n8n data tables and rows. Actions: createTable, listTables, getTable, updateTable, deleteTable, getRows, insertRows, updateRows, upsertRows, deleteRows. Requires n8n enterprise/cloud with data tables feature.`,
+    description: `Manage n8n data tables and rows. Actions: createTable, listTables, getTable, updateTable, deleteTable, getRows, insertRows, updateRows, upsertRows, deleteRows.`,
     inputSchema: {
       type: 'object',
       properties: {


### PR DESCRIPTION
## Summary

- Removed incorrect "enterprise/cloud only" restriction from `n8n_manage_datatable` tool description and documentation — data tables are available on all n8n plans including self-hosted
- Removed 2 redundant pitfalls: "Requires N8N_API_URL and N8N_API_KEY" (implicit for all n8n management tools) and "enterprise or cloud plans" (incorrect)
- Version bump 2.40.3 → 2.40.4

## Test plan

- [x] `npm run build` — clean
- [x] `npm run typecheck` — clean

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)