### PR TITLE
fix: normalize If node operator names (isNotEmpty -> notEmpty)

### DIFF
--- a/src/services/node-sanitizer.ts
+++ b/src/services/node-sanitizer.ts
@@ -177,6 +177,15 @@ function sanitizeOperator(operator: any): any {
     }
   }
 
+  // Normalize operator names to what n8n engine expects (e.g. isNotEmpty -> notEmpty)
+  if (sanitized.operation) {
+    const normalized = normalizeOperationName(sanitized.operation);
+    if (normalized !== sanitized.operation) {
+      logger.debug(`Normalizing operator: "${sanitized.operation}" -> "${normalized}"`);
+      sanitized.operation = normalized;
+    }
+  }
+
   // Set singleValue based on operator type
   if (sanitized.operation) {
     if (isUnaryOperator(sanitized.operation)) {
@@ -190,6 +199,20 @@ function sanitizeOperator(operator: any): any {
   }
 
   return sanitized;
+}
+
+/**
+ * Normalize operator names to what the n8n execution engine expects.
+ * The n8n UI generates "notEmpty"/"empty" but LLMs often produce
+ * "isNotEmpty"/"isEmpty" which the engine silently ignores (#665).
+ */
+const OPERATOR_ALIASES: Record<string, string> = {
+  isNotEmpty: 'notEmpty',
+  isEmpty: 'empty',
+};
+
+function normalizeOperationName(operation: string): string {
+  return OPERATOR_ALIASES[operation] ?? operation;
 }
 
 /**
@@ -207,7 +230,8 @@ function isOperationName(value: string): boolean {
  */
 function inferDataType(operation: string): string {
   // Boolean operations
-  const booleanOps = ['true', 'false', 'isEmpty', 'isNotEmpty'];
+  // Note: isEmpty/isNotEmpty are normalized to empty/notEmpty (object-type) by sanitizer
+  const booleanOps = ['true', 'false'];
   if (booleanOps.includes(operation)) {
     return 'boolean';
   }


### PR DESCRIPTION
## Problem

When using `n8n_update_partial_workflow` to update an If node condition with `isNotEmpty` operator, the workflow saves successfully but always evaluates to FALSE at runtime. No error anywhere - completely silent failure.

The root cause is that the MCP validator uses `isNotEmpty`/`isEmpty` as operator names, but the n8n execution engine expects `notEmpty`/`empty`. The n8n UI also generates `notEmpty`/`empty`. Since the engine doesnt recognize `isNotEmpty`, it silently defaults to false.

I spent a lot of time debugging this because the saved workflow looks perfectly correct in the API response.

## What I changed

In `src/services/node-sanitizer.ts`:

1. **Added `OPERATOR_ALIASES` map** that translates LLM-friendly names to what n8n engine expects:
   - `isNotEmpty` -> `notEmpty`
   - `isEmpty` -> `empty`

2. **Added `normalizeOperationName()` function** that applies the alias mapping

3. **Applied normalization in `sanitizeOperator()`** - after the operator structure is fixed but before singleValue is set. This way the operation name is correct by the time the unary check runs.

4. **Updated `inferDataType()`** - removed `isEmpty`/`isNotEmpty` from the boolean operations list since after normalization they become `empty`/`notEmpty` which are object-type operations. The comment explains why.

## How it works now

```
LLM generates: {type: "number", operation: "isNotEmpty", singleValue: true}
Sanitizer normalizes to: {type: "number", operation: "notEmpty", singleValue: true}
n8n engine recognizes "notEmpty" and evaluates correctly
```

Before this fix, `isNotEmpty` was passed through unchanged and the engine silently ignored it.

Concieved by Romuald Członkowski - https://www.aiadvisors.pl/en

Closes #665