### PR TITLE
feat(mcp): add per-operation tool filtering via DISABLED_TOOL_OPERATIONS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,10 +132,10 @@ AUTH_TOKEN=your-secure-token-here
 #
 # Eligible tools and their operations:
 #   n8n_executions       — action: get, list, delete
-#   n8n_workflow_versions — mode: list, get, rollback, delete, prune, truncate
+#   n8n_workflow_versions — mode: list, get, rollback, delete, prune
 #
 # Read-only deployment recipe (blocks all destructive operations):
-# DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune,truncate;n8n_executions:delete
+# DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune;n8n_executions:delete
 #
 # Combine with n8n API key RBAC for defence in depth.
 # Default: (empty - all operations enabled)

--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,25 @@ AUTH_TOKEN=your-secure-token-here
 # Default: (empty - all tools enabled)
 # DISABLED_TOOLS=
 
+# Per-Operation Tool Filtering
+# Disable specific operations within a tool without losing its read paths.
+# Useful for sensitive deployments that need read-only access
+# to tools that bundle read and write operations under one name.
+#
+# Format: Semicolon-separated list of <tool_name>:<comma_separated_operations>
+# Operation names match the action / mode enum values in each tool's schema.
+#
+# Eligible tools and their operations:
+#   n8n_executions       — action: get, list, delete
+#   n8n_workflow_versions — mode: list, get, rollback, delete, prune, truncate
+#
+# Read-only deployment recipe (blocks all destructive operations):
+# DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune,truncate;n8n_executions:delete
+#
+# Combine with n8n API key RBAC for defence in depth.
+# Default: (empty - all operations enabled)
+# DISABLED_TOOL_OPERATIONS=
+
 # =========================
 # MULTI-TENANT CONFIGURATION
 # =========================

--- a/README.md
+++ b/README.md
@@ -389,6 +389,22 @@ These tools require `N8N_API_URL` and `N8N_API_KEY` in your configuration.
 #### System Tools
 - **`n8n_health_check`** - Check n8n API connectivity and features
 
