### PR TITLE
feat(auth): add OAuth 2.1 support with n8n as authorization server

### DIFF
--- a/src/auth/n8n-token-verifier.ts
+++ b/src/auth/n8n-token-verifier.ts
@@ -1,0 +1,62 @@
+import type { OAuthTokenVerifier } from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { logger } from '../utils/logger';
+
+/**
+ * Verifies OAuth access tokens issued by n8n's authorization server.
+ * n8n's OAuth tokens are only accepted by the /mcp-server/http endpoint,
+ * not by the public REST API (/api/v1/ which requires X-N8N-API-KEY).
+ * We validate by sending a lightweight JSON-RPC ping to n8n's MCP endpoint.
+ */
+export class N8nTokenVerifier implements OAuthTokenVerifier {
+  private n8nBaseUrl: string;
+
+  constructor(n8nBaseUrl: string) {
+    // Strip trailing slash
+    this.n8nBaseUrl = n8nBaseUrl.replace(/\/+$/, '');
+  }
+
+  async verifyAccessToken(token: string): Promise<AuthInfo> {
+    try {
+      // Validate by sending a JSON-RPC ping to n8n's MCP endpoint.
+      // The /mcp-server/http endpoint accepts OAuth Bearer tokens,
+      // unlike /api/v1/ which only accepts X-N8N-API-KEY.
+      const response = await fetch(`${this.n8nBaseUrl}/mcp-server/http`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'ping',
+          id: 1,
+        }),
+      });
+
+      if (!response.ok) {
+        logger.warn('n8n token verification failed', {
+          status: response.status,
+        });
+        throw new Error('Invalid or expired n8n access token');
+      }
+
+      logger.info('n8n token verified successfully');
+
+      return {
+        token,
+        clientId: 'n8n-oauth-user',
+        scopes: ['tool:listWorkflows', 'tool:getWorkflowDetails'],
+        expiresAt: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
+        extra: { n8nBaseUrl: this.n8nBaseUrl },
+      };
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('n8n access token')) {
+        throw error;
+      }
+      logger.error('n8n token verification error', error);
+      throw new Error('Failed to verify token against n8n');
+    }
+  }
+}

--- a/src/auth/oauth-clients-store.ts
+++ b/src/auth/oauth-clients-store.ts
@@ -1,0 +1,42 @@
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import crypto from 'crypto';
+
+/**
+ * In-memory OAuth client store implementing RFC 7591 Dynamic Client Registration.
+ * When a client registers without specifying scopes, defaults to the server's supported scopes.
+ */
+export class InMemoryClientsStore implements OAuthRegisteredClientsStore {
+  private clients = new Map<string, OAuthClientInformationFull>();
+  private defaultScopes: string[];
+
+  constructor(defaultScopes: string[] = ['mcp:read', 'mcp:write']) {
+    this.defaultScopes = defaultScopes;
+  }
+
+  getClient(clientId: string): OAuthClientInformationFull | undefined {
+    return this.clients.get(clientId);
+  }
+
+  registerClient(
+    clientData: Omit<OAuthClientInformationFull, 'client_id' | 'client_id_issued_at'>
+  ): OAuthClientInformationFull {
+    const clientId = crypto.randomUUID();
+    const clientSecret = crypto.randomBytes(32).toString('hex');
+    const now = Math.floor(Date.now() / 1000);
+
+    const client: OAuthClientInformationFull = {
+      ...clientData,
+      // If client didn't specify scopes, grant the server's supported scopes
+      scope: clientData.scope || this.defaultScopes.join(' '),
+      client_id: clientId,
+      client_secret: clientSecret,
+      client_id_issued_at: now,
+      // Secret does not expire
+      client_secret_expires_at: 0,
+    };
+
+    this.clients.set(clientId, client);
+    return client;
+  }
+}

