### PR TITLE
fix: include workflow-patterns.json in npm package (#681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.42.2] - 2026-03-30
+
+### Fixed
+
+- **`workflow-patterns.json` missing from npm package** (Issue #681): Added `data/workflow-patterns.json` to the `files` array in `package.json` so the patterns file is included in the published npm package and works out of the box without manual generation.
+
+Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en
+
 ## [2.42.1] - 2026-03-30
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.42.1",
+  "version": "2.42.2",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -124,6 +124,7 @@
     "dist/**/*",
     "ui-apps/dist/**/*",
     "data/nodes.db",
+    "data/workflow-patterns.json",
     ".env.example",
     "README.md",
     "LICENSE",


### PR DESCRIPTION
## Summary

Fixes #681 — `data/workflow-patterns.json` was not included in the published npm package, causing `search_templates({searchMode: "patterns"})` to return an error.

## Change

Added `data/workflow-patterns.json` to the `files` array in `package.json` (alongside the existing `data/nodes.db` entry).

Verified with `npm pack --dry-run`:
```
68.6kB data/workflow-patterns.json ✓
```

## Test plan

- [x] `npm pack --dry-run` includes `data/workflow-patterns.json`
- [x] Path resolution (`__dirname/../../data/`) works for both local dev and npm installs

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)