+### Read-Only Deployment
+
+For governance-sensitive environments, use both env vars together. Fully disable purely write/destructive tools:
+
+```bash
+DISABLED_TOOLS=n8n_create_workflow,n8n_update_full_workflow,n8n_update_partial_workflow,n8n_delete_workflow,n8n_autofix_workflow,n8n_deploy_template,n8n_test_workflow,n8n_generate_workflow,n8n_manage_credentials,n8n_manage_datatable
+```
+
+For tools that bundle read and write operations under one name, block only the destructive operations while keeping `list` and `get`:
+
+```bash
+DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune;n8n_executions:delete
+```
+
+Combine with a read-only n8n API key (Settings → API in your n8n instance) for defence in depth. See [Read-Only Deployment Recipe](./docs/HTTP_DEPLOYMENT.md#read-only-deployment-recipe) for the full setup guide.
+
 ## Documentation
 
 - [Self-Hosting Guide](./docs/SELF_HOSTING.md) - npx, Docker, Railway, and local installation

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -877,6 +877,32 @@ curl -X POST https://your-server.com/mcp \
 - 🚫 Never expose n8n API directly to the internet
 - ✅ Use MCP server as a security layer
 
+### Read-Only Deployment Recipe
+
+For governance-sensitive environments where the AI agent should be able to read workflow and execution data but must not modify or delete anything, combine two layers of control:
+
+**Layer 1 — MCP layer:**
+
+Some tools are purely write/destructive and should be removed entirely via `DISABLED_TOOLS`:
+
+```bash
+DISABLED_TOOLS=n8n_create_workflow,n8n_update_full_workflow,n8n_update_partial_workflow,n8n_delete_workflow,n8n_autofix_workflow,n8n_deploy_template,n8n_test_workflow,n8n_generate_workflow,n8n_manage_credentials,n8n_manage_datatable
+```
+
+Two tools bundle read and write operations under a single name. Use `DISABLED_TOOL_OPERATIONS` to block only their destructive branches while keeping `list` and `get`:
+
+```bash
+DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune,truncate;n8n_executions:delete
+```
+
+The tool schema presented to the LLM is updated to exclude disabled operations, so the model never attempts them.
+
+**Layer 2 — n8n API key RBAC:**
+
+Scope the `N8N_API_KEY` to read-only permissions in your n8n instance (Settings → API → create a key with read-only scope). This ensures that even if the MCP layer is misconfigured, the n8n API itself will reject destructive requests.
+
+Both layers together provide defence in depth. The MCP layer is a convenience knob; the n8n API RBAC is the authoritative enforcement boundary.
+
 ## 📦 Updates & Maintenance
 
 ### Version Updates

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -892,7 +892,7 @@ DISABLED_TOOLS=n8n_create_workflow,n8n_update_full_workflow,n8n_update_partial_w
 Two tools bundle read and write operations under a single name. Use `DISABLED_TOOL_OPERATIONS` to block only their destructive branches while keeping `list` and `get`:
 
 ```bash
-DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune,truncate;n8n_executions:delete
+DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune;n8n_executions:delete
 ```
 
 The operation parameter enum in the tool schema is updated to exclude disabled values, reducing the likelihood the model attempts them. Any attempt that does reach the server is rejected at dispatch before the handler runs.

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -895,7 +895,7 @@ Two tools bundle read and write operations under a single name. Use `DISABLED_TO
 DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune,truncate;n8n_executions:delete
 ```
 
-The tool schema presented to the LLM is updated to exclude disabled operations, so the model never attempts them.
+The operation parameter enum in the tool schema is updated to exclude disabled values, reducing the likelihood the model attempts them. Any attempt that does reach the server is rejected at dispatch before the handler runs.
 
 **Layer 2 — n8n API key RBAC:**
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -15,7 +15,7 @@ import path from 'path';
 import { n8nDocumentationToolsFinal } from './tools';
 import { UIAppRegistry } from './ui';
 import { SkillResourceRegistry } from './skills';
-import { n8nManagementTools, TOOL_OPERATION_PARAM } from './tools-n8n-manager';
+import { n8nManagementTools, TOOL_OPERATION_PARAM, DESTRUCTIVE_TOOL_OPERATIONS } from './tools-n8n-manager';
 import { makeToolsN8nFriendly } from './tools-n8n-friendly';
 import { getWorkflowExampleString } from './workflow-examples';
 import { logger } from '../utils/logger';
@@ -737,6 +737,19 @@ export class N8NDocumentationMCPServer {
 
       const disabledList = [...ops].join(', ');
       cloned.description = `${cloned.description}\n\n> Operations disabled by server policy: ${disabledList}`;
+
+      // If filtering removed every destructive operation, the tool is now
+      // read-only — recompute its MCP annotations so hosts that honor them
+      // (e.g. to gate/hide destructive tools) don't keep restricting the
+      // remaining read paths, which would defeat the read-only deployment use case.
+      const destructive = DESTRUCTIVE_TOOL_OPERATIONS[toolName];
+      if (destructive && cloned.annotations) {
+        const remaining = (param?.enum as string[] | undefined) ?? [];
+        const stillDestructive = remaining.some(v => destructive.has(String(v).toLowerCase()));
+        if (!stillDestructive) {
+          cloned.annotations = { ...cloned.annotations, readOnlyHint: true, destructiveHint: false };
+        }
+      }
 
       cache.set(toolName, cloned);
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -15,7 +15,7 @@ import path from 'path';
 import { n8nDocumentationToolsFinal } from './tools';
 import { UIAppRegistry } from './ui';
 import { SkillResourceRegistry } from './skills';
-import { n8nManagementTools } from './tools-n8n-manager';
+import { n8nManagementTools, TOOL_OPERATION_PARAM } from './tools-n8n-manager';
 import { makeToolsN8nFriendly } from './tools-n8n-friendly';
 import { getWorkflowExampleString } from './workflow-examples';
 import { logger } from '../utils/logger';
@@ -180,6 +180,8 @@ export class N8NDocumentationMCPServer {
   private previousToolTimestamp: number = Date.now();
   private earlyLogger: EarlyErrorLogger | null = null;
   private disabledToolsCache: Set<string> | null = null;
+  private disabledToolOperationsCache: Map<string, Set<string>> | null = null;
+  private filteredToolDefinitionsCache: Map<string, any> | null = null;
   private useSharedDatabase: boolean = false;  // Track if using shared DB for cleanup
   private sharedDbState: SharedDatabaseState | null = null;  // Reference to shared DB state for release
   private isShutdown: boolean = false;  // Prevent double-shutdown
@@ -612,6 +614,111 @@ export class N8NDocumentationMCPServer {
     return this.disabledToolsCache;
   }
 
+  /**
+   * Parse and cache per-operation disabled rules from DISABLED_TOOL_OPERATIONS env var.
+   *
+   * Format: semicolon-separated list of <tool_name>:<comma_separated_operations>
+   * Example: DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune,truncate;n8n_executions:delete
+   *
+   * Cached after first call. Also pre-builds filteredToolDefinitionsCache so
+   * ListTools requests pay no per-request cloning cost.
+   *
+   * Safety limits mirror DISABLED_TOOLS: max 10KB env var, max 50 entries.
+   *
+   * @returns Map of toolName -> Set of disabled operation names
+   */
+  private getDisabledToolOperations(): Map<string, Set<string>> {
+    if (this.disabledToolOperationsCache !== null) {
+      return this.disabledToolOperationsCache;
+    }
+
+    const result = new Map<string, Set<string>>();
+    let envVal = process.env.DISABLED_TOOL_OPERATIONS || '';
+
+    if (!envVal) {
+      this.disabledToolOperationsCache = result;
+      this.filteredToolDefinitionsCache = new Map();
+      return result;
+    }
+
+    if (envVal.length > 10000) {
+      logger.warn(`DISABLED_TOOL_OPERATIONS environment variable too long (${envVal.length} chars), truncating to 10000`);
+      envVal = envVal.substring(0, 10000);
+    }
+
+    let entries = envVal.split(';').map(e => e.trim()).filter(Boolean);
+
+    if (entries.length > 50) {
+      logger.warn(`DISABLED_TOOL_OPERATIONS contains ${entries.length} entries, limiting to first 50`);
+      entries = entries.slice(0, 50);
+    }
+
+    for (const entry of entries) {
+      const colonIdx = entry.indexOf(':');
+      if (colonIdx === -1) continue;
+
+      const toolName = entry.substring(0, colonIdx).trim();
+      const opsStr = entry.substring(colonIdx + 1).trim();
+
+      if (!toolName || !opsStr) continue;
+
+      // Lowercase ops so matching is case-insensitive and consistent with the
+      // (lowercase) operation enum values used for schema stripping and dispatch.
+      const ops = opsStr.split(',').map(o => o.trim().toLowerCase()).filter(Boolean);
+      if (ops.length === 0) continue;
+
+      const existing = result.get(toolName) ?? new Set<string>();
+      ops.forEach(op => existing.add(op));
+      result.set(toolName, existing);
+    }
+
+    if (result.size > 0) {
+      const summary = [...result.entries()]
+        .map(([t, ops]) => `${t}: [${[...ops].join(', ')}]`)
+        .join('; ');
+      logger.info(`Disabled tool operations configured: ${summary}`);
+    }
+
+    this.disabledToolOperationsCache = result;
+    this.filteredToolDefinitionsCache = this.buildFilteredToolDefinitions(result);
+    return result;
+  }
+
+  /**
+   * Builds deep-cloned, operation-filtered tool definitions for every tool that
+   * has disabled operations. Called once on the first getDisabledToolOperations()
+   * invocation and cached — subsequent ListTools requests pay no cloning cost.
+   */
+  private buildFilteredToolDefinitions(disabledOps: Map<string, Set<string>>): Map<string, any> {
+    const cache = new Map<string, any>();
+
+    for (const [toolName, ops] of disabledOps) {
+      const paramName = TOOL_OPERATION_PARAM[toolName];
+      if (!paramName) continue;
+
+      const original = n8nManagementTools.find(t => t.name === toolName);
+      if (!original) continue;
+
+      const cloned = JSON.parse(JSON.stringify(original));
+
+      const param = cloned.inputSchema?.properties?.[paramName];
+      if (param?.enum) {
+        param.enum = (param.enum as string[]).filter(v => !ops.has(v));
+        if (param.description) {
+          const disabledList = [...ops].join(', ');
+          param.description = `${param.description} (disabled by server policy: ${disabledList})`;
+        }
+      }
+
+      const disabledList = [...ops].join(', ');
+      cloned.description = `${cloned.description}\n\n> Operations disabled by server policy: ${disabledList}`;
+
+      cache.set(toolName, cloned);
+    }
+
+    return cache;
+  }
+
   private setupHandlers(): void {
     // Handle initialization
     this.server.setRequestHandler(InitializeRequestSchema, async (request) => {
@@ -740,6 +847,12 @@ export class N8NDocumentationMCPServer {
         });
       });
       
+      // Apply per-operation filtered definitions (lazily built on first call, cached for all subsequent calls)
+      const disabledToolOps = this.getDisabledToolOperations();
+      if (disabledToolOps.size > 0 && this.filteredToolDefinitionsCache) {
+        tools = tools.map(tool => this.filteredToolDefinitionsCache!.get(tool.name) ?? tool);
+      }
+
       UIAppRegistry.injectToolMeta(tools);
       return { tools };
     });
@@ -770,6 +883,31 @@ export class N8NDocumentationMCPServer {
             }, null, 2)
           }]
         };