--- a/src/auth/oauth-config.ts
+++ b/src/auth/oauth-config.ts
@@ -1,0 +1,94 @@
+import type { OAuthMetadata } from '@modelcontextprotocol/sdk/shared/auth.js';
+import { logger } from '../utils/logger';
+
+export type AuthMode = 'token' | 'oauth' | 'both';
+
+export interface OAuthConfig {
+  issuerUrl: string;
+  serverUrl: string;
+  n8nOAuthMetadata: OAuthMetadata;
+}
+
+/**
+ * Fetch n8n's OAuth authorization server metadata.
+ */
+export async function fetchN8nOAuthMetadata(issuerUrl: string): Promise<OAuthMetadata> {
+  const metadataUrl = `${issuerUrl.replace(/\/+$/, '')}/.well-known/oauth-authorization-server`;
+  logger.info('Fetching n8n OAuth metadata', { metadataUrl });
+
+  const response = await fetch(metadataUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch OAuth metadata from ${metadataUrl}: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const metadata = await response.json() as OAuthMetadata;
+
+  // Validate required fields
+  if (!metadata.issuer || !metadata.authorization_endpoint || !metadata.token_endpoint) {
+    throw new Error(
+      'Invalid OAuth metadata: missing required fields (issuer, authorization_endpoint, token_endpoint)'
+    );
+  }
+
+  logger.info('n8n OAuth metadata fetched', {
+    issuer: metadata.issuer,
+    scopes: metadata.scopes_supported,
+    hasRegistration: !!metadata.registration_endpoint,
+  });
+
+  return metadata;
+}
+
+/**
+ * Load and validate OAuth configuration from environment variables.
+ * Returns null if OAuth is not configured (AUTH_MODE=token).
+ *
+ * This is a synchronous pre-validation step. Call fetchN8nOAuthMetadata()
+ * separately to complete the async metadata fetch.
+ */
+export function loadOAuthConfig(authMode: AuthMode): Omit<OAuthConfig, 'n8nOAuthMetadata'> | null {
+  if (authMode === 'token') {
+    return null;
+  }
+
+  const issuerUrl = process.env.OAUTH_ISSUER_URL;
+  if (!issuerUrl) {
+    throw new Error(
+      'OAUTH_ISSUER_URL is required when AUTH_MODE includes OAuth. ' +
+      'Set it to your n8n instance URL (e.g., https://n8n.example.com).'
+    );
+  }
+
+  // Validate issuerUrl is a valid URL
+  try {
+    new URL(issuerUrl);
+  } catch {
+    throw new Error(`OAUTH_ISSUER_URL is not a valid URL: ${issuerUrl}`);
+  }
+
+  const host = process.env.HOST || '0.0.0.0';
+  const port = process.env.PORT || '3000';
+  const displayHost = host === '0.0.0.0' ? 'localhost' : host;
+  const serverUrl = process.env.OAUTH_SERVER_URL || `http://${displayHost}:${port}`;
+
+  logger.info('OAuth configuration loaded (pending metadata fetch)', {
+    issuerUrl,
+    serverUrl,
+  });
+
+  return { issuerUrl, serverUrl };
+}
+
+/**
+ * Parse AUTH_MODE from environment, defaulting to 'token' for backward compatibility.
+ */
+export function loadAuthMode(): AuthMode {
+  const raw = (process.env.AUTH_MODE || 'token').toLowerCase().trim();
+  if (raw === 'token' || raw === 'oauth' || raw === 'both') {
+    return raw;
+  }
+  logger.warn(`Invalid AUTH_MODE "${raw}", falling back to "token"`);
+  return 'token';
+}

--- a/src/auth/oauth-provider.ts
+++ b/src/auth/oauth-provider.ts
@@ -1,0 +1,263 @@
+import type { OAuthServerProvider, AuthorizationParams } from '@modelcontextprotocol/sdk/server/auth/provider.js';
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type {
+  OAuthClientInformationFull,
+  OAuthTokens,
+  OAuthTokenRevocationRequest,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { Response } from 'express';
+import crypto from 'crypto';
+import { InMemoryClientsStore } from './oauth-clients-store';
+import { logger } from '../utils/logger';
+
+// TTL constants
+const AUTH_CODE_TTL_MS = 10 * 60 * 1000;       // 10 minutes
+const ACCESS_TOKEN_TTL_MS = 60 * 60 * 1000;    // 1 hour
+const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const CLEANUP_INTERVAL_MS = 15 * 60 * 1000;     // 15 minutes
+
+interface AuthCode {
+  code: string;
+  clientId: string;
+  codeChallenge: string;
+  redirectUri: string;
+  scopes: string[];
+  expiresAt: number;
+}
+
+interface StoredToken {
+  token: string;
+  clientId: string;
+  scopes: string[];
+  expiresAt: number;
+  type: 'access' | 'refresh';
+}
+
+/**
+ * In-memory OAuth 2.1 server provider for MCP.
+ * Implements the full authorization code flow with PKCE.
+ */
+export class InMemoryOAuthProvider implements OAuthServerProvider {
+  private _clientsStore: InMemoryClientsStore;
+  private authCodes = new Map<string, AuthCode>();
+  private accessTokens = new Map<string, StoredToken>();
+  private refreshTokens = new Map<string, StoredToken>();
+  private cleanupTimer: NodeJS.Timeout | null = null;
+
+  constructor(clientsStore?: InMemoryClientsStore) {
+    this._clientsStore = clientsStore || new InMemoryClientsStore();
+    this.startCleanup();
+  }
+
+  get clientsStore(): OAuthRegisteredClientsStore {
+    return this._clientsStore;
+  }
+
+  /**
+   * Auto-approve authorization: the user already initiated the MCP connection,
+   * so we redirect back immediately with an auth code.
+   */
+  async authorize(
+    client: OAuthClientInformationFull,
+    params: AuthorizationParams,
+    res: Response
+  ): Promise<void> {
+    const code = crypto.randomBytes(32).toString('hex');
+
+    this.authCodes.set(code, {
+      code,
+      clientId: client.client_id,
+      codeChallenge: params.codeChallenge,
+      redirectUri: params.redirectUri,
+      scopes: params.scopes || [],
+      expiresAt: Date.now() + AUTH_CODE_TTL_MS,
+    });
+
+    logger.info('OAuth: authorization code issued', { clientId: client.client_id });
+
+    const redirectUrl = new URL(params.redirectUri);
+    redirectUrl.searchParams.set('code', code);
+    if (params.state) {
+      redirectUrl.searchParams.set('state', params.state);
+    }
+    res.redirect(302, redirectUrl.toString());
+  }
+
+  async challengeForAuthorizationCode(
+    _client: OAuthClientInformationFull,
+    authorizationCode: string
+  ): Promise<string> {
+    const entry = this.authCodes.get(authorizationCode);
+    if (!entry || entry.expiresAt < Date.now()) {
+      throw new Error('Invalid or expired authorization code');
+    }
+    return entry.codeChallenge;
+  }
+
+  async exchangeAuthorizationCode(
+    client: OAuthClientInformationFull,
+    authorizationCode: string,
+    _codeVerifier?: string,
+    _redirectUri?: string,
+    _resource?: URL
+  ): Promise<OAuthTokens> {
+    const entry = this.authCodes.get(authorizationCode);
+    if (!entry) {
+      throw new Error('Invalid authorization code');
+    }
+    if (entry.expiresAt < Date.now()) {
+      this.authCodes.delete(authorizationCode);
+      throw new Error('Authorization code expired');
+    }
+    if (entry.clientId !== client.client_id) {
+      throw new Error('Client ID mismatch');
+    }
+
+    // Consume the auth code (one-time use)
+    this.authCodes.delete(authorizationCode);
+
+    return this.issueTokens(client.client_id, entry.scopes);
+  }
+
+  async exchangeRefreshToken(
+    client: OAuthClientInformationFull,
+    refreshToken: string,
+    scopes?: string[],
+    _resource?: URL
+  ): Promise<OAuthTokens> {
+    const stored = this.refreshTokens.get(refreshToken);
+    if (!stored || stored.expiresAt < Date.now()) {
+      if (stored) this.refreshTokens.delete(refreshToken);
+      throw new Error('Invalid or expired refresh token');
+    }
+    if (stored.clientId !== client.client_id) {
+      throw new Error('Client ID mismatch');
+    }
+
+    // Revoke old refresh token (rotation)
+    this.refreshTokens.delete(refreshToken);
+
+    // Use requested scopes if subset of original, otherwise use original
+    const effectiveScopes = scopes && scopes.every(s => stored.scopes.includes(s))
+      ? scopes
+      : stored.scopes;
+
+    return this.issueTokens(client.client_id, effectiveScopes);
+  }
+
+  async verifyAccessToken(token: string): Promise<AuthInfo> {
+    const stored = this.accessTokens.get(token);
+    if (!stored) {
+      throw new Error('Invalid access token');
+    }
+    if (stored.expiresAt < Date.now()) {
+      this.accessTokens.delete(token);
+      throw new Error('Access token expired');
+    }
+
+    return {
+      token: stored.token,
+      clientId: stored.clientId,
+      scopes: stored.scopes,
+      expiresAt: Math.floor(stored.expiresAt / 1000),
+    };
+  }
+
+  async revokeToken(
+    client: OAuthClientInformationFull,
+    request: OAuthTokenRevocationRequest
+  ): Promise<void> {
+    const { token, token_type_hint } = request;
+
+    if (token_type_hint === 'refresh_token' || !token_type_hint) {
+      const refreshEntry = this.refreshTokens.get(token);
+      if (refreshEntry && refreshEntry.clientId === client.client_id) {
+        this.refreshTokens.delete(token);
+        return;
+      }
+    }
+
+    if (token_type_hint === 'access_token' || !token_type_hint) {
+      const accessEntry = this.accessTokens.get(token);
+      if (accessEntry && accessEntry.clientId === client.client_id) {
+        this.accessTokens.delete(token);
+        return;
+      }
+    }
+    // Per RFC 7009: if token is invalid/already revoked, do nothing
+  }
+
+  /**
+   * Stop the cleanup timer (for graceful shutdown).
+   */
+  destroy(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
+  }
+
+  private issueTokens(clientId: string, scopes: string[]): OAuthTokens {
+    const accessToken = crypto.randomBytes(32).toString('hex');
+    const refreshToken = crypto.randomBytes(32).toString('hex');
+    const now = Date.now();
+
+    this.accessTokens.set(accessToken, {
+      token: accessToken,
+      clientId,
+      scopes,
+      expiresAt: now + ACCESS_TOKEN_TTL_MS,
+      type: 'access',
+    });
+
+    this.refreshTokens.set(refreshToken, {
+      token: refreshToken,
+      clientId,
+      scopes,
+      expiresAt: now + REFRESH_TOKEN_TTL_MS,
+      type: 'refresh',
+    });
+
+    const expiresInSec = Math.floor(ACCESS_TOKEN_TTL_MS / 1000);
+
+    logger.info('OAuth: tokens issued', { clientId, scopes, expiresIn: expiresInSec });
+
+    return {
+      access_token: accessToken,
+      token_type: 'bearer',
+      expires_in: expiresInSec,
+      scope: scopes.join(' '),
+      refresh_token: refreshToken,
+    };
+  }
+
+  private startCleanup(): void {
+    this.cleanupTimer = setInterval(() => {
+      this.purgeExpired();
+    }, CLEANUP_INTERVAL_MS);
+    // Allow process to exit even if timer is running
+    if (this.cleanupTimer.unref) {
+      this.cleanupTimer.unref();
+    }
+  }
+
+  private purgeExpired(): void {
+    const now = Date.now();
+    let purged = 0;
+
+    for (const [key, entry] of this.authCodes) {
+      if (entry.expiresAt < now) { this.authCodes.delete(key); purged++; }
+    }
+    for (const [key, entry] of this.accessTokens) {
+      if (entry.expiresAt < now) { this.accessTokens.delete(key); purged++; }
+    }
+    for (const [key, entry] of this.refreshTokens) {
+      if (entry.expiresAt < now) { this.refreshTokens.delete(key); purged++; }
+    }
+
+    if (purged > 0) {
+      logger.debug('OAuth: purged expired entries', { purged });
+    }
+  }
+}

--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -27,6 +27,8 @@ import {
 import { InstanceContext, validateInstanceContext } from './types/instance-context';
 import { SessionState } from './types/session-state';
 import { closeSharedDatabase } from './database/shared-database';
+import { loadAuthMode, loadOAuthConfig, fetchN8nOAuthMetadata, type AuthMode, type OAuthConfig } from './auth/oauth-config';
+import { N8nTokenVerifier } from './auth/n8n-token-verifier';
 
 dotenv.config();
 
@@ -114,6 +116,10 @@ export class SingleSessionHTTPServer {
     process.env.SESSION_TIMEOUT_MINUTES || '5', 10
   ) * 60 * 1000;
   private authToken: string | null = null;
+  private authMode: AuthMode = 'token';
+  private oauthConfig: OAuthConfig | null = null;
+  private oauthBaseConfig: Omit<OAuthConfig, 'n8nOAuthMetadata'> | null = null;
+  private n8nTokenVerifier: N8nTokenVerifier | null = null;
   private cleanupTimer: NodeJS.Timeout | null = null;
   
   constructor() {
@@ -398,49 +404,78 @@ export class SingleSessionHTTPServer {
    * Validate required environment variables
    */
   private validateEnvironment(): void {
-    // Load auth token from env var or file
-    this.authToken = this.loadAuthToken();
-    
-    if (!this.authToken || this.authToken.trim() === '') {
-      const message = 'No authentication token found or token is empty. Set AUTH_TOKEN environment variable or AUTH_TOKEN_FILE pointing to a file containing the token.';
-      logger.error(message);
-      throw new Error(message);
-    }
-    
-    // Update authToken to trimmed version
-    this.authToken = this.authToken.trim();
-    
-    if (this.authToken.length < 32) {
-      logger.warn('AUTH_TOKEN should be at least 32 characters for security');
-    }
-    
-    // Check for default token and show prominent warnings
-    const isDefaultToken = this.authToken === 'REPLACE_THIS_AUTH_TOKEN_32_CHARS_MIN_abcdefgh';
-    const isProduction = process.env.NODE_ENV === 'production';
-    
-    if (isDefaultToken) {
-      if (isProduction) {
-        const message = 'CRITICAL SECURITY ERROR: Cannot start in production with default AUTH_TOKEN. Generate secure token: openssl rand -base64 32';
+    // Determine authentication mode
+    this.authMode = loadAuthMode();
+    logger.info(`Authentication mode: ${this.authMode}`);
+
+    // Load static token when needed (token or both modes)
+    if (this.authMode === 'token' || this.authMode === 'both') {
+      this.authToken = this.loadAuthToken();
+
+      if (!this.authToken || this.authToken.trim() === '') {
+        const message = 'No authentication token found or token is empty. Set AUTH_TOKEN environment variable or AUTH_TOKEN_FILE pointing to a file containing the token.';
         logger.error(message);
-        console.error('\n🚨 CRITICAL SECURITY ERROR 🚨');
-        console.error(message);
-        console.error('Set NODE_ENV to development for testing, or update AUTH_TOKEN for production\n');
         throw new Error(message);
       }
-      
-      logger.warn('⚠️ SECURITY WARNING: Using default AUTH_TOKEN - CHANGE IMMEDIATELY!');
-      logger.warn('Generate secure token with: openssl rand -base64 32');
-      
-      // Only show console warnings in HTTP mode
-      if (process.env.MCP_MODE === 'http') {
-        console.warn('\n⚠️  SECURITY WARNING ⚠️');
-        console.warn('Using default AUTH_TOKEN - CHANGE IMMEDIATELY!');
-        console.warn('Generate secure token: openssl rand -base64 32');
-        console.warn('Update via Railway dashboard environment variables\n');
+
+      // Update authToken to trimmed version
+      this.authToken = this.authToken.trim();
+
+      if (this.authToken.length < 32) {
+        logger.warn('AUTH_TOKEN should be at least 32 characters for security');
       }
+
+      // Check for default token and show prominent warnings
+      const isDefaultToken = this.authToken === 'REPLACE_THIS_AUTH_TOKEN_32_CHARS_MIN_abcdefgh';
+      const isProduction = process.env.NODE_ENV === 'production';
+
+      if (isDefaultToken) {
+        if (isProduction) {
+          const message = 'CRITICAL SECURITY ERROR: Cannot start in production with default AUTH_TOKEN. Generate secure token: openssl rand -base64 32';
+          logger.error(message);
+          console.error('\n🚨 CRITICAL SECURITY ERROR 🚨');
+          console.error(message);
+          console.error('Set NODE_ENV to development for testing, or update AUTH_TOKEN for production\n');
+          throw new Error(message);
+        }
+
+        logger.warn('⚠️ SECURITY WARNING: Using default AUTH_TOKEN - CHANGE IMMEDIATELY!');
+        logger.warn('Generate secure token with: openssl rand -base64 32');
+
+        // Only show console warnings in HTTP mode
+        if (process.env.MCP_MODE === 'http') {
+          console.warn('\n⚠️  SECURITY WARNING ⚠️');
+          console.warn('Using default AUTH_TOKEN - CHANGE IMMEDIATELY!');
+          console.warn('Generate secure token: openssl rand -base64 32');
+          console.warn('Update via Railway dashboard environment variables\n');
+        }
+      }
+    }
+
+    // Load OAuth base config when needed (oauth or both modes)
+    // Full initialization (metadata fetch) happens async in start()
+    if (this.authMode === 'oauth' || this.authMode === 'both') {
+      this.oauthBaseConfig = loadOAuthConfig(this.authMode);
+      logger.info('OAuth configuration pre-validated (metadata will be fetched at startup)');
     }
   }
   
+
+  /**
+   * Build an InstanceContext from OAuth auth info when the token was issued by n8n.
+   * The n8n-issued Bearer token is reused as the API key for n8n API calls.
+   */
+  private buildOAuthInstanceContext(req: express.Request): InstanceContext | undefined {
+    const auth = (req as any).auth;
+    if (!auth?.token || !auth?.extra?.n8nBaseUrl) {
+      return undefined;
+    }
+
+    return {
+      n8nApiUrl: auth.extra.n8nBaseUrl,
+      n8nApiKey: auth.token,
+    };
+  }
 
   /**
    * Handle incoming MCP request using proper SDK pattern
@@ -834,7 +869,31 @@ export class SingleSessionHTTPServer {
       });
       next();
     });
-    
+
+    // Fetch n8n OAuth metadata and mount resource metadata router when OAuth is enabled
+    if ((this.authMode === 'oauth' || this.authMode === 'both') && this.oauthBaseConfig) {
+      const metadata = await fetchN8nOAuthMetadata(this.oauthBaseConfig.issuerUrl);
+      this.oauthConfig = {
+        ...this.oauthBaseConfig,
+        n8nOAuthMetadata: metadata,
+      };
+      this.n8nTokenVerifier = new N8nTokenVerifier(this.oauthBaseConfig.issuerUrl);
+
+      const { mcpAuthMetadataRouter } = await import('@modelcontextprotocol/sdk/server/auth/router.js');
+      app.use(mcpAuthMetadataRouter({
+        oauthMetadata: this.oauthConfig.n8nOAuthMetadata,
+        resourceServerUrl: new URL(this.oauthConfig.serverUrl),
+        serviceDocumentationUrl: new URL('https://github.com/czlonkowski/n8n-mcp'),
+        scopesSupported: this.oauthConfig.n8nOAuthMetadata.scopes_supported,
+        resourceName: 'n8n Documentation MCP Server',
+      }));
+      logger.info('OAuth resource metadata router mounted (n8n as auth server)', {
+        issuer: this.oauthConfig.n8nOAuthMetadata.issuer,
+        scopes: this.oauthConfig.n8nOAuthMetadata.scopes_supported,
+        serverUrl: this.oauthConfig.serverUrl,
+      });
+    }
+
     // Root endpoint with API information
     app.get('/', (req, res) => {
       const port = parseInt(process.env.PORT || '3000');
@@ -859,9 +918,15 @@ export class SingleSessionHTTPServer {
           }
         },
         authentication: {
-          type: 'Bearer Token',
+          mode: this.authMode,
+          type: this.authMode === 'token' ? 'Bearer Token' :
+                this.authMode === 'oauth' ? 'OAuth 2.1' : 'Bearer Token + OAuth 2.1',
           header: 'Authorization: Bearer <token>',
-          required_for: ['POST /mcp']
+          required_for: ['POST /mcp'],
+          ...(this.authMode !== 'token' && this.oauthConfig && {
+            n8n_auth_server: this.oauthConfig.n8nOAuthMetadata.issuer,
+            resource_metadata: `${baseUrl}/.well-known/oauth-protected-resource`,
+          }),
         },
         documentation: 'https://github.com/czlonkowski/n8n-mcp'
       });
@@ -1132,8 +1197,30 @@ export class SingleSessionHTTPServer {
       }
     });
 
+    // Build OAuth middleware using SDK's requireBearerAuth when OAuth is enabled
+    let oauthMiddleware: express.RequestHandler | undefined;
+    let resourceMetadataUrl: string | undefined;
+
+    if (this.authMode !== 'token' && this.oauthConfig && this.n8nTokenVerifier) {
+      const { requireBearerAuth } = await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js');
+      const { getOAuthProtectedResourceMetadataUrl } = await import('@modelcontextprotocol/sdk/server/auth/router.js');
+      resourceMetadataUrl = getOAuthProtectedResourceMetadataUrl(new URL(this.oauthConfig.serverUrl));
+      oauthMiddleware = requireBearerAuth({
+        verifier: this.n8nTokenVerifier,
+        resourceMetadataUrl,
+      });
+    }
+
+    // Create unified auth middleware
+    const authMiddleware = AuthManager.createAuthMiddleware(
+      this.authMode,
+      oauthMiddleware,
+      this.authToken,
+      resourceMetadataUrl
+    );
+
     // Main MCP endpoint with authentication and rate limiting
-    app.post('/mcp', authLimiter, jsonParser, async (req: express.Request, res: express.Response): Promise<void> => {
+    app.post('/mcp', authLimiter, jsonParser, authMiddleware, async (req: express.Request, res: express.Response): Promise<void> => {
       // Log comprehensive debug info about the request
       logger.info('POST /mcp request received - DETAILED DEBUG', {
         headers: req.headers,
@@ -1182,72 +1269,7 @@ export class SingleSessionHTTPServer {
         });
       }
       
-      // Enhanced authentication check with specific logging
-      const authHeader = req.headers.authorization;
-      
-      // Check if Authorization header is missing
-      if (!authHeader) {
-        logger.warn('Authentication failed: Missing Authorization header', { 
-          ip: req.ip,
-          userAgent: req.get('user-agent'),
-          reason: 'no_auth_header'
-        });
-        res.status(401).json({ 
-          jsonrpc: '2.0',
-          error: {
-            code: -32001,
-            message: 'Unauthorized'
-          },
-          id: null
-        });
-        return;
-      }
-      
-      // Check if Authorization header has Bearer prefix
-      if (!authHeader.startsWith('Bearer ')) {
-        logger.warn('Authentication failed: Invalid Authorization header format (expected Bearer token)', { 
-          ip: req.ip,
-          userAgent: req.get('user-agent'),
-          reason: 'invalid_auth_format',
-          headerPrefix: authHeader.substring(0, Math.min(authHeader.length, 10)) + '...'  // Log first 10 chars for debugging
-        });
-        res.status(401).json({ 
-          jsonrpc: '2.0',
-          error: {
-            code: -32001,
-            message: 'Unauthorized'
-          },
-          id: null
-        });
-        return;
-      }
-      
-      // Extract token and trim whitespace
-      const token = authHeader.slice(7).trim();
-
-      // SECURITY: Use timing-safe comparison to prevent timing attacks
-      // See: https://github.com/czlonkowski/n8n-mcp/issues/265 (CRITICAL-02)
-      const isValidToken = this.authToken &&
-        AuthManager.timingSafeCompare(token, this.authToken);
-
-      if (!isValidToken) {
-        logger.warn('Authentication failed: Invalid token', {
-          ip: req.ip,
-          userAgent: req.get('user-agent'),
-          reason: 'invalid_token'
-        });
-        res.status(401).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32001,
-            message: 'Unauthorized'
-          },
-          id: null
-        });
-        return;
-      }
-      
-      // Handle request with single session
+      // Authentication already handled by authMiddleware
       logger.info('Authentication successful - proceeding to handleRequest', {
         hasSession: !!this.session,
         sessionType: this.session?.isSSE ? 'SSE' : 'StreamableHTTP',
@@ -1293,19 +1315,38 @@ export class SingleSessionHTTPServer {
         return context;
       })();
 
+      // If OAuth auth succeeded, use the n8n token as the API key for downstream calls
+      const oauthContext = this.buildOAuthInstanceContext(req);
+
+      // Merge contexts: header values take precedence, but fill missing fields from OAuth
+      // This handles the common case where headers provide x-n8n-key (REST API key)
+      // but no x-n8n-url, while OAuth context knows the n8n URL from OAUTH_ISSUER_URL
+      const effectiveContext: InstanceContext | undefined = (() => {
+        if (instanceContext && oauthContext) {
+          return {
+            ...oauthContext,
+            ...instanceContext,
+            n8nApiUrl: instanceContext.n8nApiUrl || oauthContext.n8nApiUrl,
+            n8nApiKey: instanceContext.n8nApiKey || oauthContext.n8nApiKey,
+          };
+        }
+        return instanceContext || oauthContext;
+      })();
+
       // Log context extraction for debugging (only if context exists)
-      if (instanceContext) {
+      if (effectiveContext) {
         // Use sanitized logging for security
-        logger.debug('Instance context extracted from headers', {
-          hasUrl: !!instanceContext.n8nApiUrl,
-          hasKey: !!instanceContext.n8nApiKey,
-          instanceId: instanceContext.instanceId ? instanceContext.instanceId.substring(0, 8) + '...' : undefined,
-          sessionId: instanceContext.sessionId ? instanceContext.sessionId.substring(0, 8) + '...' : undefined,
-          urlDomain: instanceContext.n8nApiUrl ? new URL(instanceContext.n8nApiUrl).hostname : undefined
+        logger.debug('Instance context extracted', {
+          source: instanceContext ? 'headers' : 'oauth',
+          hasUrl: !!effectiveContext.n8nApiUrl,
+          hasKey: !!effectiveContext.n8nApiKey,
+          instanceId: effectiveContext.instanceId ? effectiveContext.instanceId.substring(0, 8) + '...' : undefined,
+          sessionId: effectiveContext.sessionId ? effectiveContext.sessionId.substring(0, 8) + '...' : undefined,
+          urlDomain: effectiveContext.n8nApiUrl ? new URL(effectiveContext.n8nApiUrl).hostname : undefined
         });
       }
 
-      await this.handleRequest(req, res, instanceContext);
+      await this.handleRequest(req, res, effectiveContext);
       
       logger.info('POST /mcp request completed - checking response status', {
         responseHeadersSent: res.headersSent,
@@ -1417,6 +1458,9 @@ export class SingleSessionHTTPServer {
       this.cleanupTimer = null;
       logger.info('Session cleanup timer stopped');
     }
+
+    // Clean up token verifier (no-op currently, but good practice)
+    this.n8nTokenVerifier = null;
     
     // Close all active transports (SDK pattern)
     const sessionIds = Object.keys(this.transports);

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,4 +1,7 @@
 import crypto from 'crypto';
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import type { AuthMode } from '../auth/oauth-config';
+import { logger } from './logger';
 
 export class AuthManager {
   private validTokens: Set<string>;
@@ -141,4 +144,130 @@ export class AuthManager {
       return false;
     }
   }
+
+  /**
+   * Create an Express middleware that handles authentication based on the configured mode.
+   *
+   * - 'token': validates static Bearer token (existing behavior)
+   * - 'oauth': delegates to SDK's requireBearerAuth middleware
+   * - 'both': tries OAuth middleware first, falls back to static token
+   *
+   * @param mode - The auth mode
+   * @param oauthMiddleware - SDK's requireBearerAuth middleware (for 'oauth' and 'both' modes)
+   * @param staticToken - Static auth token (required for 'token' and 'both' modes)
+   * @param resourceMetadataUrl - OAuth resource metadata URL for WWW-Authenticate header
+   */
+  static createAuthMiddleware(
+    mode: AuthMode,
+    oauthMiddleware?: RequestHandler,
+    staticToken?: string | null,
+    resourceMetadataUrl?: string
+  ): RequestHandler {
+    return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      const authHeader = req.headers.authorization;
+
+      if (!authHeader) {
+        logger.warn('Authentication failed: Missing Authorization header', {
+          ip: req.ip,
+          userAgent: req.get('user-agent'),
+          reason: 'no_auth_header'
+        });
+        const headers: Record<string, string> = {};
+        if (resourceMetadataUrl && (mode === 'oauth' || mode === 'both')) {
+          headers['WWW-Authenticate'] = `Bearer resource_metadata="${resourceMetadataUrl}"`;
+        }
+        res.set(headers).status(401).json({
+          jsonrpc: '2.0',
+          error: { code: -32001, message: 'Unauthorized' },
+          id: null
+        });
+        return;
+      }
+
+      if (!authHeader.startsWith('Bearer ')) {
+        logger.warn('Authentication failed: Invalid Authorization header format', {
+          ip: req.ip,
+          reason: 'invalid_auth_format'
+        });
+        res.status(401).json({
+          jsonrpc: '2.0',
+          error: { code: -32001, message: 'Unauthorized' },
+          id: null
+        });
+        return;
+      }
+
+      // Try OAuth middleware first for 'oauth' and 'both' modes
+      if ((mode === 'oauth' || mode === 'both') && oauthMiddleware) {
+        // Wrap the SDK middleware to intercept its response for 'both' mode fallback
+        const oauthResult = await new Promise<'success' | 'failed'>((resolve) => {
+          const mockRes = mode === 'both' ? createInterceptRes(res, () => resolve('failed')) : res;
+          const mockNext: NextFunction = () => resolve('success');
+          try {
+            const result = oauthMiddleware(req, mockRes as Response, mockNext);
+            // Handle async middleware
+            if (result && typeof (result as any).catch === 'function') {
+              (result as any).catch(() => resolve('failed'));
+            }
+          } catch {
+            resolve('failed');
+          }
+        });
+
+        if (oauthResult === 'success') {
+          logger.info('OAuth authentication successful');
+          next();
+          return;
+        }
+
+        // In pure 'oauth' mode, the SDK middleware already sent the 401
+        if (mode === 'oauth') {
+          return;
+        }
+        // In 'both' mode, fall through to static token check
+      }
+
+      const token = authHeader.slice(7).trim();
+
+      // Static token check for 'token' and 'both' modes
+      if ((mode === 'token' || mode === 'both') && staticToken) {
+        if (AuthManager.timingSafeCompare(token, staticToken)) {
+          logger.info('Static token authentication successful');
+          next();
+          return;
+        }
+      }
+
+      logger.warn('Authentication failed: Invalid token', { ip: req.ip, reason: 'invalid_token' });
+      const headers: Record<string, string> = {};
+      if (resourceMetadataUrl && (mode === 'oauth' || mode === 'both')) {
+        headers['WWW-Authenticate'] = `Bearer resource_metadata="${resourceMetadataUrl}"`;
+      }
+      res.set(headers).status(401).json({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Unauthorized' },
+        id: null
+      });
+    };
+  }
+}
+
+/**
+ * Create a proxy response object that intercepts status/json/send calls
+ * so the SDK middleware doesn't actually write the 401 to the real response
+ * when we want to fall back to static token auth in 'both' mode.
+ */
+function createInterceptRes(realRes: Response, onReject: () => void): Partial<Response> {
+  return {
+    status: () => {
+      onReject();
+      // Return a mock that absorbs .json()/.send()/.end()
+      return { json: () => realRes, send: () => realRes, end: () => realRes, set: () => realRes } as any;
+    },
+    set: () => ({ status: () => ({ json: () => realRes, send: () => realRes, end: () => realRes }) }) as any,
+    json: () => { onReject(); return realRes; },
+    send: () => { onReject(); return realRes; },
+    end: () => { onReject(); return realRes; },
+    headersSent: false,
+  } as Partial<Response>;
 }

--- a/tests/integration/oauth-flow.test.ts
+++ b/tests/integration/oauth-flow.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { InMemoryOAuthProvider } from '../../src/auth/oauth-provider';
+import { InMemoryClientsStore } from '../../src/auth/oauth-clients-store';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+import crypto from 'crypto';
+
+/**
+ * End-to-end OAuth 2.1 flow test simulating a real client interaction.
+ */
+describe('OAuth 2.1 End-to-End Flow', () => {
+  let provider: InMemoryOAuthProvider;
+  let clientsStore: InMemoryClientsStore;
+
+  beforeEach(() => {
+    clientsStore = new InMemoryClientsStore();
+    provider = new InMemoryOAuthProvider(clientsStore);
+  });
+
+  afterEach(() => {
+    provider.destroy();
+  });
+
+  it('completes full OAuth flow: register -> authorize -> token -> access -> refresh -> revoke', async () => {
+    // Step 1: Dynamic Client Registration (RFC 7591)
+    const registeredClient = clientsStore.registerClient({
+      redirect_uris: ['https://client.example.com/callback'],
+      client_name: 'Integration Test Client',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+    }) as OAuthClientInformationFull;
+
+    expect(registeredClient.client_id).toBeTruthy();
+    expect(registeredClient.client_secret).toBeTruthy();
+
+    // Verify client can be looked up
+    const lookedUp = clientsStore.getClient(registeredClient.client_id);
+    expect(lookedUp).toEqual(registeredClient);
+
+    // Step 2: Generate PKCE challenge
+    const codeVerifier = crypto.randomBytes(32).toString('base64url');
+    const codeChallenge = crypto
+      .createHash('sha256')
+      .update(codeVerifier)
+      .digest('base64url');
+
+    // Step 3: Authorization request
+    let capturedRedirectUrl: string | undefined;
+    const mockRes = {
+      redirect: (_status: number, url: string) => {
+        capturedRedirectUrl = url;
+      },
+    } as any;
+
+    await provider.authorize(registeredClient, {
+      codeChallenge,
+      redirectUri: 'https://client.example.com/callback',
+      state: 'random-state-value',
+      scopes: ['mcp:read', 'mcp:write'],
+    }, mockRes);
+
+    expect(capturedRedirectUrl).toBeTruthy();
+    const redirectUrl = new URL(capturedRedirectUrl!);
+    expect(redirectUrl.searchParams.get('state')).toBe('random-state-value');
+    const authCode = redirectUrl.searchParams.get('code')!;
+    expect(authCode).toBeTruthy();
+
+    // Step 4: Exchange authorization code for tokens
+    const tokens = await provider.exchangeAuthorizationCode(
+      registeredClient,
+      authCode,
+      codeVerifier,
+      'https://client.example.com/callback'
+    );
+
+    expect(tokens.access_token).toBeTruthy();
+    expect(tokens.refresh_token).toBeTruthy();
+    expect(tokens.token_type).toBe('bearer');
+    expect(tokens.expires_in).toBeGreaterThan(0);
+    expect(tokens.scope).toBe('mcp:read mcp:write');
+
+    // Step 5: Use access token
+    const authInfo = await provider.verifyAccessToken(tokens.access_token);
+    expect(authInfo.clientId).toBe(registeredClient.client_id);
+    expect(authInfo.scopes).toEqual(['mcp:read', 'mcp:write']);
+
+    // Step 6: Refresh token
+    const refreshedTokens = await provider.exchangeRefreshToken(
+      registeredClient,
+      tokens.refresh_token!
+    );
+
+    expect(refreshedTokens.access_token).not.toBe(tokens.access_token);
+    expect(refreshedTokens.refresh_token).not.toBe(tokens.refresh_token);
+
+    // Old access token should still work until it expires
+    // New access token should also work
+    const newAuthInfo = await provider.verifyAccessToken(refreshedTokens.access_token);
+    expect(newAuthInfo.clientId).toBe(registeredClient.client_id);
+
+    // Step 7: Revoke new access token
+    await provider.revokeToken!(registeredClient, {
+      token: refreshedTokens.access_token,
+      token_type_hint: 'access_token',
+    });
+
+    // Revoked token should no longer work
+    await expect(
+      provider.verifyAccessToken(refreshedTokens.access_token)
+    ).rejects.toThrow();
+
+    // Step 8: Revoke refresh token
+    await provider.revokeToken!(registeredClient, {
+      token: refreshedTokens.refresh_token!,
+      token_type_hint: 'refresh_token',
+    });
+
+    // Revoked refresh token should no longer work
+    await expect(
+      provider.exchangeRefreshToken(registeredClient, refreshedTokens.refresh_token!)
+    ).rejects.toThrow();
+  });
+
+  it('prevents authorization code reuse', async () => {
+    const client = clientsStore.registerClient({
+      redirect_uris: ['https://example.com/cb'],
+    }) as OAuthClientInformationFull;
+
+    const mockRes = { redirect: vi.fn() } as any;
+    await provider.authorize(client, {
+      codeChallenge: 'challenge',
+      redirectUri: 'https://example.com/cb',
+    }, mockRes);
+
+    const code = new URL(mockRes.redirect.mock.calls[0][1]).searchParams.get('code')!;
+
+    // First exchange succeeds
+    const tokens = await provider.exchangeAuthorizationCode(client, code);
+    expect(tokens.access_token).toBeTruthy();
+
+    // Second exchange fails (code consumed)
+    await expect(
+      provider.exchangeAuthorizationCode(client, code)
+    ).rejects.toThrow();
+  });
+
+  it('enforces refresh token rotation', async () => {
+    const client = clientsStore.registerClient({
+      redirect_uris: ['https://example.com/cb'],
+    }) as OAuthClientInformationFull;
+
+    const mockRes = { redirect: vi.fn() } as any;
+    await provider.authorize(client, {
+      codeChallenge: 'challenge',
+      redirectUri: 'https://example.com/cb',
+    }, mockRes);
+
+    const code = new URL(mockRes.redirect.mock.calls[0][1]).searchParams.get('code')!;
+    const tokens = await provider.exchangeAuthorizationCode(client, code);
+
+    // First refresh succeeds and rotates token
+    const newTokens = await provider.exchangeRefreshToken(client, tokens.refresh_token!);
+    expect(newTokens.refresh_token).not.toBe(tokens.refresh_token);
+
+    // Using old refresh token fails
+    await expect(
+      provider.exchangeRefreshToken(client, tokens.refresh_token!)
+    ).rejects.toThrow();
+
+    // Using new refresh token succeeds
+    const newerTokens = await provider.exchangeRefreshToken(client, newTokens.refresh_token!);
+    expect(newerTokens.access_token).toBeTruthy();
+  });
+});

--- a/tests/unit/auth/n8n-token-verifier.test.ts
+++ b/tests/unit/auth/n8n-token-verifier.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { N8nTokenVerifier } from '../../../src/auth/n8n-token-verifier';
+
+describe('N8nTokenVerifier', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns AuthInfo with token and n8nBaseUrl on successful verification', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 })
+    );
+
+    const verifier = new N8nTokenVerifier('https://n8n.example.com');
+    const result = await verifier.verifyAccessToken('test-token-123');
+
+    expect(result.token).toBe('test-token-123');
+    expect(result.clientId).toBe('n8n-oauth-user');
+    expect(result.scopes).toEqual(['tool:listWorkflows', 'tool:getWorkflowDetails']);
+    expect(result.extra).toEqual({ n8nBaseUrl: 'https://n8n.example.com' });
+  });
+
+  it('calls n8n MCP endpoint with correct method and headers', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ jsonrpc: '2.0', result: {}, id: 1 }), { status: 200 })
+    );
+
+    const verifier = new N8nTokenVerifier('https://n8n.example.com');
+    await verifier.verifyAccessToken('my-token');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://n8n.example.com/mcp-server/http',
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': 'Bearer my-token',
+          'Content-Type': 'application/json',
+          'Accept': 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'ping',
+          id: 1,
+        }),
+      }
+    );
+  });
+
+  it('strips trailing slashes from base URL', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ jsonrpc: '2.0', result: {}, id: 1 }), { status: 200 })
+    );
+
+    const verifier = new N8nTokenVerifier('https://n8n.example.com///');
+    await verifier.verifyAccessToken('token');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://n8n.example.com/mcp-server/http',
+      expect.anything()
+    );
+  });
+
+  it('throws on 401 response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Unauthorized', { status: 401 })
+    );
+
+    const verifier = new N8nTokenVerifier('https://n8n.example.com');
+    await expect(verifier.verifyAccessToken('bad-token'))
+      .rejects.toThrow('Invalid or expired n8n access token');
+  });
+
+  it('throws on 403 response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Forbidden', { status: 403 })
+    );
+
+    const verifier = new N8nTokenVerifier('https://n8n.example.com');
+    await expect(verifier.verifyAccessToken('bad-token'))
+      .rejects.toThrow('Invalid or expired n8n access token');
+  });
+
+  it('throws on network error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
+
+    const verifier = new N8nTokenVerifier('https://n8n.example.com');
+    await expect(verifier.verifyAccessToken('token'))
+      .rejects.toThrow('Failed to verify token against n8n');
+  });
+});

