### PR TITLE
fix(ci): add auth header to Docker MCP endpoint test

### DIFF
--- a/.github/workflows/docker-build-n8n.yml
+++ b/.github/workflows/docker-build-n8n.yml
@@ -148,8 +148,8 @@ jobs:
           # Test health endpoint
           curl -f http://localhost:3000/health || exit 1
           
-          # Test MCP endpoint
-          curl -f http://localhost:3000/mcp || exit 1
+          # Test MCP endpoint (requires auth since v2.47.6)
+          curl -f -H "Authorization: Bearer test-token-minimum-32-chars-long" http://localhost:3000/mcp || exit 1
           
           # Cleanup
           docker stop n8n-mcp-test


### PR DESCRIPTION
## Summary

- The `/mcp` endpoint requires authentication since v2.47.6 (GHSA-75hx-xj24-mqrw)
- The Docker image smoke test in `docker-build-n8n.yml` was calling `curl -f http://localhost:3000/mcp` without a Bearer token
- This caused a 401 response, failing the `test-image` job on every push to main

Adds `Authorization: Bearer` header using the same test token already passed as `MCP_AUTH_TOKEN` env var to the container.

## Test plan

- [x] CI `test-image` job should now pass the `/mcp` endpoint check

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)