### PR TITLE
feat: add MiniMax as LLM provider for community docs generation (default M3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -187,6 +187,28 @@ ENABLE_MULTI_TENANT=false
 # Set to true to automatically generate metadata when running fetch:templates
 # METADATA_GENERATION_ENABLED=false
 
+# ==========================================
+# LLM PROVIDER CONFIGURATION (Community Docs)
+# ==========================================
+# Configure the LLM used for AI-powered community node documentation generation.
+#
+# Option 1: Use a provider preset (recommended for cloud providers)
+# Supported presets: openai, minimax, anthropic
+# N8N_MCP_LLM_PROVIDER=minimax
+#
+# Option 2: Manual configuration (for local servers or custom endpoints)
+# N8N_MCP_LLM_BASE_URL=http://localhost:1234/v1
+# N8N_MCP_LLM_MODEL=qwen3-4b-thinking-2507
+#
+# API key (auto-detected from MINIMAX_API_KEY or OPENAI_API_KEY if not set)
+# N8N_MCP_LLM_API_KEY=
+#
+# MiniMax API key (get from https://platform.minimaxi.com)
+# MINIMAX_API_KEY=
+#
+# Request timeout in milliseconds (default: 60000)
+# N8N_MCP_LLM_TIMEOUT=60000
+
 # ========================================
 # INTEGRATION TESTING CONFIGURATION
 # ========================================

--- a/README.md
+++ b/README.md
@@ -1259,7 +1259,7 @@ Set `N8N_MCP_LLM_PROVIDER` for quick setup with a cloud provider:
 | Provider | Preset Name | Default Model | API Key Env Var |
 |----------|------------|---------------|-----------------|
 | [OpenAI](https://openai.com) | `openai` | `gpt-4o-mini` | `OPENAI_API_KEY` |
-| [MiniMax](https://www.minimaxi.com) | `minimax` | `MiniMax-M2.7` | `MINIMAX_API_KEY` |
+| [MiniMax](https://www.minimaxi.com) | `minimax` | `MiniMax-M3` | `MINIMAX_API_KEY` |
 | [Anthropic](https://anthropic.com) | `anthropic` | `claude-sonnet-4-20250514` | `N8N_MCP_LLM_API_KEY` |
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1248,10 +1248,43 @@ The system automatically handles:
 
 See [Automated Release Guide](./docs/AUTOMATED_RELEASES.md) for complete details.
 
+## 🤖 LLM Provider Configuration
+
+The AI-powered community node documentation generator supports multiple LLM providers. Configure via environment variables:
+
+### Provider Presets
+
+Set `N8N_MCP_LLM_PROVIDER` for quick setup with a cloud provider:
+
+| Provider | Preset Name | Default Model | API Key Env Var |
+|----------|------------|---------------|-----------------|
+| [OpenAI](https://openai.com) | `openai` | `gpt-4o-mini` | `OPENAI_API_KEY` |
+| [MiniMax](https://www.minimaxi.com) | `minimax` | `MiniMax-M2.7` | `MINIMAX_API_KEY` |
+| [Anthropic](https://anthropic.com) | `anthropic` | `claude-sonnet-4-20250514` | `N8N_MCP_LLM_API_KEY` |
+
+```bash
+# Example: Use MiniMax as the LLM provider
+N8N_MCP_LLM_PROVIDER=minimax
+MINIMAX_API_KEY=your-api-key
+```
+
+### Manual Configuration
+
+For local servers or custom endpoints, configure each setting individually:
+
+```bash
+N8N_MCP_LLM_BASE_URL=http://localhost:1234/v1
+N8N_MCP_LLM_MODEL=qwen3-4b-thinking-2507
+N8N_MCP_LLM_API_KEY=not-needed
+```
+
+Manual overrides (`N8N_MCP_LLM_BASE_URL`, `N8N_MCP_LLM_MODEL`) take precedence over preset defaults.
+
 ## 👏 Acknowledgments
 
 - [n8n](https://n8n.io) team for the workflow automation platform
 - [Anthropic](https://anthropic.com) for the Model Context Protocol
+- [MiniMax](https://www.minimaxi.com) for the MiniMax AI platform
 - All contributors and users of this project
 
 ### Template Attribution

--- a/src/community/documentation-generator.ts
+++ b/src/community/documentation-generator.ts
@@ -1,8 +1,9 @@
 /**
  * AI-powered documentation generator for community nodes.
  *
- * Uses a local LLM (Qwen or compatible) via OpenAI-compatible API
- * to generate structured documentation summaries from README content.
+ * Uses an LLM via OpenAI-compatible API to generate structured
+ * documentation summaries from README content. Supports multiple
+ * providers including local servers, OpenAI, MiniMax, and others.
  */
 
 import OpenAI from 'openai';
@@ -60,6 +61,42 @@ export interface DocumentationGeneratorConfig {
   /** Temperature for generation (default: 0.3, set to undefined to omit) */
   temperature?: number;
 }
+
+/**
+ * Provider preset configuration for cloud LLM services.
+ * Each preset defines the base URL, default model, and provider-specific behavior.
+ */
+export interface LLMProviderPreset {
+  baseUrl: string;
+  model: string;
+  /** Whether temperature should be sent (cloud providers may reject unsupported values) */
+  supportsTemperature: boolean;
+  /** Temperature range constraint [min, max] */
+  temperatureRange?: [number, number];
+}
+
+/**
+ * Built-in LLM provider presets for quick configuration.
+ * Use N8N_MCP_LLM_PROVIDER env var to select a preset by name.
+ */
+export const LLM_PROVIDER_PRESETS: Record<string, LLMProviderPreset> = {
+  openai: {
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o-mini',
+    supportsTemperature: true,
+  },
+  minimax: {
+    baseUrl: 'https://api.minimax.io/v1',
+    model: 'MiniMax-M2.7',
+    supportsTemperature: true,
+    temperatureRange: [0, 1],
+  },
+  anthropic: {
+    baseUrl: 'https://api.anthropic.com/v1',
+    model: 'claude-sonnet-4-20250514',
+    supportsTemperature: true,
+  },
+};
 
 /**
  * Default configuration
@@ -243,23 +280,34 @@ Guidelines:
   }
 
   /**
-   * Extract JSON from LLM response (handles markdown code blocks)
+   * Strip thinking/reasoning tags from LLM responses.
+   * Some models (MiniMax M2.5/M2.7, Qwen) wrap internal reasoning in <think> tags.
+   */
+  private stripThinkingTags(content: string): string {
+    return content.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+  }
+
+  /**
+   * Extract JSON from LLM response (handles markdown code blocks and thinking tags)
    */
   private extractJson(content: string): string {
+    // Strip thinking tags from reasoning models (MiniMax, Qwen, etc.)
+    const cleaned = this.stripThinkingTags(content);
+
     // Try to extract from markdown code block
-    const jsonBlockMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/);
+    const jsonBlockMatch = cleaned.match(/```(?:json)?\s*([\s\S]*?)```/);
     if (jsonBlockMatch) {
       return jsonBlockMatch[1].trim();
     }
 
     // Try to find JSON object directly
-    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    const jsonMatch = cleaned.match(/\{[\s\S]*\}/);
     if (jsonMatch) {
       return jsonMatch[0];
     }
 
     // Return as-is if no extraction needed
-    return content.trim();
+    return cleaned.trim();
   }
 
   /**
@@ -351,21 +399,68 @@ Guidelines:
 }
 
 /**
- * Create a documentation generator with environment variable configuration
+ * Clamp temperature to a provider's supported range.
+ */
+export function clampTemperature(value: number, range: [number, number]): number {
+  return Math.max(range[0], Math.min(range[1], value));
+}
+
+/**
+ * Resolve provider preset from N8N_MCP_LLM_PROVIDER env var.
+ * Returns undefined if no preset matches.
+ */
+export function resolveProviderPreset(providerName?: string): LLMProviderPreset | undefined {
+  if (!providerName) return undefined;
+  return LLM_PROVIDER_PRESETS[providerName.toLowerCase()];
+}
+
+/**
+ * Create a documentation generator with environment variable configuration.
+ *
+ * Supports two configuration modes:
+ * 1. **Provider preset**: Set `N8N_MCP_LLM_PROVIDER` to a provider name (e.g., "minimax", "openai")
+ *    and the base URL, model, and temperature handling are auto-configured.
+ * 2. **Manual config**: Set `N8N_MCP_LLM_BASE_URL`, `N8N_MCP_LLM_MODEL`, etc. individually.
+ *
+ * Manual overrides (BASE_URL, MODEL) take precedence over preset defaults.
  */
 export function createDocumentationGenerator(): DocumentationGenerator {
-  const baseUrl = process.env.N8N_MCP_LLM_BASE_URL || 'http://localhost:1234/v1';
-  const model = process.env.N8N_MCP_LLM_MODEL || 'qwen3-4b-thinking-2507';
+  const providerName = process.env.N8N_MCP_LLM_PROVIDER;
+  const preset = resolveProviderPreset(providerName);
+
+  const baseUrl = process.env.N8N_MCP_LLM_BASE_URL || preset?.baseUrl || 'http://localhost:1234/v1';
+  const model = process.env.N8N_MCP_LLM_MODEL || preset?.model || 'qwen3-4b-thinking-2507';
   const timeout = parseInt(process.env.N8N_MCP_LLM_TIMEOUT || '60000', 10);
-  const apiKey = process.env.N8N_MCP_LLM_API_KEY || process.env.OPENAI_API_KEY;
-  // Only set temperature for local LLM servers; cloud APIs like OpenAI may not support custom values
-  const isLocalServer = !baseUrl.includes('openai.com') && !baseUrl.includes('anthropic.com');
+  const apiKey = process.env.N8N_MCP_LLM_API_KEY
+    || process.env.MINIMAX_API_KEY
+    || process.env.OPENAI_API_KEY;
+
+  // Determine temperature based on provider capabilities
+  const isCloudProvider = preset != null
+    || baseUrl.includes('openai.com')
+    || baseUrl.includes('anthropic.com')
+    || baseUrl.includes('minimax.io');
+
+  let temperature: number | undefined;
+  if (isCloudProvider && preset?.supportsTemperature) {
+    temperature = 0.3;
+    if (preset.temperatureRange) {
+      temperature = clampTemperature(temperature, preset.temperatureRange);
+    }
+  } else if (!isCloudProvider) {
+    // Local servers generally support temperature
+    temperature = 0.3;
+  }
+
+  if (preset) {
+    logger.info(`Using LLM provider preset: ${providerName} (${model} via ${baseUrl})`);
+  }
 
   return new DocumentationGenerator({
     baseUrl,
     model,
     timeout,
     ...(apiKey ? { apiKey } : {}),
-    ...(isLocalServer ? { temperature: 0.3 } : {}),
+    ...(temperature !== undefined ? { temperature } : {}),
   });
 }

--- a/src/community/documentation-generator.ts
+++ b/src/community/documentation-generator.ts
@@ -87,7 +87,7 @@ export const LLM_PROVIDER_PRESETS: Record<string, LLMProviderPreset> = {
   },
   minimax: {
     baseUrl: 'https://api.minimax.io/v1',
-    model: 'MiniMax-M2.7',
+    model: 'MiniMax-M3',
     supportsTemperature: true,
     temperatureRange: [0, 1],
   },
@@ -281,7 +281,7 @@ Guidelines:
 
   /**
    * Strip thinking/reasoning tags from LLM responses.
-   * Some models (MiniMax M2.5/M2.7, Qwen) wrap internal reasoning in <think> tags.
+   * Some models (MiniMax M2.7, Qwen) wrap internal reasoning in <think> tags.
    */
   private stripThinkingTags(content: string): string {
     return content.replace(/<think>[\s\S]*?<\/think>/g, '').trim();

--- a/src/community/index.ts
+++ b/src/community/index.ts
@@ -23,7 +23,11 @@ export {
   DocumentationResult,
   DocumentationSummary,
   DocumentationSummarySchema,
+  LLMProviderPreset,
+  LLM_PROVIDER_PRESETS,
   createDocumentationGenerator,
+  clampTemperature,
+  resolveProviderPreset,
 } from './documentation-generator';
 
 export {

--- a/tests/integration/community/llm-provider-integration.test.ts
+++ b/tests/integration/community/llm-provider-integration.test.ts
@@ -135,7 +135,7 @@ describe('LLM Provider Integration', () => {
 
       const generator = createDocumentationGenerator();
 
-      expect(generator['model']).toBe('MiniMax-M2.7');
+      expect(generator['model']).toBe('MiniMax-M3');
     });
   });
 
@@ -151,12 +151,12 @@ describe('LLM Provider Integration', () => {
 
     it('should allow model override with preset', () => {
       process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
-      process.env.N8N_MCP_LLM_MODEL = 'MiniMax-M2.5-highspeed';
+      process.env.N8N_MCP_LLM_MODEL = 'MiniMax-M2.7-highspeed';
       process.env.MINIMAX_API_KEY = 'test-key';
 
       const generator = createDocumentationGenerator();
 
-      expect(generator['model']).toBe('MiniMax-M2.5-highspeed');
+      expect(generator['model']).toBe('MiniMax-M2.7-highspeed');
     });
 
     it('should use local defaults when no provider is set', () => {

--- a/tests/integration/community/llm-provider-integration.test.ts
+++ b/tests/integration/community/llm-provider-integration.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  DocumentationGenerator,
+  DocumentationGeneratorConfig,
+  LLM_PROVIDER_PRESETS,
+  createDocumentationGenerator,
+} from '../../../src/community/documentation-generator';
+
+// Mock OpenAI to avoid real API calls
+vi.mock('openai', () => {
+  return {
+    default: vi.fn().mockImplementation((config: { baseURL?: string; apiKey?: string }) => ({
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue({
+            choices: [
+              {
+                message: {
+                  content: JSON.stringify({
+                    purpose: 'Test node purpose',
+                    capabilities: ['feature1'],
+                    authentication: 'API Key',
+                    commonUseCases: ['use case'],
+                    limitations: [],
+                    relatedNodes: [],
+                  }),
+                },
+              },
+            ],
+          }),
+        },
+      },
+      _config: config,
+    })),
+  };
+});
+
+vi.mock('../../../src/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('LLM Provider Integration', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.N8N_MCP_LLM_PROVIDER;
+    delete process.env.N8N_MCP_LLM_BASE_URL;
+    delete process.env.N8N_MCP_LLM_MODEL;
+    delete process.env.N8N_MCP_LLM_API_KEY;
+    delete process.env.MINIMAX_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.clearAllMocks();
+  });
+
+  describe('MiniMax provider end-to-end', () => {
+    it('should generate documentation using minimax preset', async () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
+      process.env.MINIMAX_API_KEY = 'test-minimax-key';
+
+      const generator = createDocumentationGenerator();
+      const result = await generator.generateSummary({
+        nodeType: 'n8n-nodes-community.test',
+        displayName: 'Test Node',
+        readme: '# Test Node\nA test community node.',
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.summary.purpose).toBe('Test node purpose');
+    });
+
+    it('should handle MiniMax response with thinking tags in batch mode', async () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
+      process.env.MINIMAX_API_KEY = 'test-key';
+
+      const generator = createDocumentationGenerator();
+
+      // Inject mock client directly to ensure batch works
+      const mockCreate = vi.fn().mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content:
+                '<think>Analyzing node...</think>\n' +
+                JSON.stringify({
+                  purpose: 'Test node purpose',
+                  capabilities: ['feature1'],
+                  authentication: 'API Key',
+                  commonUseCases: ['use case'],
+                  limitations: [],
+                  relatedNodes: [],
+                }),
+            },
+          },
+        ],
+      });
+      Object.defineProperty(generator, 'client', {
+        value: { chat: { completions: { create: mockCreate } } },
+        writable: true,
+      });
+
+      const inputs = [
+        {
+          nodeType: 'n8n-nodes-community.node1',
+          displayName: 'Node 1',
+          readme: '# Node 1',
+        },
+        {
+          nodeType: 'n8n-nodes-community.node2',
+          displayName: 'Node 2',
+          readme: '# Node 2',
+        },
+      ];
+
+      const results = await generator.generateBatch(inputs, 2);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].error).toBeUndefined();
+      expect(results[1].error).toBeUndefined();
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('should use MiniMax preset model by default', () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
+      process.env.MINIMAX_API_KEY = 'test-key';
+
+      const generator = createDocumentationGenerator();
+
+      expect(generator['model']).toBe('MiniMax-M2.7');
+    });
+  });
+
+  describe('Provider fallback chain', () => {
+    it('should use preset when only N8N_MCP_LLM_PROVIDER is set', () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'openai';
+      process.env.OPENAI_API_KEY = 'test-key';
+
+      const generator = createDocumentationGenerator();
+
+      expect(generator['model']).toBe('gpt-4o-mini');
+    });
+
+    it('should allow model override with preset', () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
+      process.env.N8N_MCP_LLM_MODEL = 'MiniMax-M2.5-highspeed';
+      process.env.MINIMAX_API_KEY = 'test-key';
+
+      const generator = createDocumentationGenerator();
+
+      expect(generator['model']).toBe('MiniMax-M2.5-highspeed');
+    });
+
+    it('should use local defaults when no provider is set', () => {
+      const generator = createDocumentationGenerator();
+
+      expect(generator['model']).toBe('qwen3-4b-thinking-2507');
+      expect(generator['temperature']).toBe(0.3);
+    });
+  });
+});

