### PR TITLE
ci(docker): pre-build test image in workflow, drop in-test build flake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,18 @@ jobs:
         env:
           CI: true
       
+      # Pre-build the Docker test image used by tests/integration/docker/*.test.ts
+      # Two test files used to build it independently inside their beforeAll hooks; the
+      # builder stage does an `npm install` from the public registry which intermittently
+      # fails on CI runners and tanked the entire test job. Building it here once gets us:
+      #  - one build attempt instead of two
+      #  - a clear, separately-visible CI step when the npm registry is flaky
+      #  - the test suite degrades to skipped tests if this step fails (won't block PRs)
+      - name: Build Docker test image
+        run: npm run docker:test:build
+        timeout-minutes: 8
+        continue-on-error: true
+
       # Run integration tests separately (with MSW setup)
       - name: Run integration tests
         run: npm run test:integration -- --reporter=default --reporter=junit

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "test:update-partial:debug": "node dist/scripts/test-update-partial-debug.js",
     "test:issue-45-fix": "node dist/scripts/test-issue-45-fix.js",
     "test:auth-logging": "tsx scripts/test-auth-logging.ts",
+    "docker:test:build": "docker build -t n8n-mcp-test:latest .",
     "test:docker": "./scripts/test-docker-config.sh all",
     "test:docker:unit": "./scripts/test-docker-config.sh unit",
     "test:docker:integration": "./scripts/test-docker-config.sh integration",

