### PR TITLE
fix: use stdio-wrapper.js as default bin entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "bin": {
-    "n8n-mcp": "./dist/mcp/index.js"
+    "n8n-mcp": "./dist/mcp/stdio-wrapper.js"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
## Summary

Changes the `bin` entry in `package.json` from `./dist/mcp/index.js` to `./dist/mcp/stdio-wrapper.js`.

The current default entry point (`index.js`) writes INFO-level logs to **stdout** via `console.log()`, which corrupts the JSON-RPC MCP transport. The `stdio-wrapper.js` already exists in the package and properly:
- Silences all `console.*` methods
- Intercepts `process.stdout.write` to only pass JSON-RPC messages
- Redirects non-JSONRPC output to stderr

This is a one-line change — no new code, just wiring the correct entry point.

Fixes #693. Related: #555, #628.

## Test plan

- [ ] Run `npx n8n-mcp` with default env (no `LOG_LEVEL` or `DISABLE_CONSOLE_OUTPUT`) and verify no `[n8n-mcp] [INFO]` lines appear on stdout
- [ ] Verify MCP stdio transport initializes cleanly with Claude Desktop / Claude Code
- [ ] Verify HTTP mode still works (unaffected — uses different entry path)