--- a/tests/unit/auth/oauth-config.test.ts
+++ b/tests/unit/auth/oauth-config.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadAuthMode, loadOAuthConfig, fetchN8nOAuthMetadata } from '../../../src/auth/oauth-config';
+
+describe('loadAuthMode', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('defaults to "token" when AUTH_MODE is not set', () => {
+    delete process.env.AUTH_MODE;
+    expect(loadAuthMode()).toBe('token');
+  });
+
+  it('returns "oauth" when AUTH_MODE=oauth', () => {
+    process.env.AUTH_MODE = 'oauth';
+    expect(loadAuthMode()).toBe('oauth');
+  });
+
+  it('returns "both" when AUTH_MODE=both', () => {
+    process.env.AUTH_MODE = 'both';
+    expect(loadAuthMode()).toBe('both');
+  });
+
+  it('is case-insensitive', () => {
+    process.env.AUTH_MODE = 'OAuth';
+    expect(loadAuthMode()).toBe('oauth');
+  });
+
+  it('falls back to "token" for invalid values', () => {
+    process.env.AUTH_MODE = 'invalid';
+    expect(loadAuthMode()).toBe('token');
+  });
+});
+
+describe('loadOAuthConfig', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns null for token mode', () => {
+    expect(loadOAuthConfig('token')).toBeNull();
+  });
+
+  it('throws when OAUTH_ISSUER_URL is missing in oauth mode', () => {
+    delete process.env.OAUTH_ISSUER_URL;
+    expect(() => loadOAuthConfig('oauth')).toThrow('OAUTH_ISSUER_URL is required');
+  });
+
+  it('throws when OAUTH_ISSUER_URL is invalid', () => {
+    process.env.OAUTH_ISSUER_URL = 'not-a-url';
+    expect(() => loadOAuthConfig('oauth')).toThrow('not a valid URL');
+  });
+
+  it('loads base config with defaults', () => {
+    process.env.OAUTH_ISSUER_URL = 'https://n8n.example.com';
+    delete process.env.OAUTH_SERVER_URL;
+
+    const config = loadOAuthConfig('oauth');
+    expect(config).not.toBeNull();
+    expect(config!.issuerUrl).toBe('https://n8n.example.com');
+    expect(config!.serverUrl).toMatch(/^http:\/\//);
+  });
+
+  it('does not include scopesSupported (comes from n8n metadata)', () => {
+    process.env.OAUTH_ISSUER_URL = 'https://n8n.example.com';
+    const config = loadOAuthConfig('oauth');
+    expect(config).not.toHaveProperty('scopesSupported');
+    expect(config).not.toHaveProperty('n8nOAuthMetadata');
+  });
+
+  it('uses OAUTH_SERVER_URL when provided', () => {
+    process.env.OAUTH_ISSUER_URL = 'https://n8n.example.com';
+    process.env.OAUTH_SERVER_URL = 'https://server.example.com';
+
+    const config = loadOAuthConfig('both');
+    expect(config!.serverUrl).toBe('https://server.example.com');
+  });
+});
+
+describe('fetchN8nOAuthMetadata', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches and returns valid metadata', async () => {
+    const mockMetadata = {
+      issuer: 'https://n8n.example.com',
+      authorization_endpoint: 'https://n8n.example.com/mcp-oauth/authorize',
+      token_endpoint: 'https://n8n.example.com/mcp-oauth/token',
+      registration_endpoint: 'https://n8n.example.com/mcp-oauth/register',
+      response_types_supported: ['code'],
+      scopes_supported: ['tool:listWorkflows', 'tool:getWorkflowDetails'],
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(mockMetadata), { status: 200 })
+    );
+
+    const result = await fetchN8nOAuthMetadata('https://n8n.example.com');
+    expect(result.issuer).toBe('https://n8n.example.com');
+    expect(result.authorization_endpoint).toBe('https://n8n.example.com/mcp-oauth/authorize');
+    expect(result.scopes_supported).toEqual(['tool:listWorkflows', 'tool:getWorkflowDetails']);
+  });
+
+  it('throws on non-200 response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Not Found', { status: 404, statusText: 'Not Found' })
+    );
+
+    await expect(fetchN8nOAuthMetadata('https://n8n.example.com'))
+      .rejects.toThrow('Failed to fetch OAuth metadata');
+  });
+
+  it('throws on missing required fields', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ issuer: 'https://n8n.example.com' }), { status: 200 })
+    );
+
+    await expect(fetchN8nOAuthMetadata('https://n8n.example.com'))
+      .rejects.toThrow('missing required fields');
+  });
+
+  it('strips trailing slash from issuer URL', async () => {
+    const mockMetadata = {
+      issuer: 'https://n8n.example.com',
+      authorization_endpoint: 'https://n8n.example.com/mcp-oauth/authorize',
+      token_endpoint: 'https://n8n.example.com/mcp-oauth/token',
+      response_types_supported: ['code'],
+    };
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(mockMetadata), { status: 200 })
+    );
+
+    await fetchN8nOAuthMetadata('https://n8n.example.com/');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://n8n.example.com/.well-known/oauth-authorization-server'
+    );
+  });
+});