+      }
+
+      // Check if the requested operation is disabled via DISABLED_TOOL_OPERATIONS
+      const disabledToolOps = this.getDisabledToolOperations();
+      const disabledOpsForTool = disabledToolOps.get(name);
+      if (disabledOpsForTool && disabledOpsForTool.size > 0) {
+        const paramName = TOOL_OPERATION_PARAM[name];
+        if (paramName) {
+          const requestedOp = args?.[paramName];
+          if (requestedOp && disabledOpsForTool.has(String(requestedOp).toLowerCase())) {
+            logger.warn(`Attempted to call disabled operation: ${name}.${requestedOp}`);
+            return {
+              content: [{
+                type: 'text',
+                text: JSON.stringify({
+                  error: 'OPERATION_DISABLED',
+                  message: `Operation '${requestedOp}' on tool '${name}' is disabled by server policy.`,
+                  tool: name,
+                  operation: requestedOp,
+                  disabledOperations: [...disabledOpsForTool]
+                }, null, 2)
+              }]
+            };
+          }
+        }
       }
 
       // Safeguard: if the entire args object arrives as a JSON string, parse it.
@@ -1434,6 +1572,19 @@ export class N8NDocumentationMCPServer {
     const disabledTools = this.getDisabledTools();
     if (disabledTools.has(name)) {
       throw new Error(`Tool '${name}' is disabled via DISABLED_TOOLS environment variable`);
+    }
+
+    // Defense in depth: operation-level check
+    const disabledToolOps = this.getDisabledToolOperations();
+    const disabledOpsForTool = disabledToolOps.get(name);
+    if (disabledOpsForTool && disabledOpsForTool.size > 0) {
+      const paramName = TOOL_OPERATION_PARAM[name];
+      if (paramName) {
+        const requestedOp = args[paramName];
+        if (requestedOp && disabledOpsForTool.has(String(requestedOp).toLowerCase())) {
+          throw new Error(`Operation '${requestedOp}' on tool '${name}' is disabled by server policy`);
+        }
+      }
     }
 
     // SECURITY (GHSA-wg4g-395p-mqv3): log metadata only, not raw arg values.
@@ -4082,11 +4233,14 @@ Full documentation is being prepared. For now, use get_node_essentials for confi
   // Method removed - replaced by getToolsDocumentation
 
   private async getToolsDocumentation(topic?: string, depth: 'essentials' | 'full' = 'essentials'): Promise<string> {
+    const disabledToolOps = this.getDisabledToolOperations();
+
     if (!topic || topic === 'overview') {
-      return getToolsOverview(depth);
+      return getToolsOverview(depth, disabledToolOps.size > 0 ? disabledToolOps : undefined);
     }
-    
-    return getToolDocumentation(topic, depth);
+
+    const toolDisabledOps = disabledToolOps.get(topic);
+    return getToolDocumentation(topic, depth, toolDisabledOps);
   }
 
   // Add connect method to accept any transport

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -703,7 +703,7 @@ export class N8NDocumentationMCPServer {
 
       const param = cloned.inputSchema?.properties?.[paramName];
       if (param?.enum) {
-        param.enum = (param.enum as string[]).filter(v => !ops.has(v));
+        param.enum = (param.enum as string[]).filter(v => !ops.has(v.toLowerCase()));
         if (param.enum.length === 0) {
           logger.warn(
             `DISABLED_TOOL_OPERATIONS: all operations for '${toolName}' are disabled ` +

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -668,7 +668,7 @@ export class N8NDocumentationMCPServer {
       if (ops.length === 0) continue;
 
       const existing = result.get(toolName) ?? new Set<string>();
-      ops.forEach(op => existing.add(op));
+      ops.forEach(op => existing.add(op.toLowerCase()));
       result.set(toolName, existing);
     }
 
@@ -704,6 +704,13 @@ export class N8NDocumentationMCPServer {
       const param = cloned.inputSchema?.properties?.[paramName];
       if (param?.enum) {
         param.enum = (param.enum as string[]).filter(v => !ops.has(v));
+        if (param.enum.length === 0) {
+          logger.warn(
+            `DISABLED_TOOL_OPERATIONS: all operations for '${toolName}' are disabled ` +
+            `but the tool still appears in ListTools. ` +
+            `Consider adding '${toolName}' to DISABLED_TOOLS instead.`
+          );
+        }
         if (param.description) {
           const disabledList = [...ops].join(', ');
           param.description = `${param.description} (disabled by server policy: ${disabledList})`;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -668,8 +668,26 @@ export class N8NDocumentationMCPServer {
       if (ops.length === 0) continue;
 
       const existing = result.get(toolName) ?? new Set<string>();
-      ops.forEach(op => existing.add(op.toLowerCase()));
+      ops.forEach(op => existing.add(op));
       result.set(toolName, existing);
+    }
+
+    // Warn (don't fail) on entries that can never match, so a typo such as
+    // `n8n_execution:delete` (wrong tool) or `n8n_executions:remove` (wrong op)
+    // is visible rather than silently leaving an operation enabled.
+    for (const [toolName, ops] of result) {
+      const paramName = TOOL_OPERATION_PARAM[toolName];
+      if (!paramName) {
+        logger.warn(`DISABLED_TOOL_OPERATIONS: unknown tool '${toolName}' — no per-operation filtering applied. Eligible tools: ${Object.keys(TOOL_OPERATION_PARAM).join(', ')}`);
+        continue;
+      }
+      const tool = n8nManagementTools.find(t => t.name === toolName);
+      const enumValues: string[] = (tool?.inputSchema as any)?.properties?.[paramName]?.enum ?? [];
+      for (const op of ops) {
+        if (enumValues.length > 0 && !enumValues.includes(op)) {
+          logger.warn(`DISABLED_TOOL_OPERATIONS: '${op}' is not a valid ${paramName} for '${toolName}' (valid: ${enumValues.join(', ')}); it will have no effect.`);
+        }
+      }
     }
 
     if (result.size > 0) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -881,33 +881,9 @@ export class N8NDocumentationMCPServer {
               message: `Tool '${name}' is not available in this deployment. It has been disabled via DISABLED_TOOLS environment variable.`,
               tool: name
             }, null, 2)
-          }]
+          }],
+          isError: true
         };
-      }
-
-      // Check if the requested operation is disabled via DISABLED_TOOL_OPERATIONS
-      const disabledToolOps = this.getDisabledToolOperations();
-      const disabledOpsForTool = disabledToolOps.get(name);
-      if (disabledOpsForTool && disabledOpsForTool.size > 0) {
-        const paramName = TOOL_OPERATION_PARAM[name];
-        if (paramName) {
-          const requestedOp = args?.[paramName];
-          if (requestedOp && disabledOpsForTool.has(String(requestedOp).toLowerCase())) {
-            logger.warn(`Attempted to call disabled operation: ${name}.${requestedOp}`);
-            return {
-              content: [{
-                type: 'text',
-                text: JSON.stringify({
-                  error: 'OPERATION_DISABLED',
-                  message: `Operation '${requestedOp}' on tool '${name}' is disabled by server policy.`,
-                  tool: name,
-                  operation: requestedOp,
-                  disabledOperations: [...disabledOpsForTool]
-                }, null, 2)
-              }]
-            };
-          }
-        }
       }
 
       // Safeguard: if the entire args object arrives as a JSON string, parse it.
@@ -971,6 +947,34 @@ export class N8NDocumentationMCPServer {
       // Removing them makes Zod treat them as missing (which .optional() allows).
       if (processedArgs) {
         processedArgs = JSON.parse(JSON.stringify(processedArgs));
+      }
+
+      // Check if the requested operation is disabled via DISABLED_TOOL_OPERATIONS.
+      // Runs after argument normalization so clients that send args as a JSON string
+      // are handled correctly regardless of serialization quirks.
+      const disabledToolOps = this.getDisabledToolOperations();
+      const disabledOpsForTool = disabledToolOps.get(name);
+      if (disabledOpsForTool && disabledOpsForTool.size > 0) {
+        const paramName = TOOL_OPERATION_PARAM[name];
+        if (paramName) {
+          const requestedOp = processedArgs?.[paramName];
+          if (requestedOp && disabledOpsForTool.has(String(requestedOp).toLowerCase())) {
+            logger.warn(`Attempted to call disabled operation: ${name}.${requestedOp}`);
+            return {
+              content: [{
+                type: 'text',
+                text: JSON.stringify({
+                  error: 'OPERATION_DISABLED',
+                  message: `Operation '${requestedOp}' on tool '${name}' is disabled by server policy.`,
+                  tool: name,
+                  operation: requestedOp,
+                  disabledOperations: [...disabledOpsForTool]
+                }, null, 2)
+              }],
+              isError: true
+            };
+          }
+        }
       }
 
       const isAdditionalTool = this.additionalToolsByName.has(name);

--- a/src/mcp/tools-documentation.ts
+++ b/src/mcp/tools-documentation.ts
@@ -1,6 +1,10 @@
 import { toolsDocumentation } from './tool-docs';
 
-export function getToolDocumentation(toolName: string, depth: 'essentials' | 'full' = 'essentials'): string {
+export function getToolDocumentation(
+  toolName: string,
+  depth: 'essentials' | 'full' = 'essentials',
+  disabledOperations?: Set<string>
+): string {
   // Check for special documentation topics
   if (toolName === 'javascript_code_node_guide') {
     return getJavaScriptCodeNodeGuide(depth);
@@ -14,10 +18,14 @@ export function getToolDocumentation(toolName: string, depth: 'essentials' | 'fu
     return `Tool '${toolName}' not found. Use tools_documentation() to see available tools.`;
   }
 
+  const disabledNotice = disabledOperations && disabledOperations.size > 0
+    ? `\n> **Server policy**: The following operations are disabled in this deployment: ${[...disabledOperations].join(', ')}\n`
+    : '';
+
   if (depth === 'essentials') {
     const { essentials } = tool;
     return `# ${tool.name}
-
+${disabledNotice}
 ${essentials.description}
 
 **Example**: ${essentials.example}
@@ -35,7 +43,7 @@ For full documentation, use: tools_documentation({topic: "${toolName}", depth: "
   // Full documentation
   const { full } = tool;
   return `# ${tool.name}
-
+${disabledNotice}
 ${full.description}
 
 ## Parameters
@@ -65,7 +73,17 @@ ${full.pitfalls.map(p => `- ${p}`).join('\n')}
 ${full.relatedTools.map(t => `- ${t}`).join('\n')}`;
 }
 
-export function getToolsOverview(depth: 'essentials' | 'full' = 'essentials'): string {
+function buildDisabledOpsOverviewSection(disabledToolOps?: Map<string, Set<string>>): string {
+  if (!disabledToolOps || disabledToolOps.size === 0) return '';
+  const lines = [...disabledToolOps.entries()]
+    .map(([tool, ops]) => `- **${tool}**: ${[...ops].join(', ')}`);
+  return `\n\n## Server Policy: Disabled Operations\nThe following operations are disabled in this deployment and will be rejected if called:\n${lines.join('\n')}`;
+}
+
+export function getToolsOverview(
+  depth: 'essentials' | 'full' = 'essentials',
+  disabledToolOps?: Map<string, Set<string>>
+): string {
   // Get version info from package.json. We track n8n-nodes-base directly
   // instead of the n8n meta package, so use that as the compatibility hint.
   const packageJson = require('../../package.json');
@@ -152,7 +170,7 @@ When working with Code nodes, always start by calling the relevant guide:
 - Network-dependent: All n8n_* tools
 
 For comprehensive documentation on any tool:
-tools_documentation({topic: "tool_name", depth: "full"})`;
+tools_documentation({topic: "tool_name", depth: "full"})${buildDisabledOpsOverviewSection(disabledToolOps)}`;
   }
 
   const categories = getAllCategories();
@@ -186,7 +204,7 @@ ${tools.map(toolName => {
 - n8n API tools only available when N8N_API_URL and N8N_API_KEY are configured
 
 For detailed documentation on any tool:
-tools_documentation({topic: "tool_name", depth: "full"})`;
+tools_documentation({topic: "tool_name", depth: "full"})${buildDisabledOpsOverviewSection(disabledToolOps)}`;
 }
 
 export function searchToolDocumentation(keyword: string): string[] {

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -778,3 +778,15 @@ export const TOOL_OPERATION_PARAM: Record<string, string> = {
   'n8n_executions': 'action',
   'n8n_workflow_versions': 'mode',
 };
+
+/**
+ * The write/destructive operation values per multi-operation tool. Used by
+ * DISABLED_TOOL_OPERATIONS filtering: when every destructive value has been
+ * disabled, the filtered tool is effectively read-only and its MCP annotations
+ * are recomputed (readOnlyHint/destructiveHint) so hosts that honor them don't
+ * keep gating the remaining read paths. Values are lowercase to match parsing.
+ */
+export const DESTRUCTIVE_TOOL_OPERATIONS: Record<string, Set<string>> = {
+  'n8n_executions': new Set(['delete']),
+  'n8n_workflow_versions': new Set(['delete', 'rollback', 'prune']),
+};

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -768,3 +768,13 @@ Old backups are also pruned automatically (10 most recent per workflow, plus an 
     },
   },
 ];
+
+/**
+ * Maps tool names to the argument key that carries the operation/mode selector.
+ * Only tools listed here are eligible for DISABLED_TOOL_OPERATIONS filtering.
+ * Add an entry here when introducing a new tool that bundles multiple operations.
+ */
+export const TOOL_OPERATION_PARAM: Record<string, string> = {
+  'n8n_executions': 'action',
+  'n8n_workflow_versions': 'mode',
+};

--- a/tests/unit/mcp/disabled-tool-operations.test.ts
+++ b/tests/unit/mcp/disabled-tool-operations.test.ts
@@ -345,6 +345,32 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
       expect(enumValues).toContain('get');
     });
 
+    it('should recompute annotations to read-only when all destructive ops are disabled', () => {
+      const disabledOps = new Map([
+        ['n8n_workflow_versions', new Set(['delete', 'rollback', 'prune'])]
+      ]);
+      server = new TestableN8NMCPServer();
+      const cache = server.testBuildFilteredToolDefinitions(disabledOps);
+
+      const filtered = cache.get('n8n_workflow_versions');
+      // Only read modes (list/get) remain → tool is effectively read-only.
+      expect(filtered.annotations.readOnlyHint).toBe(true);
+      expect(filtered.annotations.destructiveHint).toBe(false);
+    });
+
+    it('should keep destructiveHint when a destructive op remains', () => {
+      // Only 'delete' disabled; 'rollback'/'prune' still available → still destructive.
+      const disabledOps = new Map([
+        ['n8n_workflow_versions', new Set(['delete'])]
+      ]);
+      server = new TestableN8NMCPServer();
+      const cache = server.testBuildFilteredToolDefinitions(disabledOps);
+
+      const filtered = cache.get('n8n_workflow_versions');
+      expect(filtered.annotations.destructiveHint).toBe(true);
+      expect(filtered.annotations.readOnlyHint).toBe(false);
+    });
+
     it('should NOT mutate the original n8nManagementTools definitions', () => {
       const originalExec = n8nManagementTools.find(t => t.name === 'n8n_executions')!;
       const originalEnum = [...(originalExec.inputSchema as any).properties.action.enum];

--- a/tests/unit/mcp/disabled-tool-operations.test.ts
+++ b/tests/unit/mcp/disabled-tool-operations.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { N8NDocumentationMCPServer } from '../../../src/mcp/server';
+import { n8nManagementTools } from '../../../src/mcp/tools-n8n-manager';
+import { getToolDocumentation } from '../../../src/mcp/tools-documentation';
+
+vi.mock('../../../src/database/database-adapter');
+vi.mock('../../../src/database/node-repository');
+vi.mock('../../../src/templates/template-service');
+vi.mock('../../../src/utils/logger');
+
+class TestableN8NMCPServer extends N8NDocumentationMCPServer {
+  public testGetDisabledToolOperations(): Map<string, Set<string>> {
+    return (this as any).getDisabledToolOperations();
+  }
+
+  public testBuildFilteredToolDefinitions(disabledOps: Map<string, Set<string>>): Map<string, any> {
+    return (this as any).buildFilteredToolDefinitions(disabledOps);
+  }
+
+  public async testExecuteTool(name: string, args: any): Promise<any> {
+    return (this as any).executeTool(name, args);
+  }
+}
+
+describe('Disabled Tool Operations Feature (Issue #714)', () => {
+  let server: TestableN8NMCPServer;
+
+  beforeEach(() => {
+    process.env.NODE_DB_PATH = ':memory:';
+    delete process.env.DISABLED_TOOL_OPERATIONS;
+    delete process.env.DISABLED_TOOLS;
+  });
+
+  afterEach(() => {
+    delete process.env.NODE_DB_PATH;
+    delete process.env.DISABLED_TOOL_OPERATIONS;
+    delete process.env.DISABLED_TOOLS;
+  });
+
+  // ---------------------------------------------------------------------------
+  // 1. Parser — getDisabledToolOperations()
+  // ---------------------------------------------------------------------------
+
+  describe('getDisabledToolOperations() - Environment Variable Parsing', () => {
+    it('should return empty map when DISABLED_TOOL_OPERATIONS is not set', () => {
+      server = new TestableN8NMCPServer();
+      expect(server.testGetDisabledToolOperations().size).toBe(0);
+    });
+
+    it('should return empty map when DISABLED_TOOL_OPERATIONS is empty string', () => {
+      process.env.DISABLED_TOOL_OPERATIONS = '';
+      server = new TestableN8NMCPServer();
+      expect(server.testGetDisabledToolOperations().size).toBe(0);
+    });
+
+    it('should parse single tool with single operation', () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:delete';
+      server = new TestableN8NMCPServer();
+      const ops = server.testGetDisabledToolOperations();
+
+      expect(ops.size).toBe(1);
+      expect(ops.get('n8n_executions')).toEqual(new Set(['delete']));
+    });
+
+    it('should parse single tool with multiple operations', () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune,truncate';
+      server = new TestableN8NMCPServer();
+      const ops = server.testGetDisabledToolOperations();
+
+      expect(ops.size).toBe(1);
+      const versionOps = ops.get('n8n_workflow_versions')!;
+      expect(versionOps.has('delete')).toBe(true);
+      expect(versionOps.has('rollback')).toBe(true);
+      expect(versionOps.has('prune')).toBe(true);
+      expect(versionOps.has('truncate')).toBe(true);
+      expect(versionOps.size).toBe(4);
+    });
+
+    it('should parse multiple tools separated by semicolons', () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune,truncate;n8n_executions:delete';
+      server = new TestableN8NMCPServer();
+      const ops = server.testGetDisabledToolOperations();
+
+      expect(ops.size).toBe(2);
+      expect(ops.get('n8n_workflow_versions')!.size).toBe(4);
+      expect(ops.get('n8n_executions')).toEqual(new Set(['delete']));
+    });
+
+    it('should trim whitespace from tool names and operations', () => {
+      process.env.DISABLED_TOOL_OPERATIONS = '  n8n_executions  :  delete  ,  list  ';
+      server = new TestableN8NMCPServer();
+      const ops = server.testGetDisabledToolOperations();
+
+      const execOps = ops.get('n8n_executions')!;
+      expect(execOps.has('delete')).toBe(true);
+      expect(execOps.has('list')).toBe(true);
+    });
+
+    it('should filter out empty operation entries', () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:delete,,list,,,';
+      server = new TestableN8NMCPServer();
+      const ops = server.testGetDisabledToolOperations();
+
+      const execOps = ops.get('n8n_executions')!;
+      expect(execOps.size).toBe(2);
+      expect(execOps.has('delete')).toBe(true);
+      expect(execOps.has('list')).toBe(true);
+    });
+
+    it('should skip entries missing a colon separator', () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions_no_colon;n8n_workflow_versions:delete';
+      server = new TestableN8NMCPServer();
+      const ops = server.testGetDisabledToolOperations();
+
+      expect(ops.has('n8n_executions_no_colon')).toBe(false);
+      expect(ops.has('n8n_workflow_versions')).toBe(true);
+    });
+
+    it('should skip entries with empty operations after colon', () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:;n8n_workflow_versions:delete';
+      server = new TestableN8NMCPServer();
+      const ops = server.testGetDisabledToolOperations();
+
+      expect(ops.has('n8n_executions')).toBe(false);
+      expect(ops.has('n8n_workflow_versions')).toBe(true);
+    });
+
+    it('should enforce 50-entry limit', () => {
+      const entries = Array.from({ length: 60 }, (_, i) => `tool_${i}:op`).join(';');
+      process.env.DISABLED_TOOL_OPERATIONS = entries;
+      server = new TestableN8NMCPServer();
+      const ops = server.testGetDisabledToolOperations();
+
+      expect(ops.size).toBeLessThanOrEqual(50);
+    });
+
+    it('should enforce 10KB size limit on env var', () => {
+      const longValue = Array.from({ length: 1000 }, (_, i) => `tool_${i}:delete`).join(';');
+      expect(longValue.length).toBeGreaterThan(10000);
+
+      process.env.DISABLED_TOOL_OPERATIONS = longValue;
+      server = new TestableN8NMCPServer();
+
+      // Should not throw and should have parsed some entries
+      expect(server.testGetDisabledToolOperations().size).toBeGreaterThan(0);
+    });
+
+    it('should return cached result on repeated calls', () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:delete';
+      server = new TestableN8NMCPServer();
+
+      const first = server.testGetDisabledToolOperations();
+      const second = server.testGetDisabledToolOperations();
+
+      expect(first).toBe(second);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Dispatch enforcement — n8n_executions
+  // ---------------------------------------------------------------------------
+
+  describe('executeTool() - Dispatch Enforcement for n8n_executions', () => {
+    it('should throw with exact error message when delete is disabled', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:delete';
+      server = new TestableN8NMCPServer();
+
+      await expect(
+        server.testExecuteTool('n8n_executions', { action: 'delete', id: '123' })
+      ).rejects.toThrow("Operation 'delete' on tool 'n8n_executions' is disabled by server policy");
+    });
+
+    it('should not block allowed operations when only delete is disabled', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:delete';
+      server = new TestableN8NMCPServer();
+
+      for (const action of ['get', 'list']) {
+        try {
+          await server.testExecuteTool('n8n_executions', { action });
+        } catch (error: any) {
+          expect(error.message).not.toContain('disabled by server policy');
+        }
+      }
+    });
+
+    it('should include the tool name and operation in the error', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:delete';
+      server = new TestableN8NMCPServer();
+
+      let message = '';
+      try {
+        await server.testExecuteTool('n8n_executions', { action: 'delete', id: '123' });
+      } catch (error: any) {
+        message = error.message;
+      }
+
+      expect(message).toContain('delete');
+      expect(message).toContain('n8n_executions');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Dispatch enforcement — n8n_workflow_versions
+  // ---------------------------------------------------------------------------
+
+  describe('executeTool() - Dispatch Enforcement for n8n_workflow_versions', () => {
+    it('should block all four destructive operations', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune,truncate';
+      server = new TestableN8NMCPServer();
+
+      for (const mode of ['delete', 'rollback', 'prune', 'truncate']) {
+        await expect(
+          server.testExecuteTool('n8n_workflow_versions', { mode })
+        ).rejects.toThrow(`Operation '${mode}' on tool 'n8n_workflow_versions' is disabled by server policy`);
+      }
+    });
+
+    it('should not block read operations when destructive ops are disabled', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune,truncate';
+      server = new TestableN8NMCPServer();
+
+      for (const mode of ['list', 'get']) {
+        try {
+          await server.testExecuteTool('n8n_workflow_versions', { mode, workflowId: 'abc' });
+        } catch (error: any) {
+          expect(error.message).not.toContain('disabled by server policy');
+        }
+      }
+    });
+
+    it('should use mode param (not action) for n8n_workflow_versions', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete';
+      server = new TestableN8NMCPServer();
+
+      await expect(
+        server.testExecuteTool('n8n_workflow_versions', { mode: 'delete', workflowId: 'abc' })
+      ).rejects.toThrow("Operation 'delete' on tool 'n8n_workflow_versions' is disabled by server policy");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. Interaction with DISABLED_TOOLS
+  // ---------------------------------------------------------------------------
+
+  describe('Interaction with DISABLED_TOOLS', () => {
+    it('should block at tool level when tool is in DISABLED_TOOLS, not operation level', async () => {
+      process.env.DISABLED_TOOLS = 'n8n_executions';
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:delete';
+      server = new TestableN8NMCPServer();
+
+      await expect(
+        server.testExecuteTool('n8n_executions', { action: 'delete', id: '123' })
+      ).rejects.toThrow("Tool 'n8n_executions' is disabled via DISABLED_TOOLS environment variable");
+    });
+
+    it('should allow DISABLED_TOOLS and DISABLED_TOOL_OPERATIONS to target different tools', async () => {
+      process.env.DISABLED_TOOLS = 'n8n_delete_workflow';
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:delete';
+      server = new TestableN8NMCPServer();
+
+      // Tool-level block still works
+      await expect(
+        server.testExecuteTool('n8n_delete_workflow', {})
+      ).rejects.toThrow('disabled via DISABLED_TOOLS');
+
+      // Operation-level block still works on the other tool
+      await expect(
+        server.testExecuteTool('n8n_executions', { action: 'delete', id: '123' })
+      ).rejects.toThrow('disabled by server policy');
+    });
+
+    it('should work correctly when only DISABLED_TOOL_OPERATIONS is set', async () => {
+      delete process.env.DISABLED_TOOLS;
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:delete';
+      server = new TestableN8NMCPServer();
+
+      await expect(
+        server.testExecuteTool('n8n_executions', { action: 'delete', id: '123' })
+      ).rejects.toThrow('disabled by server policy');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. Schema filtering — buildFilteredToolDefinitions()
+  // ---------------------------------------------------------------------------
+
+  describe('buildFilteredToolDefinitions() - Schema Mutation Safety', () => {
+    it('should remove disabled operation from n8n_executions action enum', () => {
+      const disabledOps = new Map([['n8n_executions', new Set(['delete'])]]);
+      server = new TestableN8NMCPServer();
+      const cache = server.testBuildFilteredToolDefinitions(disabledOps);
+
+      const filtered = cache.get('n8n_executions');
+      expect(filtered).toBeDefined();
+      const enumValues: string[] = filtered.inputSchema.properties.action.enum;
+      expect(enumValues).not.toContain('delete');
+      expect(enumValues).toContain('get');
+      expect(enumValues).toContain('list');
+    });
+
+    it('should remove disabled operations from n8n_workflow_versions mode enum', () => {
+      const disabledOps = new Map([
+        ['n8n_workflow_versions', new Set(['delete', 'rollback', 'prune', 'truncate'])]
+      ]);
+      server = new TestableN8NMCPServer();
+      const cache = server.testBuildFilteredToolDefinitions(disabledOps);
+
+      const filtered = cache.get('n8n_workflow_versions');
+      const enumValues: string[] = filtered.inputSchema.properties.mode.enum;
+      expect(enumValues).not.toContain('delete');
+      expect(enumValues).not.toContain('rollback');
+      expect(enumValues).not.toContain('prune');
+      expect(enumValues).not.toContain('truncate');
+      expect(enumValues).toContain('list');
+      expect(enumValues).toContain('get');
+    });
+
+    it('should NOT mutate the original n8nManagementTools definitions', () => {
+      const originalExec = n8nManagementTools.find(t => t.name === 'n8n_executions')!;
+      const originalEnum = [...(originalExec.inputSchema as any).properties.action.enum];
+
+      const disabledOps = new Map([['n8n_executions', new Set(['delete'])]]);
+      server = new TestableN8NMCPServer();
+      server.testBuildFilteredToolDefinitions(disabledOps);
+
+      const afterEnum = (originalExec.inputSchema as any).properties.action.enum;
+      expect(afterEnum).toEqual(originalEnum);
+    });
+
+    it('should produce no cache entry for unknown tool names', () => {
+      const disabledOps = new Map([['n8n_nonexistent_tool', new Set(['delete'])]]);
+      server = new TestableN8NMCPServer();
+      const cache = server.testBuildFilteredToolDefinitions(disabledOps);
+
+      expect(cache.has('n8n_nonexistent_tool')).toBe(false);
+    });
+
+    it('should include disabled ops notice in tool description', () => {
+      const disabledOps = new Map([['n8n_executions', new Set(['delete'])]]);
+      server = new TestableN8NMCPServer();
+      const cache = server.testBuildFilteredToolDefinitions(disabledOps);
+
+      const filtered = cache.get('n8n_executions');
+      expect(filtered.description).toContain('disabled by server policy');
+      expect(filtered.description).toContain('delete');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // 6. tools_documentation notice
+  // ---------------------------------------------------------------------------
+
+  describe('getToolDocumentation() - Disabled Operations Notice', () => {
+    it('should include server policy notice when operations are disabled (essentials)', () => {
+      const result = getToolDocumentation('n8n_executions', 'essentials', new Set(['delete']));
+      expect(result).toContain('Server policy');
+      expect(result).toContain('delete');
+    });
+
+    it('should include server policy notice in full depth', () => {
+      const result = getToolDocumentation('n8n_executions', 'full', new Set(['delete']));
+      expect(result).toContain('Server policy');
+      expect(result).toContain('delete');
+    });
+
+    it('should not include notice when no operations are disabled', () => {
+      const result = getToolDocumentation('n8n_executions', 'essentials');
+      expect(result).not.toContain('Server policy');
+    });
+
+    it('should list all disabled operations in the notice', () => {
+      const result = getToolDocumentation(
+        'n8n_workflow_versions',
+        'essentials',
+        new Set(['delete', 'rollback', 'prune', 'truncate'])
+      );
+      expect(result).toContain('delete');
+      expect(result).toContain('rollback');
+      expect(result).toContain('prune');
+      expect(result).toContain('truncate');
+    });
+  });
+});

--- a/tests/unit/mcp/disabled-tool-operations.test.ts
+++ b/tests/unit/mcp/disabled-tool-operations.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { N8NDocumentationMCPServer } from '../../../src/mcp/server';
 import { n8nManagementTools } from '../../../src/mcp/tools-n8n-manager';
 import { getToolDocumentation } from '../../../src/mcp/tools-documentation';
+import { logger } from '../../../src/utils/logger';
 
 vi.mock('../../../src/database/database-adapter');
 vi.mock('../../../src/database/node-repository');
@@ -154,6 +155,18 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
 
       expect(first).toBe(second);
     });
+
+    it('should normalise uppercase operation names in env var to lowercase', () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:DELETE,List';
+      server = new TestableN8NMCPServer();
+      const ops = server.testGetDisabledToolOperations();
+
+      const execOps = ops.get('n8n_executions')!;
+      expect(execOps.has('delete')).toBe(true);
+      expect(execOps.has('list')).toBe(true);
+      expect(execOps.has('DELETE')).toBe(false);
+      expect(execOps.has('List')).toBe(false);
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -196,6 +209,15 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
 
       expect(message).toContain('delete');
       expect(message).toContain('n8n_executions');
+    });
+
+    it('should block uppercase operation from client when lowercase rule is configured', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:delete';
+      server = new TestableN8NMCPServer();
+
+      await expect(
+        server.testExecuteTool('n8n_executions', { action: 'DELETE', id: '123' })
+      ).rejects.toThrow("Operation 'DELETE' on tool 'n8n_executions' is disabled by server policy");
     });
   });
 
@@ -343,6 +365,18 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
       const filtered = cache.get('n8n_executions');
       expect(filtered.description).toContain('disabled by server policy');
       expect(filtered.description).toContain('delete');
+    });
+
+    it('should warn when all operations for a tool are disabled', () => {
+      const disabledOps = new Map([
+        ['n8n_executions', new Set(['get', 'list', 'delete'])]
+      ]);
+      server = new TestableN8NMCPServer();
+      server.testBuildFilteredToolDefinitions(disabledOps);
+
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        expect.stringContaining("all operations for 'n8n_executions' are disabled")
+      );
     });
   });
 

--- a/tests/unit/mcp/disabled-tool-operations.test.ts
+++ b/tests/unit/mcp/disabled-tool-operations.test.ts
@@ -64,7 +64,7 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
     });
 
     it('should parse single tool with multiple operations', () => {
-      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune,truncate';
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune';
       server = new TestableN8NMCPServer();
       const ops = server.testGetDisabledToolOperations();
 
@@ -73,17 +73,26 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
       expect(versionOps.has('delete')).toBe(true);
       expect(versionOps.has('rollback')).toBe(true);
       expect(versionOps.has('prune')).toBe(true);
-      expect(versionOps.has('truncate')).toBe(true);
-      expect(versionOps.size).toBe(4);
+      expect(versionOps.size).toBe(3);
+    });
+
+    it('should parse operation names case-insensitively', () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:Delete,ROLLBACK';
+      server = new TestableN8NMCPServer();
+      const ops = server.testGetDisabledToolOperations();
+
+      const versionOps = ops.get('n8n_workflow_versions')!;
+      expect(versionOps.has('delete')).toBe(true);
+      expect(versionOps.has('rollback')).toBe(true);
     });
 
     it('should parse multiple tools separated by semicolons', () => {
-      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune,truncate;n8n_executions:delete';
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune;n8n_executions:delete';
       server = new TestableN8NMCPServer();
       const ops = server.testGetDisabledToolOperations();
 
       expect(ops.size).toBe(2);
-      expect(ops.get('n8n_workflow_versions')!.size).toBe(4);
+      expect(ops.get('n8n_workflow_versions')!.size).toBe(3);
       expect(ops.get('n8n_executions')).toEqual(new Set(['delete']));
     });
 