--- a/tests/unit/community/documentation-generator.test.ts
+++ b/tests/unit/community/documentation-generator.test.ts
@@ -967,6 +967,42 @@ describe('DocumentationGenerator', () => {
       expect(result.summary.purpose).toBe('Sends messages to Slack channels');
     });
 
+    it('should handle MiniMax-style multi-line thinking tags', async () => {
+      const thinkContent = '<think>\nStep 1: Read the node info\nStep 2: Extract capabilities\nStep 3: Generate JSON\n</think>';
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: thinkContent + '\n' + JSON.stringify(validSummary),
+            },
+          },
+        ],
+      });
+
+      const result = await generator.generateSummary(sampleInput);
+
+      expect(result.error).toBeUndefined();
+      expect(result.summary.purpose).toBe('Sends messages to Slack channels');
+    });
+
+    it('should handle response with multiple thinking blocks', async () => {
+      mockCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content:
+                '<think>First thought</think>Some text<think>Second thought</think>\n' + JSON.stringify(validSummary),
+            },
+          },
+        ],
+      });
+
+      const result = await generator.generateSummary(sampleInput);
+
+      expect(result.error).toBeUndefined();
+      expect(result.summary.purpose).toBe('Sends messages to Slack channels');
+    });
+
     it('should return error when response contains multiple JSON objects', async () => {
       // When the response contains multiple JSON objects concatenated,
       // JSON.parse will fail, and we should get a default summary with error

--- a/tests/unit/community/llm-provider-presets.test.ts
+++ b/tests/unit/community/llm-provider-presets.test.ts
@@ -37,7 +37,7 @@ describe('LLM Provider Presets', () => {
       expect(LLM_PROVIDER_PRESETS).toHaveProperty('minimax');
       const minimax = LLM_PROVIDER_PRESETS.minimax;
       expect(minimax.baseUrl).toBe('https://api.minimax.io/v1');
-      expect(minimax.model).toBe('MiniMax-M2.7');
+      expect(minimax.model).toBe('MiniMax-M3');
       expect(minimax.supportsTemperature).toBe(true);
       expect(minimax.temperatureRange).toEqual([0, 1]);
     });
@@ -104,7 +104,7 @@ describe('LLM Provider Presets', () => {
     it('should resolve MiniMax preset (mixed case)', () => {
       const preset = resolveProviderPreset('MiniMax');
       expect(preset).toBeDefined();
-      expect(preset!.model).toBe('MiniMax-M2.7');
+      expect(preset!.model).toBe('MiniMax-M3');
     });
 
     it('should resolve openai preset', () => {
@@ -156,7 +156,7 @@ describe('LLM Provider Presets', () => {
 
       const generator = createDocumentationGenerator();
 
-      expect(generator['model']).toBe('MiniMax-M2.7');
+      expect(generator['model']).toBe('MiniMax-M3');
     });
 
     it('should use openai preset when N8N_MCP_LLM_PROVIDER=openai', () => {
@@ -170,12 +170,12 @@ describe('LLM Provider Presets', () => {
 
     it('should allow N8N_MCP_LLM_MODEL to override preset model', () => {
       process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
-      process.env.N8N_MCP_LLM_MODEL = 'MiniMax-M2.5-highspeed';
+      process.env.N8N_MCP_LLM_MODEL = 'MiniMax-M2.7-highspeed';
       process.env.MINIMAX_API_KEY = 'test-key';
 
       const generator = createDocumentationGenerator();
 
-      expect(generator['model']).toBe('MiniMax-M2.5-highspeed');
+      expect(generator['model']).toBe('MiniMax-M2.7-highspeed');
     });
 
     it('should allow N8N_MCP_LLM_BASE_URL to override preset base URL', () => {
@@ -186,7 +186,7 @@ describe('LLM Provider Presets', () => {
       const generator = createDocumentationGenerator();
 
       // Model should still come from preset since N8N_MCP_LLM_MODEL is not set
-      expect(generator['model']).toBe('MiniMax-M2.7');
+      expect(generator['model']).toBe('MiniMax-M3');
     });
 
     it('should auto-detect MINIMAX_API_KEY when no explicit API key is set', () => {

--- a/tests/unit/community/llm-provider-presets.test.ts
+++ b/tests/unit/community/llm-provider-presets.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  LLM_PROVIDER_PRESETS,
+  LLMProviderPreset,
+  clampTemperature,
+  resolveProviderPreset,
+  createDocumentationGenerator,
+  DocumentationGenerator,
+} from '../../../src/community/documentation-generator';
+
+// Mock OpenAI
+vi.mock('openai', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: vi.fn(),
+        },
+      },
+    })),
+  };
+});
+
+// Mock logger
+vi.mock('../../../src/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('LLM Provider Presets', () => {
+  describe('LLM_PROVIDER_PRESETS', () => {
+    it('should include minimax preset', () => {
+      expect(LLM_PROVIDER_PRESETS).toHaveProperty('minimax');
+      const minimax = LLM_PROVIDER_PRESETS.minimax;
+      expect(minimax.baseUrl).toBe('https://api.minimax.io/v1');
+      expect(minimax.model).toBe('MiniMax-M2.7');
+      expect(minimax.supportsTemperature).toBe(true);
+      expect(minimax.temperatureRange).toEqual([0, 1]);
+    });
+
+    it('should include openai preset', () => {
+      expect(LLM_PROVIDER_PRESETS).toHaveProperty('openai');
+      const openai = LLM_PROVIDER_PRESETS.openai;
+      expect(openai.baseUrl).toBe('https://api.openai.com/v1');
+      expect(openai.model).toBe('gpt-4o-mini');
+      expect(openai.supportsTemperature).toBe(true);
+    });
+
+    it('should include anthropic preset', () => {
+      expect(LLM_PROVIDER_PRESETS).toHaveProperty('anthropic');
+      const anthropic = LLM_PROVIDER_PRESETS.anthropic;
+      expect(anthropic.baseUrl).toBe('https://api.anthropic.com/v1');
+      expect(anthropic.supportsTemperature).toBe(true);
+    });
+
+    it('all presets should have required fields', () => {
+      for (const [name, preset] of Object.entries(LLM_PROVIDER_PRESETS)) {
+        expect(preset.baseUrl).toBeTruthy();
+        expect(preset.model).toBeTruthy();
+        expect(typeof preset.supportsTemperature).toBe('boolean');
+      }
+    });
+  });
+
+  describe('clampTemperature', () => {
+    it('should clamp value below minimum', () => {
+      expect(clampTemperature(-0.5, [0, 1])).toBe(0);
+    });
+
+    it('should clamp value above maximum', () => {
+      expect(clampTemperature(1.5, [0, 1])).toBe(1);
+    });
+
+    it('should not clamp value within range', () => {
+      expect(clampTemperature(0.5, [0, 1])).toBe(0.5);
+    });
+
+    it('should handle value at exact minimum', () => {
+      expect(clampTemperature(0, [0, 1])).toBe(0);
+    });
+
+    it('should handle value at exact maximum', () => {
+      expect(clampTemperature(1, [0, 1])).toBe(1);
+    });
+
+    it('should handle custom range', () => {
+      expect(clampTemperature(0.1, [0.2, 0.8])).toBe(0.2);
+      expect(clampTemperature(0.9, [0.2, 0.8])).toBe(0.8);
+      expect(clampTemperature(0.5, [0.2, 0.8])).toBe(0.5);
+    });
+  });
+
+  describe('resolveProviderPreset', () => {
+    it('should resolve minimax preset (lowercase)', () => {
+      const preset = resolveProviderPreset('minimax');
+      expect(preset).toBeDefined();
+      expect(preset!.baseUrl).toBe('https://api.minimax.io/v1');
+    });
+
+    it('should resolve MiniMax preset (mixed case)', () => {
+      const preset = resolveProviderPreset('MiniMax');
+      expect(preset).toBeDefined();
+      expect(preset!.model).toBe('MiniMax-M2.7');
+    });
+
+    it('should resolve openai preset', () => {
+      const preset = resolveProviderPreset('openai');
+      expect(preset).toBeDefined();
+      expect(preset!.baseUrl).toBe('https://api.openai.com/v1');
+    });
+
+    it('should resolve OPENAI preset (uppercase)', () => {
+      const preset = resolveProviderPreset('OPENAI');
+      expect(preset).toBeDefined();
+    });
+
+    it('should return undefined for unknown provider', () => {
+      expect(resolveProviderPreset('unknown')).toBeUndefined();
+    });
+
+    it('should return undefined for empty string', () => {
+      expect(resolveProviderPreset('')).toBeUndefined();
+    });
+
+    it('should return undefined for undefined', () => {
+      expect(resolveProviderPreset(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('createDocumentationGenerator with provider presets', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      process.env = { ...originalEnv };
+      // Clear all LLM-related env vars
+      delete process.env.N8N_MCP_LLM_PROVIDER;
+      delete process.env.N8N_MCP_LLM_BASE_URL;
+      delete process.env.N8N_MCP_LLM_MODEL;
+      delete process.env.N8N_MCP_LLM_TIMEOUT;
+      delete process.env.N8N_MCP_LLM_API_KEY;
+      delete process.env.MINIMAX_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should use minimax preset when N8N_MCP_LLM_PROVIDER=minimax', () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
+      process.env.MINIMAX_API_KEY = 'test-minimax-key';
+
+      const generator = createDocumentationGenerator();
+
+      expect(generator['model']).toBe('MiniMax-M2.7');
+    });
+
+    it('should use openai preset when N8N_MCP_LLM_PROVIDER=openai', () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'openai';
+      process.env.OPENAI_API_KEY = 'test-openai-key';
+
+      const generator = createDocumentationGenerator();
+
+      expect(generator['model']).toBe('gpt-4o-mini');
+    });
+
+    it('should allow N8N_MCP_LLM_MODEL to override preset model', () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
+      process.env.N8N_MCP_LLM_MODEL = 'MiniMax-M2.5-highspeed';
+      process.env.MINIMAX_API_KEY = 'test-key';
+
+      const generator = createDocumentationGenerator();
+
+      expect(generator['model']).toBe('MiniMax-M2.5-highspeed');
+    });
+
+    it('should allow N8N_MCP_LLM_BASE_URL to override preset base URL', () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
+      process.env.N8N_MCP_LLM_BASE_URL = 'https://custom-proxy.example.com/v1';
+      process.env.MINIMAX_API_KEY = 'test-key';
+
+      const generator = createDocumentationGenerator();
+
+      // Model should still come from preset since N8N_MCP_LLM_MODEL is not set
+      expect(generator['model']).toBe('MiniMax-M2.7');
+    });
+
+    it('should auto-detect MINIMAX_API_KEY when no explicit API key is set', () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
+      process.env.MINIMAX_API_KEY = 'test-minimax-key';
+
+      const generator = createDocumentationGenerator();
+
+      // Generator should be created successfully (no error thrown)
+      expect(generator).toBeInstanceOf(DocumentationGenerator);
+    });
+
+    it('should prefer N8N_MCP_LLM_API_KEY over MINIMAX_API_KEY', () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
+      process.env.N8N_MCP_LLM_API_KEY = 'explicit-key';
+      process.env.MINIMAX_API_KEY = 'minimax-key';
+
+      const generator = createDocumentationGenerator();
+
+      expect(generator).toBeInstanceOf(DocumentationGenerator);
+    });
+
+    it('should set temperature for minimax provider', () => {
+      process.env.N8N_MCP_LLM_PROVIDER = 'minimax';
+      process.env.MINIMAX_API_KEY = 'test-key';
+
+      const generator = createDocumentationGenerator();
+
+      expect(generator['temperature']).toBe(0.3);
+    });
+
+    it('should set temperature for local server (no provider preset)', () => {
+      delete process.env.N8N_MCP_LLM_PROVIDER;
+      process.env.N8N_MCP_LLM_BASE_URL = 'http://localhost:1234/v1';
+
+      const generator = createDocumentationGenerator();
+
+      expect(generator['temperature']).toBe(0.3);
+    });
+
+    it('should fall back to defaults when no provider and no env vars', () => {
+      const generator = createDocumentationGenerator();
+
+      expect(generator['model']).toBe('qwen3-4b-thinking-2507');
+      expect(generator['timeout']).toBe(60000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a **provider preset system** for the documentation generator with built-in support for MiniMax, OpenAI, and Anthropic
- Users can configure cloud LLM providers via a single `N8N_MCP_LLM_PROVIDER` env var (e.g., `minimax`, `openai`)
- Default model for `minimax` preset is **MiniMax-M3** (512K context, 128K max output, image input support); legacy `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` remain accessible via `N8N_MCP_LLM_MODEL` override
- Add **think-tag stripping** (`<think>...</think>`) for reasoning models like MiniMax M2.7 and Qwen
- Add **temperature clamping** to respect provider-specific ranges (MiniMax: 0-1)
- Auto-detect `MINIMAX_API_KEY` in the API key fallback chain

## Changes

| File | Change |
|------|--------|
| `src/community/documentation-generator.ts` | Provider presets (default model `MiniMax-M3`), think-tag stripping, temperature clamping, factory function update |
| `src/community/index.ts` | Export new types and functions |
| `.env.example` | LLM provider configuration section with MiniMax docs |
| `README.md` | Provider preset table (default `MiniMax-M3`), configuration guide, MiniMax acknowledgment |
| `tests/unit/community/llm-provider-presets.test.ts` | Unit tests for presets, clamping, resolution (asserting `MiniMax-M3` default) |
| `tests/unit/community/documentation-generator.test.ts` | Additional think-tag stripping tests |
| `tests/integration/community/llm-provider-integration.test.ts` | Integration tests for end-to-end MiniMax flow (asserting `MiniMax-M3` default) |

## Test plan

- [x] All new+existing tests pass (`npx vitest run`)
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Provider preset resolution (case-insensitive)
- [x] Temperature clamping within MiniMax range [0, 1]
- [x] Think-tag stripping for single and multi-block responses
- [x] API key auto-detection fallback chain
- [x] Manual config overrides preset defaults (e.g., `N8N_MCP_LLM_MODEL=MiniMax-M2.7-highspeed`)
- [x] Batch documentation generation with MiniMax

Concieved by Romuald Członkowski - www.aiadvisors.pl/en