### PR TITLE
fix: add projectId and require columns for n8n_manage_datatable createTable (v2.47.10, #731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.47.10] - 2026-04-16
+
+### Added
+
+- **`projectId` parameter on `n8n_manage_datatable` `createTable` (Issue #731, reported by @nesl247).** Tables can now be created directly in a specific n8n project instead of always landing in the default/personal project. The n8n public API (`POST /data-tables`) already accepts `projectId` as an optional body field — it was never wired through the MCP tool. `projectId` is threaded through the tool inputSchema, the Zod `createTableSchema`, and the `createDataTable` API client signature, matching the existing pattern on `n8n_create_workflow`. Workflows in team projects that rely on project-scoped data tables (e.g. queue-based processing) can now be fully automated via MCP.
+
+### Changed
+
+- **`columns` is now required (at least one) for `n8n_manage_datatable` `createTable`.** Previously the tool schema marked `columns` as optional, but the underlying n8n API rejects the call with `VALIDATION_ERROR: request/body must have required property 'columns'`. The Zod schema now enforces `.min(1, 'At least one column is required')` so the failure surfaces at the MCP boundary with a clear message instead of an opaque 400 from the API round-trip. Tool inputSchema description, `keyParameters`, `full.description`, parameter docs, and pitfalls are all updated to match.
+
+### Fixed
+
+- **Removed incorrect pitfall claiming `projectId` could not be set via the public API** in `n8n_manage_datatable` tool docs. The n8n API has always supported it; this documentation was misleading agents into manual UI workarounds.
+
+Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en
+
 ## [2.47.9] - 2026-04-16
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.47.8",
+  "version": "2.47.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.47.8",
+      "version": "2.47.10",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.47.9",
+  "version": "2.47.10",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -2751,7 +2751,8 @@ const createTableSchema = z.object({
   columns: z.array(z.object({
     name: z.string().min(1, 'Column name cannot be empty'),
     type: z.enum(['string', 'number', 'boolean', 'date']).optional(),
-  })).optional(),
+  })).min(1, 'At least one column is required'),
+  projectId: z.string().optional(),
 });
 
 const listTablesSchema = z.object({

--- a/src/mcp/tool-docs/workflow_management/n8n-manage-datatable.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-manage-datatable.ts
@@ -5,7 +5,7 @@ export const n8nManageDatatableDoc: ToolDocumentation = {
   category: 'workflow_management',
   essentials: {
     description: 'Manage n8n data tables and rows. Unified tool for table CRUD and row operations with filtering, pagination, and dry-run support.',
-    keyParameters: ['action', 'tableId', 'name', 'data', 'filter'],
+    keyParameters: ['action', 'tableId', 'name', 'columns', 'data', 'filter'],
     example: 'n8n_manage_datatable({action: "createTable", name: "Contacts", columns: [{name: "email", type: "string"}]})',
     performance: 'Fast (100-500ms)',
     tips: [
@@ -19,7 +19,7 @@ export const n8nManageDatatableDoc: ToolDocumentation = {
   },
   full: {
     description: `**Table Actions:**
-- **createTable**: Create a new data table with optional typed columns
+- **createTable**: Create a new data table with one or more typed columns (columns are required)
 - **listTables**: List all data tables (paginated)
 - **getTable**: Get table details and column definitions by ID
 - **updateTable**: Rename an existing table (name only — column modifications not supported via API)
@@ -42,7 +42,7 @@ export const n8nManageDatatableDoc: ToolDocumentation = {
       action: { type: 'string', required: true, description: 'Operation to perform' },
       tableId: { type: 'string', required: false, description: 'Data table ID (required for all except createTable and listTables)' },
       name: { type: 'string', required: false, description: 'For createTable/updateTable: table name' },
-      columns: { type: 'array', required: false, description: 'For createTable: column definitions [{name, type?}]. Types: string, number, boolean, date' },
+      columns: { type: 'array', required: false, description: 'For createTable (required, at least one): column definitions [{name, type?}]. Types: string, number, boolean, date' },
       data: { type: 'array|object', required: false, description: 'For insertRows: array of row objects. For updateRows/upsertRows: object with column values' },
       filter: { type: 'object', required: false, description: 'Filter: {type?: "and"|"or", filters: [{columnName, condition, value}]}' },
       limit: { type: 'number', required: false, description: 'For listTables/getRows: max results (1-100)' },
@@ -100,7 +100,7 @@ export const n8nManageDatatableDoc: ToolDocumentation = {
       'deleteRows requires a filter — cannot delete all rows without one',
       'Column types cannot be changed after table creation via API',
       'updateTable can only rename the table (no column modifications via public API)',
-      'projectId cannot be set via the public API — use the n8n UI',
+      'createTable requires at least one column — schema cannot be changed after creation',
     ],
     relatedTools: ['n8n_create_workflow', 'n8n_list_workflows', 'n8n_health_check'],
   },

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -622,7 +622,7 @@ export const n8nManagementTools: ToolDefinition[] = [
         name: { type: 'string', description: 'For createTable: table name. For updateTable: new name (rename only — schema is immutable after creation)' },
         columns: {
           type: 'array',
-          description: 'For createTable only: column definitions (schema is immutable after creation via public API)',
+          description: 'For createTable (required, at least one): column definitions. Schema is immutable after creation via public API.',
           items: {
             type: 'object',
             properties: {
@@ -644,6 +644,7 @@ export const n8nManagementTools: ToolDefinition[] = [
         returnType: { type: 'string', enum: ['count', 'id', 'all'], description: 'For insertRows: what to return (default: count)' },
         returnData: { type: 'boolean', description: 'For updateRows/upsertRows/deleteRows: return affected rows (default: false)' },
         dryRun: { type: 'boolean', description: 'For updateRows/upsertRows/deleteRows: preview without applying (default: false)' },
+        projectId: { type: 'string', description: 'For createTable: project ID to create the table in. If omitted, uses the default project.' },
       },
       required: ['action'],
     },

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -646,7 +646,7 @@ export class N8nApiClient {
     }
   }
 
-  async createDataTable(params: { name: string; columns?: DataTableColumn[] }): Promise<DataTable> {
+  async createDataTable(params: { name: string; columns?: DataTableColumn[]; projectId?: string }): Promise<DataTable> {
     try {
       const response = await this.client.post('/data-tables', params);
       return response.data;

--- a/tests/unit/mcp/handlers-manage-datatable.test.ts
+++ b/tests/unit/mcp/handlers-manage-datatable.test.ts
@@ -132,27 +132,55 @@ describe('Data Table Handlers (n8n_manage_datatable)', () => {
       });
     });
 
-    it('should create data table with name only (no columns)', async () => {
+    it('should create data table in a specific project when projectId is provided', async () => {
       const createdTable = {
-        id: 'dt-456',
-        name: 'Empty Table',
+        id: 'dt-789',
+        name: 'Project Table',
+        projectId: 'proj-123',
       };
 
       mockApiClient.createDataTable.mockResolvedValue(createdTable);
 
       const result = await handlers.handleCreateTable({
-        name: 'Empty Table',
+        name: 'Project Table',
+        columns: [{ name: 'id', type: 'string' }],
+        projectId: 'proj-123',
       });
 
       expect(result).toEqual({
         success: true,
-        data: { id: 'dt-456', name: 'Empty Table' },
-        message: 'Data table "Empty Table" created with ID: dt-456',
+        data: { id: 'dt-789', name: 'Project Table' },
+        message: 'Data table "Project Table" created with ID: dt-789',
       });
 
       expect(mockApiClient.createDataTable).toHaveBeenCalledWith({
-        name: 'Empty Table',
+        name: 'Project Table',
+        columns: [{ name: 'id', type: 'string' }],
+        projectId: 'proj-123',
       });
+    });
+
+    it('should return Zod validation error when columns is missing', async () => {
+      const result = await handlers.handleCreateTable({
+        name: 'No Columns Table',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid input');
+      expect(result.details).toHaveProperty('errors');
+      expect(mockApiClient.createDataTable).not.toHaveBeenCalled();
+    });
+
+    it('should return Zod validation error when columns is an empty array', async () => {
+      const result = await handlers.handleCreateTable({
+        name: 'Empty Columns Table',
+        columns: [],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid input');
+      expect(result.details).toHaveProperty('errors');
+      expect(mockApiClient.createDataTable).not.toHaveBeenCalled();
     });
 
     it('should return error when API returns empty response (null)', async () => {
@@ -160,6 +188,7 @@ describe('Data Table Handlers (n8n_manage_datatable)', () => {
 
       const result = await handlers.handleCreateTable({
         name: 'Ghost Table',
+        columns: [{ name: 'id', type: 'string' }],
       });
 
       expect(result).toEqual({
@@ -174,6 +203,7 @@ describe('Data Table Handlers (n8n_manage_datatable)', () => {
 
       const result = await handlers.handleCreateTable({
         name: 'Broken Table',
+        columns: [{ name: 'id', type: 'string' }],
       });
 
       expect(result).toEqual({
@@ -195,6 +225,7 @@ describe('Data Table Handlers (n8n_manage_datatable)', () => {
 
       const result = await handlers.handleCreateTable({
         name: 'Test Table',
+        columns: [{ name: 'id', type: 'string' }],
       });
 
       expect(result).toEqual({
@@ -209,6 +240,7 @@ describe('Data Table Handlers (n8n_manage_datatable)', () => {
 
       const result = await handlers.handleCreateTable({
         name: 'Enterprise Table',
+        columns: [{ name: 'id', type: 'string' }],
       });
 
       expect(result.success).toBe(false);
@@ -222,6 +254,7 @@ describe('Data Table Handlers (n8n_manage_datatable)', () => {
 
       const result = await handlers.handleCreateTable({
         name: 'Error Table',
+        columns: [{ name: 'id', type: 'string' }],
       });
 
       expect(result).toEqual({


### PR DESCRIPTION
## Summary
- Fixes #731 by adding `projectId` to `n8n_manage_datatable` createTable, threaded through tool schema, Zod validator, and API client (pattern mirrors `n8n_create_workflow`).
- Enforces `columns` as required (at least one) on createTable so MCP rejects invalid calls with a clear Zod error instead of an opaque n8n API 400.
- Removes incorrect pitfall claiming `projectId` cannot be set via the public API.

## Test plan
- [x] `npm run build` passes
- [x] `npm test -- tests/unit/mcp/handlers-manage-datatable.test.ts` — 39/39 pass (2 new negative Zod tests + 1 new projectId test)
- [x] Live MCP verification: tables created with/without `projectId` land in the right project; `tools_documentation` shows all updates
- [ ] CI green

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)