### PR TITLE
fix(diff-engine): scope addConnection duplicate check to sourceIndex (#738)

### DIFF
--- a/src/services/workflow-diff-engine.ts
+++ b/src/services/workflow-diff-engine.ts
@@ -697,15 +697,20 @@ export class WorkflowDiffEngine {
       return `Target node not found: "${operation.target}". Available nodes: ${availableNodes}. Tip: Use node ID for names with special characters (apostrophes, quotes).`;
     }
 
-    // Check if connection already exists
-    const sourceOutput = operation.sourceOutput || 'main';
+    // Check if a connection already exists *at the same sourceIndex*.
+    // For multi-output nodes (Switch, IF, etc.) the connection is keyed
+    // by (source, sourceOutput, sourceIndex, target) — two outputs of
+    // the same Switch can both legitimately fan into the same target
+    // node (e.g. several branches sharing a fallback / error handler).
+    // Without scoping the check to sourceIndex, the second branch was
+    // rejected with "Connection already exists" even though
+    // (source, sourceIndex=N, target) didn't actually exist yet (#738).
+    const { sourceOutput, sourceIndex } = this.resolveSmartParameters(workflow, operation);
     const existing = workflow.connections[sourceNode.name]?.[sourceOutput];
-    if (existing) {
-      const hasConnection = existing.some(connections =>
-        connections.some(c => c.node === targetNode.name)
-      );
+    if (existing && Array.isArray(existing[sourceIndex])) {
+      const hasConnection = existing[sourceIndex].some(c => c.node === targetNode.name);
       if (hasConnection) {
-        return `Connection already exists from "${sourceNode.name}" to "${targetNode.name}"`;
+        return `Connection already exists from "${sourceNode.name}" to "${targetNode.name}" at sourceIndex=${sourceIndex}`;
       }
     }
 

--- a/tests/unit/services/workflow-diff-engine.test.ts
+++ b/tests/unit/services/workflow-diff-engine.test.ts
@@ -1274,9 +1274,81 @@ describe('WorkflowDiffEngine', () => {
       };
 
       const result = await diffEngine.applyDiff(baseWorkflow, request);
-      
+
       expect(result.success).toBe(false);
       expect(result.errors![0].message).toContain('Connection already exists');
+    });
+
+    // Regression test for #738. The duplicate-connection check used to
+    // ignore sourceIndex, so two outputs of a Switch node fanning into
+    // the same target (a common pattern when several branches share a
+    // fallback / error handler) was rejected with
+    // "Connection already exists" even though
+    // (source, sourceIndex=N, target) didn't actually exist yet.
+    it('should allow connecting different sourceIndex outputs to the same target (#738)', async () => {
+      // Manually wire a "Switch -> HTTP Request" connection at sourceIndex 0
+      // so we can verify that a NEW connection at sourceIndex 1 to the same
+      // target is allowed.
+      baseWorkflow.connections['Slack'] = {
+        main: [
+          [{ node: 'HTTP Request', type: 'main', index: 0 }], // index 0
+          // index 1 is intentionally absent
+        ],
+      };
+
+      const operation: AddConnectionOperation = {
+        type: 'addConnection',
+        source: 'Slack',
+        target: 'HTTP Request',
+        sourceIndex: 1, // Different output index — must be permitted.
+      };
+
+      const request: WorkflowDiffRequest = {
+        id: 'test-workflow',
+        operations: [operation]
+      };
+
+      const result = await diffEngine.applyDiff(baseWorkflow, request);
+
+      expect(result.success).toBe(true);
+      // The new connection is appended at index 1 alongside the
+      // pre-existing index-0 connection.
+      const slackConnections = result.workflow!.connections['Slack'].main;
+      expect(slackConnections[0]).toEqual([
+        { node: 'HTTP Request', type: 'main', index: 0 },
+      ]);
+      expect(slackConnections[1]).toEqual([
+        { node: 'HTTP Request', type: 'main', index: 0 },
+      ]);
+    });
+
+    // The duplicate check must STILL fire when the (source, sourceIndex,
+    // target) triple is genuinely a duplicate — re-adding the same edge
+    // at the same index is still an error.
+    it('should still reject duplicate connections at the same sourceIndex (#738)', async () => {
+      baseWorkflow.connections['Slack'] = {
+        main: [
+          [{ node: 'HTTP Request', type: 'main', index: 0 }],
+        ],
+      };
+
+      const operation: AddConnectionOperation = {
+        type: 'addConnection',
+        source: 'Slack',
+        target: 'HTTP Request',
+        sourceIndex: 0, // Same index that already has the edge.
+      };
+
+      const request: WorkflowDiffRequest = {
+        id: 'test-workflow',
+        operations: [operation]
+      };
+
+      const result = await diffEngine.applyDiff(baseWorkflow, request);
+
+      expect(result.success).toBe(false);
+      expect(result.errors![0].message).toContain('Connection already exists');
+      expect(result.errors![0].message).toContain('sourceIndex=0');
     });
 
     it('should reject connection to non-existent source node', async () => {


### PR DESCRIPTION
Closes #738.

## What

`validateAddConnection` checked uniqueness on `(source, sourceOutput,
target)` only, scanning the entire `existing: Connection[][]` array
across **all** `sourceIndex` slots. Two outputs of a Switch node fanning
into the same target node — e.g. several branches sharing a
fallback / error handler, exactly the scenario in the bug report — got
rejected with `Connection already exists` even though
`(source, sourceIndex=N, target)` wasn't actually a duplicate.

## Fix

`validateAddConnection` now:

- resolves `sourceIndex` via `resolveSmartParameters`, the same helper
  `applyAddConnection` and rewire already use (it honours `sourceIndex`,
  `case=`, `branch=`, and the numeric-sourceOutput remap from
  #537 / #659);
- only checks the `existing[sourceIndex]` slot for the target;
- includes the offending `sourceIndex` in the error message so callers
  can distinguish a genuine duplicate from an unrelated index.

## Tests

`tests/unit/services/workflow-diff-engine.test.ts`:

- **New** `should allow connecting different sourceIndex outputs to the
  same target (#738)`: pre-wires `Slack -> HTTP Request` at
  `sourceIndex=0`; `addConnection` at `sourceIndex=1` is accepted; the
  resulting workflow has both indices populated.
- **New** `should still reject duplicate connections at the same
  sourceIndex (#738)`: re-adding the same edge at the same index still
  errors with `Connection already exists` and now includes
  `sourceIndex=0` in the message.
- The pre-existing `should reject duplicate connections` continues to
  pass — the default-sourceIndex-0 path is unchanged.

## Verification

- `npx vitest run tests/unit/services/workflow-diff-engine.test.ts -t addConnection`
  → 7 passing tests.
- I confirmed locally that reverting just the validation block back to
  the old sourceIndex-blind code makes **both** new #738 tests fail —
  i.e. the new tests catch the regression cleanly.