### PR TITLE
ci: collapse agentic triage to single approval gate

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"d5228b82efa96cdab03cfb43740290fe073610113fd42697d822b7655641cbc0","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8138005e553d8368256fb7a4f4ca604d011217c6537a97e1bb356643b8aa6d4c","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -200,14 +200,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_4cff8f8793122a3e_EOF'
+          cat << 'GH_AW_PROMPT_4a02f78a21384b0c_EOF'
           <system>
-          GH_AW_PROMPT_4cff8f8793122a3e_EOF
+          GH_AW_PROMPT_4a02f78a21384b0c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4cff8f8793122a3e_EOF'
+          cat << 'GH_AW_PROMPT_4a02f78a21384b0c_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:5), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -239,12 +239,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_4cff8f8793122a3e_EOF
+          GH_AW_PROMPT_4a02f78a21384b0c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_4cff8f8793122a3e_EOF'
+          cat << 'GH_AW_PROMPT_4a02f78a21384b0c_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_4cff8f8793122a3e_EOF
+          GH_AW_PROMPT_4a02f78a21384b0c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -414,9 +414,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_53a513fc3e6cef41_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c281518129c72234_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":5},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_53a513fc3e6cef41_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_c281518129c72234_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -618,7 +618,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_c2261d7be92d2d82_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_d0230fabc1b8e435_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -662,7 +662,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c2261d7be92d2d82_EOF
+          GH_AW_MCP_CONFIG_d0230fabc1b8e435_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -862,7 +862,7 @@ jobs:
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
       needs.activation.outputs.stale_lock_file_failed == 'true')
     runs-on: ubuntu-slim
-    environment: agentic-triage
+    environment: agentic-triage-passthrough
     permissions:
       contents: read
       discussions: write
@@ -1158,7 +1158,7 @@ jobs:
 
   pre_activation:
     runs-on: ubuntu-slim
-    environment: agentic-triage
+    environment: agentic-triage-passthrough
     outputs:
       activated: ${{ steps.check_skip_bots.outputs.skip_bots_ok == 'true' }}
       matched_command: ''
@@ -1190,7 +1190,7 @@ jobs:
       - detection
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
-    environment: agentic-triage
+    environment: agentic-triage-passthrough
     permissions:
       contents: read
       discussions: write

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -21,6 +21,7 @@ permissions:
 network: defaults
 
 safe-outputs:
+  environment: agentic-triage-passthrough
   report-failure-as-issue: false
   add-labels:
     max: 5


### PR DESCRIPTION
## Summary

Follow-up to #745. The Stage 1 smoke test (issue #747) confirmed Copilot's round-3 concern: the single `environment: agentic-triage` was being applied to four jobs (`pre_activation`, `agent`, `safe_outputs`, `conclusion`), and GitHub does **not** batch deployment approvals across job-queue events within a single run. Result: 3 separate approval clicks per issue.

This PR splits into two environments:
- `agentic-triage` (gated, your existing required-reviewer environment) → only on the `agent` job (the expensive Copilot run)
- `agentic-triage-passthrough` (no rules) → on `pre_activation`, `safe_outputs`, `conclusion`

## New flow

1. Issue opens → `pre_activation` runs immediately (skip-bots check, ubuntu-slim, ~5s)
2. `activation` runs (ubuntu-slim)
3. `agent` queues, waits for **single** approval
4. You click Approve once
5. `agent` runs (Copilot, ~2-5 min), then `detection`/`safe_outputs`/`conclusion` run without further prompts

Free side benefit: bot-opened issues short-circuit at `pre_activation` (skip-bots) and never prompt for approval at all.

## What's in this PR

- `.github/workflows/issue-triage.md` — one new line: `safe-outputs.environment: agentic-triage-passthrough`
- `.github/workflows/issue-triage.lock.yml` — recompiled

## Required before merge

Create the passthrough environment so it has no rules (otherwise GitHub will auto-create it on first run, which usually works, but on some org-policy setups admin auto-create is restricted):

1. Settings → Environments → New environment → name: `agentic-triage-passthrough`
2. Leave all protection rules **unchecked**
3. Save

## Test plan

- [ ] Create `agentic-triage-passthrough` environment with no rules
- [ ] Merge PR
- [ ] Open a throwaway test issue
- [ ] Verify a single approval prompt appears (on the `agent` job)
- [ ] Approve once → confirm triage comment + label appear without further prompts

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)