--- a/tests/unit/auth/oauth-provider.test.ts
+++ b/tests/unit/auth/oauth-provider.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { InMemoryOAuthProvider } from '../../../src/auth/oauth-provider';
+import { InMemoryClientsStore } from '../../../src/auth/oauth-clients-store';
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/sdk/shared/auth.js';
+
+describe('InMemoryOAuthProvider', () => {
+  let provider: InMemoryOAuthProvider;
+  let clientsStore: InMemoryClientsStore;
+  let testClient: OAuthClientInformationFull;
+
+  beforeEach(() => {
+    clientsStore = new InMemoryClientsStore();
+    provider = new InMemoryOAuthProvider(clientsStore);
+
+    // Register a test client
+    testClient = clientsStore.registerClient({
+      redirect_uris: ['https://example.com/callback'],
+      client_name: 'Test Client',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+    }) as OAuthClientInformationFull;
+  });
+
+  afterEach(() => {
+    provider.destroy();
+  });
+
+  describe('clientsStore', () => {
+    it('returns the clients store', () => {
+      expect(provider.clientsStore).toBe(clientsStore);
+    });
+  });
+
+  describe('authorize', () => {
+    it('redirects with authorization code and state', async () => {
+      const res = {
+        redirect: vi.fn(),
+      } as any;
+
+      await provider.authorize(testClient, {
+        codeChallenge: 'test-challenge',
+        redirectUri: 'https://example.com/callback',
+        state: 'test-state',
+        scopes: ['mcp:read'],
+      }, res);
+
+      expect(res.redirect).toHaveBeenCalledOnce();
+      const [status, url] = res.redirect.mock.calls[0];
+      expect(status).toBe(302);
+
+      const redirectUrl = new URL(url);
+      expect(redirectUrl.searchParams.get('code')).toBeTruthy();
+      expect(redirectUrl.searchParams.get('state')).toBe('test-state');
+      expect(redirectUrl.origin + redirectUrl.pathname).toBe('https://example.com/callback');
+    });
+
+    it('redirects without state when not provided', async () => {
+      const res = { redirect: vi.fn() } as any;
+
+      await provider.authorize(testClient, {
+        codeChallenge: 'test-challenge',
+        redirectUri: 'https://example.com/callback',
+      }, res);
+
+      const redirectUrl = new URL(res.redirect.mock.calls[0][1]);
+      expect(redirectUrl.searchParams.has('state')).toBe(false);
+    });
+  });
+
+  describe('challengeForAuthorizationCode', () => {
+    it('returns the code challenge', async () => {
+      const res = { redirect: vi.fn() } as any;
+      await provider.authorize(testClient, {
+        codeChallenge: 'my-challenge-123',
+        redirectUri: 'https://example.com/callback',
+      }, res);
+
+      const code = new URL(res.redirect.mock.calls[0][1]).searchParams.get('code')!;
+      const challenge = await provider.challengeForAuthorizationCode(testClient, code);
+      expect(challenge).toBe('my-challenge-123');
+    });
+
+    it('throws for invalid code', async () => {
+      await expect(
+        provider.challengeForAuthorizationCode(testClient, 'nonexistent')
+      ).rejects.toThrow('Invalid or expired');
+    });
+  });
+
+  describe('exchangeAuthorizationCode', () => {
+    it('returns tokens for valid code', async () => {
+      const res = { redirect: vi.fn() } as any;
+      await provider.authorize(testClient, {
+        codeChallenge: 'challenge',
+        redirectUri: 'https://example.com/callback',
+        scopes: ['mcp:read'],
+      }, res);
+
+      const code = new URL(res.redirect.mock.calls[0][1]).searchParams.get('code')!;
+      const tokens = await provider.exchangeAuthorizationCode(testClient, code);
+
+      expect(tokens.access_token).toBeTruthy();
+      expect(tokens.refresh_token).toBeTruthy();
+      expect(tokens.token_type).toBe('bearer');
+      expect(tokens.expires_in).toBeGreaterThan(0);
+      expect(tokens.scope).toBe('mcp:read');
+    });
+
+    it('consumes the code (one-time use)', async () => {
+      const res = { redirect: vi.fn() } as any;
+      await provider.authorize(testClient, {
+        codeChallenge: 'challenge',
+        redirectUri: 'https://example.com/callback',
+      }, res);
+
+      const code = new URL(res.redirect.mock.calls[0][1]).searchParams.get('code')!;
+      await provider.exchangeAuthorizationCode(testClient, code);
+
+      await expect(
+        provider.exchangeAuthorizationCode(testClient, code)
+      ).rejects.toThrow('Invalid authorization code');
+    });
+
+    it('rejects wrong client', async () => {
+      const res = { redirect: vi.fn() } as any;
+      await provider.authorize(testClient, {
+        codeChallenge: 'challenge',
+        redirectUri: 'https://example.com/callback',
+      }, res);
+
+      const code = new URL(res.redirect.mock.calls[0][1]).searchParams.get('code')!;
+      const otherClient = { ...testClient, client_id: 'other-id' };
+
+      await expect(
+        provider.exchangeAuthorizationCode(otherClient, code)
+      ).rejects.toThrow('Client ID mismatch');
+    });
+  });
+
+  describe('verifyAccessToken', () => {
+    it('verifies a valid token', async () => {
+      const res = { redirect: vi.fn() } as any;
+      await provider.authorize(testClient, {
+        codeChallenge: 'challenge',
+        redirectUri: 'https://example.com/callback',
+        scopes: ['mcp:read', 'mcp:write'],
+      }, res);
+
+      const code = new URL(res.redirect.mock.calls[0][1]).searchParams.get('code')!;
+      const tokens = await provider.exchangeAuthorizationCode(testClient, code);
+
+      const authInfo = await provider.verifyAccessToken(tokens.access_token);
+      expect(authInfo.clientId).toBe(testClient.client_id);
+      expect(authInfo.scopes).toEqual(['mcp:read', 'mcp:write']);
+      expect(authInfo.token).toBe(tokens.access_token);
+      expect(authInfo.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    });
+
+    it('rejects invalid token', async () => {
+      await expect(
+        provider.verifyAccessToken('invalid-token')
+      ).rejects.toThrow('Invalid access token');
+    });
+  });
+
+  describe('exchangeRefreshToken', () => {
+    it('issues new tokens from refresh token', async () => {
+      const res = { redirect: vi.fn() } as any;
+      await provider.authorize(testClient, {
+        codeChallenge: 'challenge',
+        redirectUri: 'https://example.com/callback',
+        scopes: ['mcp:read'],
+      }, res);
+
+      const code = new URL(res.redirect.mock.calls[0][1]).searchParams.get('code')!;
+      const tokens = await provider.exchangeAuthorizationCode(testClient, code);
+
+      const newTokens = await provider.exchangeRefreshToken(
+        testClient, tokens.refresh_token!
+      );
+
+      expect(newTokens.access_token).toBeTruthy();
+      expect(newTokens.access_token).not.toBe(tokens.access_token);
+      expect(newTokens.refresh_token).toBeTruthy();
+      expect(newTokens.refresh_token).not.toBe(tokens.refresh_token);
+    });
+
+    it('rotates refresh token (old one invalid)', async () => {
+      const res = { redirect: vi.fn() } as any;
+      await provider.authorize(testClient, {
+        codeChallenge: 'challenge',
+        redirectUri: 'https://example.com/callback',
+      }, res);
+
+      const code = new URL(res.redirect.mock.calls[0][1]).searchParams.get('code')!;
+      const tokens = await provider.exchangeAuthorizationCode(testClient, code);
+
+      await provider.exchangeRefreshToken(testClient, tokens.refresh_token!);
+
+      await expect(
+        provider.exchangeRefreshToken(testClient, tokens.refresh_token!)
+      ).rejects.toThrow('Invalid or expired');
+    });
+
+    it('rejects wrong client', async () => {
+      const res = { redirect: vi.fn() } as any;
+      await provider.authorize(testClient, {
+        codeChallenge: 'challenge',
+        redirectUri: 'https://example.com/callback',
+      }, res);
+
+      const code = new URL(res.redirect.mock.calls[0][1]).searchParams.get('code')!;
+      const tokens = await provider.exchangeAuthorizationCode(testClient, code);
+      const otherClient = { ...testClient, client_id: 'other-id' };
+
+      await expect(
+        provider.exchangeRefreshToken(otherClient, tokens.refresh_token!)
+      ).rejects.toThrow('Client ID mismatch');
+    });
+  });
+
+  describe('revokeToken', () => {
+    it('revokes an access token', async () => {
+      const res = { redirect: vi.fn() } as any;
+      await provider.authorize(testClient, {
+        codeChallenge: 'challenge',
+        redirectUri: 'https://example.com/callback',
+      }, res);
+
+      const code = new URL(res.redirect.mock.calls[0][1]).searchParams.get('code')!;
+      const tokens = await provider.exchangeAuthorizationCode(testClient, code);
+
+      await provider.revokeToken!(testClient, {
+        token: tokens.access_token,
+        token_type_hint: 'access_token',
+      });
+
+      await expect(
+        provider.verifyAccessToken(tokens.access_token)
+      ).rejects.toThrow('Invalid access token');
+    });
+
+    it('revokes a refresh token', async () => {
+      const res = { redirect: vi.fn() } as any;
+      await provider.authorize(testClient, {
+        codeChallenge: 'challenge',
+        redirectUri: 'https://example.com/callback',
+      }, res);
+
+      const code = new URL(res.redirect.mock.calls[0][1]).searchParams.get('code')!;
+      const tokens = await provider.exchangeAuthorizationCode(testClient, code);
+
+      await provider.revokeToken!(testClient, {
+        token: tokens.refresh_token!,
+        token_type_hint: 'refresh_token',
+      });
+
+      await expect(
+        provider.exchangeRefreshToken(testClient, tokens.refresh_token!)
+      ).rejects.toThrow('Invalid or expired');
+    });
+
+    it('does nothing for invalid token (per RFC 7009)', async () => {
+      await expect(
+        provider.revokeToken!(testClient, { token: 'nonexistent' })
+      ).resolves.toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add OAuth 2.1 authentication mode (`AUTH_MODE=oauth|both|token`) with n8n as the authorization server
- Fix missing `expiresAt` in `N8nTokenVerifier` AuthInfo, which caused MCP SDK's `requireBearerAuth` to reject verified tokens with a 500 error
- Merge header and OAuth instance contexts so `x-n8n-key` header works alongside OAuth-derived n8n URL, enabling management tools (list/create/update workflows) in OAuth mode

## Test plan
- [ ] `npm test` passes
- [ ] Server starts in `AUTH_MODE=oauth` with `OAUTH_ISSUER_URL` pointing to n8n
- [ ] Claude Code `/mcp` reconnect succeeds after OAuth flow
- [ ] Management tools (n8n_list_workflows, etc.) appear and work with `x-n8n-key` header

Conceived by Romuald Członkowski - www.aiadvisors.pl/en