### PR TITLE
fix: implement __patch_find_replace in setNestedProperty

### DIFF
--- a/src/services/workflow-diff-engine.ts
+++ b/src/services/workflow-diff-engine.ts
@@ -1280,6 +1280,22 @@ export class WorkflowDiffEngine {
     }
 
     const finalKey = keys[keys.length - 1];
+    
+    // Handle __patch_find_replace for string values (Issue #642)
+    if (value && typeof value === 'object' && '__patch_find_replace' in value) {
+      const patches = value.__patch_find_replace;
+      if (Array.isArray(patches) && typeof current[finalKey] === 'string') {
+        let result = current[finalKey];
+        for (const patch of patches) {
+          if (patch.find && typeof patch.replace === 'string') {
+            result = result.split(patch.find).join(patch.replace);
+          }
+        }
+        current[finalKey] = result;
+        return;
+      }
+    }
+    
     if (value === null) {
       delete current[finalKey];
     } else {


### PR DESCRIPTION
## Summary

Fixes #642

## Problem

When using `updateNode` with `__patch_find_replace` in updates, the patch object was being set as the literal value instead of applying the find/replace operation to the existing string.

```javascript
// This would corrupt jsCode
n8n_update_partial_workflow({
  operations: [{
    type: "updateNode",
    name: "My Code Node",
    updates: {
      "parameters.jsCode": {
        "__patch_find_replace": [
          { "find": "old text", "replace": "new text" }
        ]
      }
    }
  }]
})
```

Result: `jsCode` becomes `[object Object]` → `SyntaxError`

## Solution

Modified `setNestedProperty()` to detect `__patch_find_replace` objects and apply the patches to existing string values:

```typescript
if (value && typeof value === 'object' && '__patch_find_replace' in value) {
  const patches = value.__patch_find_replace;
  if (Array.isArray(patches) && typeof current[finalKey] === 'string') {
    let result = current[finalKey];
    for (const patch of patches) {
      if (patch.find && typeof patch.replace === 'string') {
        result = result.split(patch.find).join(patch.replace);
      }
    }
    current[finalKey] = result;
    return;
  }
}
```

## Testing

- Existing string values get patched correctly
- Multiple patches are applied in order
- Non-string values fall back to direct assignment