@@ -226,11 +235,11 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
   // ---------------------------------------------------------------------------
 
   describe('executeTool() - Dispatch Enforcement for n8n_workflow_versions', () => {
-    it('should block all four destructive operations', async () => {
-      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune,truncate';
+    it('should block all destructive operations', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune';
       server = new TestableN8NMCPServer();
 
-      for (const mode of ['delete', 'rollback', 'prune', 'truncate']) {
+      for (const mode of ['delete', 'rollback', 'prune']) {
         await expect(
           server.testExecuteTool('n8n_workflow_versions', { mode })
         ).rejects.toThrow(`Operation '${mode}' on tool 'n8n_workflow_versions' is disabled by server policy`);
@@ -238,7 +247,7 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
     });
 
     it('should not block read operations when destructive ops are disabled', async () => {
-      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune,truncate';
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:delete,rollback,prune';
       server = new TestableN8NMCPServer();
 
       for (const mode of ['list', 'get']) {
@@ -322,7 +331,7 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
 
     it('should remove disabled operations from n8n_workflow_versions mode enum', () => {
       const disabledOps = new Map([
-        ['n8n_workflow_versions', new Set(['delete', 'rollback', 'prune', 'truncate'])]
+        ['n8n_workflow_versions', new Set(['delete', 'rollback', 'prune'])]
       ]);
       server = new TestableN8NMCPServer();
       const cache = server.testBuildFilteredToolDefinitions(disabledOps);
@@ -332,7 +341,6 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
       expect(enumValues).not.toContain('delete');
       expect(enumValues).not.toContain('rollback');
       expect(enumValues).not.toContain('prune');
-      expect(enumValues).not.toContain('truncate');
       expect(enumValues).toContain('list');
       expect(enumValues).toContain('get');
     });
@@ -406,12 +414,11 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
       const result = getToolDocumentation(
         'n8n_workflow_versions',
         'essentials',
-        new Set(['delete', 'rollback', 'prune', 'truncate'])
+        new Set(['delete', 'rollback', 'prune'])
       );
       expect(result).toContain('delete');
       expect(result).toContain('rollback');
       expect(result).toContain('prune');
-      expect(result).toContain('truncate');
     });
   });
 });


### PR DESCRIPTION
# PR: Per-operation tool filtering via `DISABLED_TOOL_OPERATIONS` — Closes #714


## What this does

Introduces a new environment variable `DISABLED_TOOL_OPERATIONS` that lets operators disable specific operations within a tool at dispatch time, without losing the tool's read paths. This unblocks the read-only deployment use case described in #714.

```
DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune,truncate;n8n_executions:delete
```

Format: semicolon-separated list of `<tool_name>:<comma_separated_operations>`. Operation names match the existing `action` / `mode` enum values in each tool's schema.

## Why

`DISABLED_TOOLS` operates at tool level — disabling `n8n_executions` kills `list` and `get` along with `delete`. Governance-sensitive deployments need a finer knob. This PR adds that knob with minimal surface area and zero runtime overhead after the first request.

## What changed

### `src/mcp/server.ts`
- **`getDisabledToolOperations()`** — parses `DISABLED_TOOL_OPERATIONS` at first use, caches the result. Same safety limits as `getDisabledTools()`: 10KB env var cap, 50-entry cap.
- **`buildFilteredToolDefinitions()`** — called once on first parse. Deep-clones only the affected tool definitions and filters the operation `enum` array so the LLM never sees disabled ops in `ListTools`.
- **`ListToolsRequestSchema` handler** — applies pre-built filtered definitions via a Map lookup. Zero cloning cost per request.
- **`CallToolRequestSchema` handler** — checks disabled operations before calling the handler. Returns a structured `OPERATION_DISABLED` error.
  > **Note (behaviour change):** also fixes the existing `DISABLED_TOOLS` response to include `isError: true` — previously the response was a content-only envelope; this aligns it with the correct MCP protocol shape and with the new `OPERATION_DISABLED` response. Integrations checking `response.isError` directly will now see `true` instead of `undefined`.
- **`executeTool()`** — secondary defense-in-depth guard, mirrors the existing `DISABLED_TOOLS` guard pattern.

### `src/mcp/tools-n8n-manager.ts`
- **`TOOL_OPERATION_PARAM`** — exported map of `toolName -> argument key`. Necessary because eligible tools use different argument names for their operation selector: `n8n_executions` uses `action`, `n8n_workflow_versions` uses `mode`. The dispatch guard needs to know which argument to inspect per tool. Co-located with the tool definitions so adding a future eligible tool is a single-file change.

### `src/mcp/tools-documentation.ts`
- **`getToolDocumentation()`** — accepts an optional `disabledOperations?: Set<string>` parameter. When set, prepends a clear server policy notice to both essentials and full output.
- **`getToolsOverview()`** — accepts an optional `disabledToolOps?: Map<string, Set<string>>` parameter. When set, appends a `## Server Policy: Disabled Operations` section.

### `tests/unit/mcp/disabled-tool-operations.test.ts`
- 30 tests across 6 groups: parser edge cases, dispatch enforcement for `n8n_executions`, dispatch enforcement for `n8n_workflow_versions`, interaction with `DISABLED_TOOLS`, schema filtering/mutation safety, and `tools_documentation` notice.

### Docs and configuration
- **`README.md`** — Read-Only Deployment section added under Available MCP Tools, covering both `DISABLED_TOOLS` (purely write tools) and `DISABLED_TOOL_OPERATIONS` (mixed-operation tools).
- **`docs/HTTP_DEPLOYMENT.md`** — Read-Only Deployment Recipe section added under Security Best Practices, with the full two-layer setup guide.
- **`.env.example`** — `DISABLED_TOOL_OPERATIONS` block added after `DISABLED_TOOLS` with format, eligible tools, and the read-only recipe example.

## Design decisions worth discussing

**Documentation approach**: disabled operations are surfaced as a plain text notice at the top of the `tools_documentation` output, not by filtering out tips/examples. Filtering free-form text strings is fragile — the notice alone is sufficient for the LLM to understand the constraint.

**Unknown operation names**: if a configured operation doesn't exist in the tool's enum (e.g. a typo), both the schema layer and the dispatch layer are silent no-ops — the enum filter has nothing to remove, and the dispatch guard will never match. The description notice will include the configured name as-is. This is intentionally consistent with how `DISABLED_TOOLS` handles unknown tool names — user's responsibility, server stays stable.

**Caching**: `getDisabledToolOperations()` is lazy — it initialises on the first MCP request (either `ListTools` or `CallTool`), not at server startup. This is the same pattern as `getDisabledTools()`. The comment in the code says so explicitly.

**Scope**: only `n8n_executions` and `n8n_workflow_versions` are eligible today. Adding a new tool requires one line in `TOOL_OPERATION_PARAM` in `tools-n8n-manager.ts`.

## Open questions / suggestions welcome

- Should unknown operation names in the env var be silently ignored (current) or emit a `logger.warn` at parse time listing valid alternatives? Hard failure at startup is probably too strict for a config knob.

- `TOOL_OPERATION_PARAM` exists because the two eligible tools use different argument names for their operation selector (`action` vs `mode`). If future tools are added, this map grows. A cleaner long-term fix would be to standardize the operation selector argument name across all multi-operation tools (e.g. always use `operation`), which would eliminate the need for this map entirely and make per-operation filtering generic.

Conceived by Romuald Czlonkowski — https://www.aiadvisors.pl/en