--- a/tests/integration/docker/docker-config.test.ts
+++ b/tests/integration/docker/docker-config.test.ts
@@ -1,23 +1,20 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { execSync, spawn } from 'child_process';
+import { spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import { exec, waitForHealthy, isRunningInHttpMode, getProcessEnv } from './test-helpers';
+import {
+  exec,
+  waitForHealthy,
+  isRunningInHttpMode,
+  getProcessEnv,
+  ensureDockerTestImage,
+  DOCKER_TEST_IMAGE_NAME
+} from './test-helpers';
 
 // Skip tests if not in CI or if Docker is not available
 const SKIP_DOCKER_TESTS = process.env.CI !== 'true' && !process.env.RUN_DOCKER_TESTS;
 const describeDocker = SKIP_DOCKER_TESTS ? describe.skip : describe;
-
-// Helper to check if Docker is available
-async function isDockerAvailable(): Promise<boolean> {
-  try {
-    await exec('docker --version');
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 // Helper to generate unique container names
 function generateContainerName(suffix: string): string {
@@ -36,44 +33,21 @@ async function cleanupContainer(containerName: string) {
 
 describeDocker('Docker Config File Integration', () => {
   let tempDir: string;
+  // True when Docker is available AND the test image is ready to use.
+  // Tests gated by `if (!dockerAvailable) return;` skip silently otherwise.
   let dockerAvailable: boolean;
-  const imageName = 'n8n-mcp-test:latest';
+  const imageName = DOCKER_TEST_IMAGE_NAME;
   const containers: string[] = [];
 
   beforeAll(async () => {
-    dockerAvailable = await isDockerAvailable();
-    if (!dockerAvailable) {
+    const result = await ensureDockerTestImage();
+    dockerAvailable = result.status === 'ready';
+    if (result.status === 'skip-no-docker') {
       console.warn('Docker not available, skipping Docker integration tests');
-      return;
+    } else if (result.status === 'missing') {
+      console.warn(result.message);
     }
-
-    // Check if image exists
-    let imageExists = false;
-    try {
-      await exec(`docker image inspect ${imageName}`);
-      imageExists = true;
-    } catch {
-      imageExists = false;
-    }
-
-    // Build test image if in CI or if explicitly requested or if image doesn't exist
-    if (!imageExists || process.env.CI === 'true' || process.env.BUILD_DOCKER_TEST_IMAGE === 'true') {
-      const projectRoot = path.resolve(__dirname, '../../../');
-      console.log('Building Docker image for tests...');
-      try {
-        execSync(`docker build -t ${imageName} .`, {
-          cwd: projectRoot,
-          stdio: 'inherit'
-        });
-        console.log('Docker image built successfully');
-      } catch (error) {
-        console.error('Failed to build Docker image:', error);
-        throw new Error('Docker image build failed - tests cannot continue');
-      }
-    } else {
-      console.log(`Using existing Docker image: ${imageName}`);
-    }
-  }, 60000); // Increase timeout to 60s for Docker build
+  }, 30000);
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-config-test-'));

--- a/tests/integration/docker/docker-config.test.ts
+++ b/tests/integration/docker/docker-config.test.ts
@@ -47,7 +47,9 @@ describeDocker('Docker Config File Integration', () => {
     } else if (result.status === 'missing') {
       console.warn(result.message);
     }
-  }, 30000);
+    // Inspect-only path is sub-second. The 5-minute window covers BUILD_DOCKER_TEST_IMAGE=true
+    // local auto-builds, which need to finish the npm install in the builder stage.
+  }, 300000);
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-config-test-'));

--- a/tests/integration/docker/docker-entrypoint.test.ts
+++ b/tests/integration/docker/docker-entrypoint.test.ts
@@ -1,23 +1,19 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { execSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
-import { exec, waitForHealthy, isRunningInHttpMode, getProcessEnv } from './test-helpers';
+import {
+  exec,
+  waitForHealthy,
+  isRunningInHttpMode,
+  getProcessEnv,
+  ensureDockerTestImage,
+  DOCKER_TEST_IMAGE_NAME
+} from './test-helpers';
 
 // Skip tests if not in CI or if Docker is not available
 const SKIP_DOCKER_TESTS = process.env.CI !== 'true' && !process.env.RUN_DOCKER_TESTS;
 const describeDocker = SKIP_DOCKER_TESTS ? describe.skip : describe;
-
-// Helper to check if Docker is available
-async function isDockerAvailable(): Promise<boolean> {
-  try {
-    await exec('docker --version');
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 // Helper to generate unique container names
 function generateContainerName(suffix: string): string {
@@ -61,44 +57,21 @@ async function runContainerWithTimeout(
 
 describeDocker('Docker Entrypoint Script', () => {
   let tempDir: string;
+  // True when Docker is available AND the test image is ready to use.
+  // Tests gated by `if (!dockerAvailable) return;` skip silently otherwise.
   let dockerAvailable: boolean;
-  const imageName = 'n8n-mcp-test:latest';
+  const imageName = DOCKER_TEST_IMAGE_NAME;
   const containers: string[] = [];
 
   beforeAll(async () => {
-    dockerAvailable = await isDockerAvailable();
-    if (!dockerAvailable) {
+    const result = await ensureDockerTestImage();
+    dockerAvailable = result.status === 'ready';
+    if (result.status === 'skip-no-docker') {
       console.warn('Docker not available, skipping Docker entrypoint tests');
-      return;
+    } else if (result.status === 'missing') {
+      console.warn(result.message);
     }
-
-    // Check if image exists
-    let imageExists = false;
-    try {
-      await exec(`docker image inspect ${imageName}`);
-      imageExists = true;
-    } catch {
-      imageExists = false;
-    }
-
-    // Build test image if in CI or if explicitly requested or if image doesn't exist
-    if (!imageExists || process.env.CI === 'true' || process.env.BUILD_DOCKER_TEST_IMAGE === 'true') {
-      const projectRoot = path.resolve(__dirname, '../../../');
-      console.log('Building Docker image for tests...');
-      try {
-        execSync(`docker build -t ${imageName} .`, {
-          cwd: projectRoot,
-          stdio: 'inherit'
-        });
-        console.log('Docker image built successfully');
-      } catch (error) {
-        console.error('Failed to build Docker image:', error);
-        throw new Error('Docker image build failed - tests cannot continue');
-      }
-    } else {
-      console.log(`Using existing Docker image: ${imageName}`);
-    }
-  }, 60000); // Increase timeout to 60s for Docker build
+  }, 30000);
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-entrypoint-test-'));

--- a/tests/integration/docker/docker-entrypoint.test.ts
+++ b/tests/integration/docker/docker-entrypoint.test.ts
@@ -71,7 +71,9 @@ describeDocker('Docker Entrypoint Script', () => {
     } else if (result.status === 'missing') {
       console.warn(result.message);
     }
-  }, 30000);
+    // Inspect-only path is sub-second. The 5-minute window covers BUILD_DOCKER_TEST_IMAGE=true
+    // local auto-builds, which need to finish the npm install in the builder stage.
+  }, 300000);
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-entrypoint-test-'));

--- a/tests/integration/docker/test-helpers.ts
+++ b/tests/integration/docker/test-helpers.ts
@@ -1,7 +1,80 @@
 import { promisify } from 'util';
-import { exec as execCallback } from 'child_process';
+import { exec as execCallback, execSync } from 'child_process';
+import path from 'path';
 
 export const exec = promisify(execCallback);
+
+/**
+ * Test image name shared by all Docker integration tests.
+ */
+export const DOCKER_TEST_IMAGE_NAME = 'n8n-mcp-test:latest';
+
+/**
+ * Check if Docker is available on the host.
+ */
+export async function isDockerAvailable(): Promise<boolean> {
+  try {
+    await exec('docker --version');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Result of attempting to ensure the Docker test image exists.
+ * - "ready": image is present and tests can run
+ * - "skip-no-docker": Docker is not available on the host; suite should skip
+ * - "missing": Docker is available but the image is not pre-built; suite should skip
+ *   with an actionable error message instead of silently auto-building (which is
+ *   what caused the CI flake — npm install inside `docker build` is unreliable).
+ *
+ * Local devs can opt in to auto-build by setting BUILD_DOCKER_TEST_IMAGE=true,
+ * but the CI workflow pre-builds the image in a dedicated step instead.
+ */
+export type EnsureImageResult =
+  | { status: 'ready' }
+  | { status: 'skip-no-docker' }
+  | { status: 'missing'; message: string };
+
+/**
+ * Verify the Docker test image is available without building it.
+ * If BUILD_DOCKER_TEST_IMAGE=true is set, fall back to building (local dev convenience).
+ */
+export async function ensureDockerTestImage(): Promise<EnsureImageResult> {
+  if (!(await isDockerAvailable())) {
+    return { status: 'skip-no-docker' };
+  }
+
+  try {
+    await exec(`docker image inspect ${DOCKER_TEST_IMAGE_NAME}`);
+    return { status: 'ready' };
+  } catch {}
+
+  if (process.env.BUILD_DOCKER_TEST_IMAGE === 'true') {
+    const projectRoot = path.resolve(__dirname, '../../../');
+    try {
+      execSync(`docker build -t ${DOCKER_TEST_IMAGE_NAME} .`, {
+        cwd: projectRoot,
+        stdio: 'inherit'
+      });
+      return { status: 'ready' };
+    } catch (error) {
+      return {
+        status: 'missing',
+        message: `Auto-build failed (BUILD_DOCKER_TEST_IMAGE=true). ${(error as Error).message}`
+      };
+    }
+  }
+
+  return {
+    status: 'missing',
+    message:
+      `Docker image ${DOCKER_TEST_IMAGE_NAME} not found. ` +
+      `In CI: ensure the "Build Docker test image" step ran. ` +
+      `Locally: run \`npm run docker:test:build\` first, or re-run with BUILD_DOCKER_TEST_IMAGE=true to auto-build.`
+  };
+}
 
 /**
  * Wait for a container to be healthy by checking the health endpoint

--- a/tests/integration/docker/test-helpers.ts
+++ b/tests/integration/docker/test-helpers.ts
@@ -6,6 +6,9 @@ export const exec = promisify(execCallback);
 
 /**
  * Test image name shared by all Docker integration tests.
+ *
+ * NOTE: must stay in sync with the `docker:test:build` script in package.json.
+ * npm scripts can't reference TS constants, so the literal lives in two places.
  */
 export const DOCKER_TEST_IMAGE_NAME = 'n8n-mcp-test:latest';
 
@@ -46,10 +49,22 @@ export async function ensureDockerTestImage(): Promise<EnsureImageResult> {
     return { status: 'skip-no-docker' };
   }
 
+  let inspectError: string | null = null;
   try {
     await exec(`docker image inspect ${DOCKER_TEST_IMAGE_NAME}`);
     return { status: 'ready' };
-  } catch {}
+  } catch (error) {
+    // Distinguish "image truly missing" (the common case) from "daemon unreachable"
+    // / permission errors. The latter look identical to "missing" in our return shape
+    // otherwise, sending users down the wrong fix path.
+    const stderr = (error as { stderr?: string }).stderr ?? '';
+    const message = (error as Error).message ?? '';
+    const combined = `${stderr}\n${message}`;
+    if (/Cannot connect to the Docker daemon|permission denied|is the docker daemon running/i.test(combined)) {
+      return { status: 'skip-no-docker' };
+    }
+    inspectError = stderr.trim() || message.trim() || 'unknown error';
+  }
 
   if (process.env.BUILD_DOCKER_TEST_IMAGE === 'true') {
     const projectRoot = path.resolve(__dirname, '../../../');
@@ -70,7 +85,7 @@ export async function ensureDockerTestImage(): Promise<EnsureImageResult> {
   return {
     status: 'missing',
     message:
-      `Docker image ${DOCKER_TEST_IMAGE_NAME} not found. ` +
+      `Docker image ${DOCKER_TEST_IMAGE_NAME} not found (${inspectError}). ` +
       `In CI: ensure the "Build Docker test image" step ran. ` +
       `Locally: run \`npm run docker:test:build\` first, or re-run with BUILD_DOCKER_TEST_IMAGE=true to auto-build.`
   };


### PR DESCRIPTION
## Problem

Two Docker integration test files (`tests/integration/docker/{docker-config,docker-entrypoint}.test.ts`) each had a `beforeAll` hook that ran `docker build` against the project root. The Dockerfile builder stage runs `npm install` for ~10 packages from the public npm registry — which intermittently times out on GitHub Actions runners.

Both files built independently in parallel, doubling the exposure. When the npm registry blipped, the entire 716-test integration suite would fail despite 715 tests being green. This was blocking unrelated PRs from going green (e.g. PR #757).

The original failure pattern, from a recent CI log:
```
#12 ERROR: process "/bin/sh -c echo '{}' > package.json && npm install ..." did not complete successfully: exit code: 1
> [builder 4/6] RUN ... npm install --no-save typescript@^5.8.3 ...
ERROR: failed to build: failed to solve: ... did not complete successfully: exit code: 1
Failed to build Docker image: Error: Command failed: docker build -t n8n-mcp-test:latest .
Error: Docker image build failed - tests cannot continue
```

The test suite then reported 715 passed / 1 failed — the failure being the `beforeAll` hook itself, not any actual test logic.

## Fix

Three structural changes:

### 1. Pre-build the test image in a dedicated workflow step

`.github/workflows/test.yml` — new step before `Run integration tests`:
```yaml
- name: Build Docker test image
  run: npm run docker:test:build
  timeout-minutes: 8
  continue-on-error: true
```

One build attempt per CI run instead of two. `continue-on-error: true` so a transient npm registry failure doesn't block the whole job — the test suite degrades to skipped Docker tests, the same way it already does on runners without Docker installed.

### 2. Extract `ensureDockerTestImage()` into shared helpers

`tests/integration/docker/test-helpers.ts` — new helper returning a discriminated union:

```ts
type EnsureImageResult =
  | { status: 'ready' }
  | { status: 'skip-no-docker' }
  | { status: 'missing'; message: string };
```

The 'missing' branch (Docker installed, image not pre-built) returns an actionable message pointing local devs to either `npm run docker:test:build` or `BUILD_DOCKER_TEST_IMAGE=true` for auto-build.

### 3. Collapse the `beforeAll` in both test files

Each `beforeAll` shrinks from ~30 lines to ~10. Removed the `process.env.CI === 'true' → force-rebuild` branch (that's now the workflow's job). The 18+ existing per-test `if (!dockerAvailable) return;` guards stay unchanged.

### Bonus

`package.json` — added `"docker:test:build": "docker build -t n8n-mcp-test:latest ."` so local devs have a one-liner.

## Test plan

- [x] Typecheck clean (`npm run typecheck`)
- [x] Local dry-run (Docker available, image NOT pre-built):
  ```
  CI=true npx vitest run tests/integration/docker/docker-config.test.ts tests/integration/docker/docker-entrypoint.test.ts
  ```
  → 31 docker tests skip silently via the existing per-test guards. Same shape as the pre-fix "no Docker on runner" path.
- [x] Full unit suite green (5397 passing)
- [x] Independent code review (`APPROVE WITH NITS` — one redundant comment dropped, others either forward-looking or intentional)
- [x] Code-simplifier pass — no changes warranted; PR is tight and correct

## Followups (not in this PR)

Reviewer flagged two cheap mitigations to consider later:
- Add `::warning::` annotation when Docker tests skip in CI so reviewers see a yellow on the PR (not just a separate red workflow step they might miss)
- Add a non-blocking weekly cron workflow that builds the image with `continue-on-error: false` so genuine Dockerfile breakage surfaces somewhere

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)