### PR TITLE
chore: update n8n to 2.18.4 and bump version to 2.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.49.0] - 2026-04-28
+
+### Changed
+
+- **Updated n8n to 2.18.4** (from 2.16.1). All four n8n packages bumped to the versions pinned by `n8n@stable`:
+  - `n8n-nodes-base`: 2.16.0 → 2.18.3
+  - `n8n-core`: 2.16.1 → 2.18.3
+  - `n8n-workflow`: 2.16.0 → 2.18.3
+  - `@n8n/n8n-nodes-langchain`: 2.16.1 → 2.18.3
+  - Pins are now exact (no caret) to prevent npm from auto-resolving to `2.19.0`, which `n8n@stable` does not yet endorse and which would also force a different `zod` peer.
+- **Bumped `zod` to 3.25.67** (from 3.24.1) to satisfy the new `zod` peer dependency declared by `n8n-core@2.18.3` and `n8n-workflow@2.18.3` — the same version `n8n@stable` itself depends on.
+- **Rebuilt node database**: 1,588 nodes total — 820 core (675 from `n8n-nodes-base` + 145 from `@n8n/n8n-nodes-langchain`) + 768 community (668 verified + 100 from npm). Community READMEs refreshed via `generate:docs:readme-only` (763/768 with READMEs, 581/768 with AI summaries — the AI-summary backfill for newly-added community nodes runs separately via the local LLM step).
+- **README badges and node counts updated** to reflect the new n8n version, node totals, and current passing-test count (`5,418`).
+
+Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en
+
 ## [2.48.3] - 2026-04-28
 
 ### Fixed

--- a/MEMORY_N8N_UPDATE.md
+++ b/MEMORY_N8N_UPDATE.md
@@ -1,6 +1,6 @@
 # n8n Update Process - Quick Reference
 
-## ⚡ Recommended Fast Workflow (2026-03-25)
+## ⚡ Recommended Fast Workflow (verified 2026-04-28)
 
 **CRITICAL FIRST STEP**: Check existing releases to avoid version conflicts!
 
@@ -47,20 +47,20 @@ node dist/scripts/generate-community-docs.js --summary-only --skip-existing-summ
 # 9. Create feature branch
 git checkout -b update/n8n-X.X.X
 
-# 7. Update version in package.json (must be HIGHER than latest release!)
+# 10. Update version in package.json (must be HIGHER than latest release!)
 # Edit: "version": "2.XX.X" (not the version from the release list!)
 
-# 8. Update CHANGELOG.md
+# 11. Update CHANGELOG.md
 # - Change version number to match package.json
 # - Update date to today
 # - Update dependency versions
 # - Include community node refresh counts
 
-# 9. Update README badge and node counts
+# 12. Update README badge and node counts
 # Edit line 8: Change n8n version badge to new n8n version
 # Update total node count in description (core + community)
 
-# 10. Commit and push
+# 13. Commit and push
 git add -A
 git commit -m "chore: update n8n to X.X.X and bump version to 2.XX.X
 
@@ -81,10 +81,10 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 
 git push -u origin update/n8n-X.X.X
 
-# 11. Create PR
+# 14. Create PR
 gh pr create --title "chore: update n8n to X.X.X" --body "Updates n8n and all related dependencies to the latest versions..."
 
-# 12. After PR is merged, verify release triggered
+# 15. After PR is merged, verify release triggered
 gh release list | head -1
 # If the new version appears, you're done!
 # If not, the version might have already been released - bump version again and create new PR
@@ -122,7 +122,7 @@ npm run update:all
 This single command will:
 1. ✅ Check for n8n updates and ask for confirmation
 2. ✅ Update all n8n dependencies to latest compatible versions
-3. ✅ Run all 1,182 tests (933 unit + 249 integration)
+3. ✅ Run all ~5,418 tests (~4,661 unit + ~757 integration)
 4. ✅ Validate critical nodes
 5. ✅ Build the project
 6. ✅ Bump the version
@@ -164,7 +164,7 @@ git commit -m "chore: update n8n to vX.X.X
 - Updated @n8n/n8n-nodes-langchain from X.X.X to X.X.X
 - Rebuilt node database with XXX nodes
 - Sanitized XXX workflow templates (if present)
-- All 1,182 tests passing (933 unit, 249 integration)
+- All ~5,418 tests passing (~4,661 unit, ~757 integration)
 - All validation tests passing
 
 🤖 Generated with [Claude Code](https://claude.ai/code)
@@ -203,9 +203,9 @@ This command:
 - Confirms everything is working correctly
 
 ### `npm test`
-- Runs all 1,182 tests
-- Unit tests: 933 tests across 30 files
-- Integration tests: 249 tests across 14 files
+- Runs ~5,418 tests
+- Unit tests: ~4,661 tests across ~140 files
+- Integration tests: ~757 tests across ~56 files
 - Must pass before publishing!
 
 ## Important Notes

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![GitHub stars](https://img.shields.io/github/stars/czlonkowski/n8n-mcp?style=social)](https://github.com/czlonkowski/n8n-mcp)
 [![npm version](https://img.shields.io/npm/v/n8n-mcp.svg)](https://www.npmjs.com/package/n8n-mcp)
 [![codecov](https://codecov.io/gh/czlonkowski/n8n-mcp/graph/badge.svg?token=YOUR_TOKEN)](https://codecov.io/gh/czlonkowski/n8n-mcp)
-[![Tests](https://img.shields.io/badge/tests-3336%20passing-brightgreen.svg)](https://github.com/czlonkowski/n8n-mcp/actions)
-[![n8n version](https://img.shields.io/badge/n8n-2.16.1-orange.svg)](https://github.com/n8n-io/n8n)
+[![Tests](https://img.shields.io/badge/tests-5418%20passing-brightgreen.svg)](https://github.com/czlonkowski/n8n-mcp/actions)
+[![n8n version](https://img.shields.io/badge/n8n-2.18.4-orange.svg)](https://github.com/n8n-io/n8n)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io%2Fczlonkowski%2Fn8n--mcp-green.svg)](https://github.com/czlonkowski/n8n-mcp/pkgs/container/n8n-mcp)
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/n8n-mcp?referralCode=n8n-mcp)
 
-A Model Context Protocol (MCP) server that provides AI assistants with comprehensive access to n8n node documentation, properties, and operations. Deploy in minutes to give Claude and other AI assistants deep knowledge about n8n's 1,505 workflow automation nodes (812 core + 693 community).
+A Model Context Protocol (MCP) server that provides AI assistants with comprehensive access to n8n node documentation, properties, and operations. Deploy in minutes to give Claude and other AI assistants deep knowledge about n8n's 1,588 workflow automation nodes (820 core + 768 community).
 
 ## Overview
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,21 +10,21 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.28.0",
-        "@n8n/n8n-nodes-langchain": "2.16.1",
+        "@n8n/n8n-nodes-langchain": "2.18.3",
         "@supabase/supabase-js": "^2.57.4",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-rate-limit": "^7.1.5",
         "form-data": "^4.0.5",
         "lru-cache": "^11.2.1",
-        "n8n-core": "2.16.1",
-        "n8n-nodes-base": "2.16.0",
-        "n8n-workflow": "2.16.0",
+        "n8n-core": "2.18.3",
+        "n8n-nodes-base": "2.18.3",
+        "n8n-workflow": "2.18.3",
         "openai": "^4.77.0",
         "sql.js": "^1.13.0",
         "tslib": "^2.6.2",
         "uuid": "^10.0.0",
-        "zod": "3.24.1"
+        "zod": "3.25.67"
       },
       "bin": {
         "n8n-mcp": "dist/mcp/stdio-wrapper.js"
@@ -6428,9 +6428,9 @@
       }
     },
     "node_modules/@kafkajs/confluent-schema-registry/node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "license": "BSD-3-Clause",
       "optional": true,
       "peer": true,
@@ -6439,13 +6439,13 @@
       }
     },
     "node_modules/@kafkajs/confluent-schema-registry/node_modules/mappersmith": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/mappersmith/-/mappersmith-2.47.0.tgz",
-      "integrity": "sha512-3GenMRqE2/zLIUuFs/75j54bzhlDZ1okLw/u5BtmPgMq+8OueH8jmY7jbgBRCR3jERRzW0HQ+lxB1715I0bS5w==",
+      "version": "2.47.1",
+      "resolved": "https://registry.npmjs.org/mappersmith/-/mappersmith-2.47.1.tgz",
+      "integrity": "sha512-OVSkU/ANvclScrTZh7x9SwmK4iZ9fo0AO0a5Nr+Xx4PZ/Kj/B1BixqNLhaKSBBXMyPbOrbjdoasX5SfbGTcsOA==",
       "license": "MIT",
       "peerDependencies": {
-        "diff": "^7.0.0",
-        "tty-table": "^4.2.3"
+        "diff": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "tty-table": "^4.0.0 || ^5.0.0"
       },
       "peerDependenciesMeta": {
         "diff": {
@@ -7282,9 +7282,9 @@
       }
     },
     "node_modules/@n8n/ai-utilities": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.10.0.tgz",
-      "integrity": "sha512-AbVFIZJuaQ6dn9WYbu+Nah5DPRsrC/2VQ8mvAdGjBSpOeEx2UcQ0hC+q3zsljTCfN5vm9+cyu3wHbgZpdguu3w==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.12.0.tgz",
+      "integrity": "sha512-Oc42+NIQPa+FQVB9qgRe98LP5aiQ0Jk0yOkXisUejAs6c4jkcJrNIjNk3IDXDfFS9LSX2/uERDkv3P7fzqRaXQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@langchain/classic": "1.0.5",
@@ -7292,7 +7292,7 @@
         "@langchain/core": "1.1.34",
         "@langchain/openai": "1.1.3",
         "@langchain/textsplitters": "1.0.1",
-        "@n8n/config": "2.15.0",
+        "@n8n/config": "2.17.0",
         "@n8n/typescript-config": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-tiktoken": "1.0.21",
@@ -7308,9 +7308,9 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/client-s3": {
-      "version": "3.1030.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1030.0.tgz",
-      "integrity": "sha512-sgGb4ub0JXnHaXnok5td7A1KGwENFPwOrwgzvpkeWq9w16Sl7x2KhYtVl+Fdd/7LAvaEtm3HqrYtNmm2d0OXmQ==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1038.0.tgz",
+      "integrity": "sha512-k60qm50bWkaqNfCJe1z28WaqgpztE0wbWVMZw6ZJcTOGfrWFhsJeLCEqtkH8w00iEozKx9GQwdQXz4G0sMGdKA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -7318,57 +7318,57 @@
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-node": "^3.972.30",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.9",
-        "@aws-sdk/middleware-expect-continue": "^3.972.9",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.7",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-location-constraint": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.28",
-        "@aws-sdk/middleware-ssec": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.16",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/eventstream-serde-browser": "^4.2.13",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.13",
-        "@smithy/eventstream-serde-node": "^4.2.13",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-blob-browser": "^4.2.14",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/hash-stream-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/md5-js": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-node": "^3.972.37",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
+        "@aws-sdk/middleware-expect-continue": "^3.972.10",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.14",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-blob-browser": "^4.2.15",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/hash-stream-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/md5-js": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.15",
+        "@smithy/util-waiter": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7376,14 +7376,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/client-s3/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7406,24 +7406,25 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/core": {
-      "version": "3.973.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
-      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
+      "version": "3.974.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.6.tgz",
+      "integrity": "sha512-8Vu7zGxu+39ChR/s5J7nXBw3a2kMHAi0OfKT8ohgTVjX0qYed/8mIfdBb638oBmKrWCwwKjYAM5J/4gMJ8nAJA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/xml-builder": "^3.972.17",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.20",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -7446,14 +7447,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/core/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7461,18 +7462,18 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/core/node_modules/@smithy/signature-v4": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
-      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -7525,14 +7526,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.6.tgz",
-      "integrity": "sha512-NMbiqKdruhwwgI6nzBVe2jWMkXjaoQz2YOs3rFX+2F3gGyrJDkDPwMpV/RsTFeq2vAQ055wZNtOXFK4NYSkM8g==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
+      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7540,17 +7541,17 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
-      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.32.tgz",
+      "integrity": "sha512-7vA4GHg8NSmQxquJHSBcSM3RgB4ZaaRi6u4+zGFKOmOH6aqlgr2Sda46clkZDYzlirgfY96w15Zj0jh6PT48ng==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7558,22 +7559,22 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
-      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.34.tgz",
+      "integrity": "sha512-vBrhWujFCLp1u8ptJRWYlipMutzPptb8pDQ00rKVH9q67T7rGd3VTWIj63aKrlLuY6qSsw1Rt5F/D/7wnNgryA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7581,14 +7582,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7596,26 +7597,26 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
-      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.36.tgz",
+      "integrity": "sha512-FBHyCmV8EB0gUvh1d+CZm87zt2PrdC7OyWexLRoH3I5zWSOUGa+9t58Y5jbxRfwUp3AWpHAFvKY6YzgR845sVA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-login": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/credential-provider-env": "^3.972.32",
+        "@aws-sdk/credential-provider-http": "^3.972.34",
+        "@aws-sdk/credential-provider-login": "^3.972.36",
+        "@aws-sdk/credential-provider-process": "^3.972.32",
+        "@aws-sdk/credential-provider-sso": "^3.972.36",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7623,20 +7624,20 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
-      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.36.tgz",
+      "integrity": "sha512-IFap01lJKxQc0C/OHmZwZQr/cKq0DhrcmKedRrdnnl42D+P0SImnnnWQjv07uIPqpEdtqmkPXb9TiPYTU+prxQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7644,14 +7645,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/credential-provider-login/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7659,24 +7660,24 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.37.tgz",
+      "integrity": "sha512-/WFixFAAiw8WpmjZcI0l4t3DerXLmVinOIfuotmRZnu2qmsFPoqqmstASz0z8bi1pGdFXzeLzf6bwucM3mZcUQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/credential-provider-env": "^3.972.32",
+        "@aws-sdk/credential-provider-http": "^3.972.34",
+        "@aws-sdk/credential-provider-ini": "^3.972.36",
+        "@aws-sdk/credential-provider-process": "^3.972.32",
+        "@aws-sdk/credential-provider-sso": "^3.972.36",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.36",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7684,18 +7685,18 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
-      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.32.tgz",
+      "integrity": "sha512-uZp4tlGbpczV8QxmtIwOpSkcyGtBRR8/T4BAumRKfAt1nwCig3FSCZvrKl6ARDIDVRYn5p2oRcAsfFR01EgMGA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7703,20 +7704,20 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
-      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.36.tgz",
+      "integrity": "sha512-DsLr0UHMyKzRJKe2bjlwU8q1cfoXg8TIJKV/xwvnalAemiZLOZunFzj/whGnFDZIBVLdnbLiwv5SvRf1+CSwkg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/token-providers": "3.1026.0",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/token-providers": "3.1038.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7724,19 +7725,19 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
-      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.36.tgz",
+      "integrity": "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7744,18 +7745,18 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.9.tgz",
-      "integrity": "sha512-COToYKgquDyligbcAep7ygs48RK+mwe/IYprq4+TSrVFzNOYmzWvHf6werpnKV5VYpRiwdn+Wa5ZXkPqLVwcTg==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
+      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -7764,14 +7765,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7779,16 +7780,16 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.9.tgz",
-      "integrity": "sha512-V/FNCjFxnh4VGu+HdSiW4Yg5GELihA1MIDSAdsEPvuayXBVmr0Jaa6jdLAZLH38KYXl/vVjri9DQJWnTAujHEA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
+      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7796,14 +7797,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-expect-continue/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7811,9 +7812,9 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.7.tgz",
-      "integrity": "sha512-uU4/ch2CLHB8Phu1oTKnnQ4e8Ujqi49zEnQYBhWYT53zfFvtJCdGsaOoypBr8Fm/pmCBssRmGoIQ4sixgdLP9w==",
+      "version": "3.974.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.14.tgz",
+      "integrity": "sha512-mhTO3amGzYv/DQNbbqZo6UkHquBHlEEVRZwXmjeRqLmy1l9z3xCiFzglPL7n9JpVc2DZc9kjaraAn3JQrueZbw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -7821,15 +7822,15 @@
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/crc64-nvme": "^3.972.6",
-        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/crc64-nvme": "^3.972.7",
+        "@aws-sdk/types": "^3.973.8",
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -7868,14 +7869,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7898,16 +7899,16 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
-      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7915,14 +7916,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7930,15 +7931,15 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.9.tgz",
-      "integrity": "sha512-TyfOi2XNdOZpNKeTJwRUsVAGa+14nkyMb2VVGG+eDgcWG/ed6+NUo72N3hT6QJioxym80NSinErD+LBRF0Ir1w==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7946,15 +7947,15 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
-      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7962,17 +7963,17 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
-      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/types": "^3.973.8",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7980,14 +7981,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7995,25 +7996,25 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.28.tgz",
-      "integrity": "sha512-qJHcJQH9UNPUrnPlRtCozKjtqAaypQ5IgQxTNoPsVYIQeuwNIA8Rwt3NvGij1vCDYDfCmZaPLpnJEHlZXeFqmg==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.35.tgz",
+      "integrity": "sha512-lLppaNTAz+wNgLdi4FtHzrlwrGF0ODTnBWHBaFg85SKs0eJ+M+tP5ifrA8f/0lNd+Ak3MC1NGC6RavV3ny4HTg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -8036,14 +8037,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8051,18 +8052,18 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/signature-v4": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
-      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -8115,15 +8116,15 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.9.tgz",
-      "integrity": "sha512-wSA2BR7L0CyBNDJeSrleIIzC+DzL93YNTdfU0KPGLiocK6YsRv1nPAzPF+BFSdcs0Qa5ku5Kcf4KvQcWwKGenQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8131,20 +8132,20 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
-      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.36.tgz",
+      "integrity": "sha512-O2beToxguBvrZFFZ+fFgPbbae8MvyIBjQ6lImee4APHEXXNAD5ZJ2ayLF1mb7rsKw86TM81y5czg82bZncjSjg==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-retry": "^4.3.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8152,14 +8153,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8167,49 +8168,50 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
-      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
+      "version": "3.997.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.4.tgz",
+      "integrity": "sha512-4Sf+WY1lMJzXlw5MiyCMe/UzdILCwvuaHThbqMXS6dfh9gZy3No360I42RXquOI/ULUOhWy2HCyU0Fp20fQGPQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/middleware-host-header": "^3.972.9",
-        "@aws-sdk/middleware-logger": "^3.972.9",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/region-config-resolver": "^3.972.11",
-        "@aws-sdk/types": "^3.973.7",
-        "@aws-sdk/util-endpoints": "^3.996.6",
-        "@aws-sdk/util-user-agent-browser": "^3.972.9",
-        "@aws-sdk/util-user-agent-node": "^3.973.15",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/core": "^3.23.14",
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/hash-node": "^4.2.13",
-        "@smithy/invalid-dependency": "^4.2.13",
-        "@smithy/middleware-content-length": "^4.2.13",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-retry": "^4.5.0",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.23",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.22",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.6",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.45",
-        "@smithy/util-defaults-mode-node": "^4.2.49",
-        "@smithy/util-endpoints": "^3.3.4",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.5",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -8218,14 +8220,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8248,17 +8250,17 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
-      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/config-resolver": "^4.4.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8266,18 +8268,18 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.16.tgz",
-      "integrity": "sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ==",
+      "version": "3.996.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.23.tgz",
+      "integrity": "sha512-wBbys3Y53Ikly556vyADurKpYQHXS7Jjaskbz+Ga9PZCz7PB/9f3VdKbDlz7dqIzn+xwz7L/a6TR4iXcOi8IRw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.28",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/signature-v4": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8299,14 +8301,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8314,18 +8316,18 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/signature-v4": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
-      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -8378,19 +8380,19 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1026.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
-      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
+      "version": "3.1038.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1038.0.tgz",
+      "integrity": "sha512-Qniru+9oGGb/HNK/gGZWbV3jsD0k71ngE7qMQ/x6gYNYLd2EOwHCS6E2E6jfkaqO4i0d+nNKmfRy8bNcshKdGQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/core": "^3.973.27",
-        "@aws-sdk/nested-clients": "^3.996.19",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/core": "^3.974.6",
+        "@aws-sdk/nested-clients": "^3.997.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8398,14 +8400,14 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/types": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
-      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8427,17 +8429,17 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
-      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-endpoints": "^3.3.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8445,31 +8447,31 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
-      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
-      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
+      "version": "3.973.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.22.tgz",
+      "integrity": "sha512-YTYqTmOUrwbm1h99Ee4y/mVYpFRl0oSO/amtP5cc1BZZWdaAVWs9zj3TkyRHWvR9aI/ZS8m3mS6awXtYUlWyaw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.36",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -8486,15 +8488,16 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
-      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "version": "3.972.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.21.tgz",
+      "integrity": "sha512-qxNiHUtlrsjTeSlrPWiFkWps7uD6YB4eKzg7eLAFH8jbiHTlt0ePNlo2Xu+WlftP38JIcMaIX4jTUjOlE2ySWw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@smithy/types": "^4.14.0",
-        "fast-xml-parser": "5.5.8",
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8587,6 +8590,41 @@
           "optional": true
         },
         "typeorm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@n8n/ai-utilities/node_modules/@langchain/classic/node_modules/langsmith": {
+      "version": "0.3.87",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
+      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/uuid": "^10.0.0",
+        "chalk": "^4.1.2",
+        "console-table-printer": "^2.12.1",
+        "p-queue": "^6.6.2",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
           "optional": true
         }
       }
@@ -9132,32 +9170,14 @@
         }
       }
     },
-    "node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/openai": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.2.7.tgz",
-      "integrity": "sha512-vR9zoF0/EZ03X0Tc6woIEWRDSDSr2l64n+MQCW8NduScJtBJs5r/Ng3Lrp2bjtJQywEMQoOhcrV2DMmAIPWgnw==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tiktoken": "^1.0.12",
-        "openai": "^6.18.0",
-        "zod": "^3.25.76 || ^4"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@langchain/core": "^1.0.0"
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/langsmith": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.20.tgz",
-      "integrity": "sha512-ULhLM8RswvQDXufLtNtvclHrWCBx8Cb5UPI6lAZC+8Dq59iHsVPz/3Ac9khWNm1VIvChRsuykixD/WrmzuuA3Q==",
+    "node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/classic/node_modules/langsmith": {
+      "version": "0.5.25",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.25.tgz",
+      "integrity": "sha512-AG7NOymrDmwaWq+wus5hJHZjPFKXwsEdfqGBU3eZiF5242mme+5wuJocdBJKGyU1kgBO7TuLHiqtdyIwl4V4yQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "p-queue": "6.6.2",
-        "uuid": "10.0.0"
+        "p-queue": "6.6.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
@@ -9180,6 +9200,44 @@
           "optional": true
         },
         "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/openai": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.2.7.tgz",
+      "integrity": "sha512-vR9zoF0/EZ03X0Tc6woIEWRDSDSr2l64n+MQCW8NduScJtBJs5r/Ng3Lrp2bjtJQywEMQoOhcrV2DMmAIPWgnw==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12",
+        "openai": "^6.18.0",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@langchain/core": "^1.0.0"
+      }
+    },
+    "node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/openai/node_modules/openai": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.35.0.tgz",
+      "integrity": "sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
           "optional": true
         }
       }
@@ -9216,13 +9274,12 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/langsmith": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.20.tgz",
-      "integrity": "sha512-ULhLM8RswvQDXufLtNtvclHrWCBx8Cb5UPI6lAZC+8Dq59iHsVPz/3Ac9khWNm1VIvChRsuykixD/WrmzuuA3Q==",
+      "version": "0.5.25",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.25.tgz",
+      "integrity": "sha512-AG7NOymrDmwaWq+wus5hJHZjPFKXwsEdfqGBU3eZiF5242mme+5wuJocdBJKGyU1kgBO7TuLHiqtdyIwl4V4yQ==",
       "license": "MIT",
       "dependencies": {
-        "p-queue": "6.6.2",
-        "uuid": "10.0.0"
+        "p-queue": "6.6.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
@@ -9247,19 +9304,6 @@
         "ws": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/langsmith/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@langchain/core/node_modules/uuid": {
@@ -9336,12 +9380,12 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.2.tgz",
-      "integrity": "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
+      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
       "license": "MIT",
       "dependencies": {
-        "eventemitter3": "^5.0.1",
+        "eventemitter3": "^5.0.4",
         "p-timeout": "^7.0.0"
       },
       "engines": {
@@ -9379,6 +9423,27 @@
       },
       "peerDependencies": {
         "@langchain/core": "^1.0.0"
+      }
+    },
+    "node_modules/@n8n/ai-utilities/node_modules/@langchain/openai/node_modules/openai": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.35.0.tgz",
+      "integrity": "sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/@langchain/openai/node_modules/zod": {
@@ -9553,9 +9618,9 @@
       "license": "MIT"
     },
     "node_modules/@n8n/ai-utilities/node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "funding": [
         {
           "type": "github",
@@ -9566,9 +9631,10 @@
       "optional": true,
       "peer": true,
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -9632,13 +9698,12 @@
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/langsmith": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.20.tgz",
-      "integrity": "sha512-ULhLM8RswvQDXufLtNtvclHrWCBx8Cb5UPI6lAZC+8Dq59iHsVPz/3Ac9khWNm1VIvChRsuykixD/WrmzuuA3Q==",
+      "version": "0.5.25",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.25.tgz",
+      "integrity": "sha512-AG7NOymrDmwaWq+wus5hJHZjPFKXwsEdfqGBU3eZiF5242mme+5wuJocdBJKGyU1kgBO7TuLHiqtdyIwl4V4yQ==",
       "license": "MIT",
       "dependencies": {
-        "p-queue": "6.6.2",
-        "uuid": "10.0.0"
+        "p-queue": "6.6.2"
       },
       "peerDependencies": {
         "@opentelemetry/api": "*",
@@ -9665,19 +9730,6 @@
         }
       }
     },
-    "node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/langsmith/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@n8n/ai-utilities/node_modules/langchain/node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -9698,62 +9750,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/langsmith": {
-      "version": "0.3.87",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.87.tgz",
-      "integrity": "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
-        "console-table-printer": "^2.12.1",
-        "p-queue": "^6.6.2",
-        "semver": "^7.6.3",
-        "uuid": "^10.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "*",
-        "@opentelemetry/exporter-trace-otlp-proto": "*",
-        "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/exporter-trace-otlp-proto": {
-          "optional": true
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@n8n/ai-utilities/node_modules/openai": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
-      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/@n8n/ai-utilities/node_modules/p-timeout": {
@@ -9782,15 +9778,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/@n8n/ai-utilities/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@n8n/ai-utilities/node_modules/zod-to-json-schema": {
       "version": "3.23.3",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
@@ -9801,18 +9788,18 @@
       }
     },
     "node_modules/@n8n/backend-common": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.16.0.tgz",
-      "integrity": "sha512-DgeX/URJU2Olx6HLiHwpQEXh97E+jEVBGJ1Ha5fuI1oChd9+6yv+NA77zKP24h5TFRDSJbiPqAtv9O1OZx9/gg==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.18.3.tgz",
+      "integrity": "sha512-i1UtztkX1sYq4DyzpRpch4lemZEB4HhKynEIWH82IxATr0HTiWMV92DQrtxqqySQ8sYhROG3dSKpQK1ZFvqgBg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/config": "2.15.0",
-        "@n8n/constants": "0.20.0",
-        "@n8n/decorators": "1.16.0",
+        "@n8n/config": "2.17.0",
+        "@n8n/constants": "0.22.0",
+        "@n8n/decorators": "1.18.3",
         "@n8n/di": "0.10.0",
         "callsites": "3.1.0",
         "flatted": "3.4.2",
-        "n8n-workflow": "2.16.0",
+        "n8n-workflow": "2.18.3",
         "picocolors": "1.0.1",
         "reflect-metadata": "0.2.2",
         "stream-json": "1.9.1",
@@ -9863,18 +9850,18 @@
       }
     },
     "node_modules/@n8n/client-oauth2": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@n8n/client-oauth2/-/client-oauth2-1.1.1.tgz",
-      "integrity": "sha512-Bp+uyFhFrDyn6wIcHpv4VJJDBbIbXzWezXitqhnVtEJQH1Wg5MBNV2MhhStf9oVy2BFhNPzcR/1JnF9zpaRD2w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@n8n/client-oauth2/-/client-oauth2-1.2.0.tgz",
+      "integrity": "sha512-S8DbjxGN3nbOftkP85FZ+yAx+9m8SpBWToAmLRMHKNhG8xODd7irtZRuuoDvv4ba+LOtz0X7fZrCh576yahnzw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "axios": "1.15.0"
       }
     },
     "node_modules/@n8n/config": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.15.0.tgz",
-      "integrity": "sha512-dsZ9hm57d6X7DOlDZFCxgAlLz4/Na9FEmHg+maYo2J9AaeMzY1HcW6c4zPpHOA/Gz6yzmuf4lD2Z7g3SORqCTw==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.17.0.tgz",
+      "integrity": "sha512-c9GGiUhsVllvOAjq9/TLMM0Dxdw/vj+TMiJCAYXrRkg+GK2mattFxDJb7R/CjE4OS6hLW5QfDcZM74zEKS3FTw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@n8n/di": "0.10.0",
@@ -9882,32 +9869,23 @@
         "zod": "3.25.67"
       }
     },
-    "node_modules/@n8n/config/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@n8n/constants": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.20.0.tgz",
-      "integrity": "sha512-MEOzKdGp/EZP1g/Ivqwy4COXURVMgIlPNC0A0EDkrXyJFoUcNm1rQ0GVS5VWRqndoT8seaOnEBngHaIWx8EN3Q==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.22.0.tgz",
+      "integrity": "sha512-u7eBSp6R9LfDCVy1GVEfaL6bVgHP/g6WSISm9LObdG2evv7SO5m7UCwwN9HP1uiaiwRk0n4xjyNSLse7OCX4TQ==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@n8n/decorators": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.16.0.tgz",
-      "integrity": "sha512-AR59M5YX+s7jyWpST8ZXCdRBcfCeGmI9L0ktggMoLEN4bHIaT/qmg6mjSH1M+t4gZ72GN0riKdli07KiIuGV9g==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.18.3.tgz",
+      "integrity": "sha512-qYB0vOTybZfH2aGo4coE+NrYZBSPDtyMSyY7D3cMzo7BsMBfKAQiU5xp7OT7qPzl53osUtPvbVHu375U8gUbvA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/constants": "0.20.0",
+        "@n8n/constants": "0.22.0",
         "@n8n/di": "0.10.0",
-        "@n8n/permissions": "0.56.0",
-        "lodash": "4.17.23",
-        "n8n-workflow": "2.16.0"
+        "@n8n/permissions": "0.57.0",
+        "lodash": "4.18.1",
+        "n8n-workflow": "2.18.3"
       }
     },
     "node_modules/@n8n/di": {
@@ -9920,35 +9898,42 @@
       }
     },
     "node_modules/@n8n/errors": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.6.0.tgz",
-      "integrity": "sha512-oVJ0lgRYJY6/aPOW2h37ea5T+nX7/wULRn5FymwYeaiYlsLdqwIQEtGwZrajpzxJB0Os74u4lSH3WWQgZCkgxQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.7.0.tgz",
+      "integrity": "sha512-fz3VnXwiCk8B+u5vPg/49hz0b9X/RRMdaG+BgV9bozDMu390e2obAx9GPY75e3wht+p6i+6gt3C16eBabcXwNA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "callsites": "3.1.0"
       }
     },
     "node_modules/@n8n/expression-runtime": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.8.0.tgz",
-      "integrity": "sha512-SnBLoLsrGUCS9cVrF20UuSyKcMv+y6Clc4+EA9zLjX85S0GPwOAdApUVSsi81ejPAqMlm42TW1L6r7NpcK/ztQ==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.10.1.tgz",
+      "integrity": "sha512-o9ppz7OUjeEaihkk2S8DG7NEb2NohpBAnp68UWDas9y5ockpE1050FuDNhhpOn0/e1S5fBo8Cf/uIzBmQj6rSg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
+        "@n8n/errors": "0.7.0",
         "@n8n/tournament": "1.0.6",
         "isolated-vm": "^6.0.2",
-        "js-base64": "3.7.2",
+        "js-base64": "3.7.8",
         "jssha": "3.3.1",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "luxon": "3.7.2",
         "md5": "2.3.0",
         "title-case": "3.0.3",
         "transliteration": "2.3.5"
       }
     },
+    "node_modules/@n8n/expression-runtime/node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@n8n/imap": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@n8n/imap/-/imap-0.16.0.tgz",
-      "integrity": "sha512-zBIvVYqbQiSdnPyH/t+XGyJcI4yIBbzsPml5fENW/oB3RAk3UriCqIrTVLjTyLwIxOB8UX3iKcXrJNHO13deyg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@n8n/imap/-/imap-0.17.0.tgz",
+      "integrity": "sha512-jkPP8CeK4cMxTx5jvBVphhJKnCzBVHhkC1sbrIYGyC5xSPmAyafDD4eZY6LzNaYTS4ekbQMAhdrooGLscWivJA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "iconv-lite": "0.6.3",
@@ -9971,18 +9956,18 @@
       }
     },
     "node_modules/@n8n/json-schema-to-zod": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@n8n/json-schema-to-zod/-/json-schema-to-zod-1.7.0.tgz",
-      "integrity": "sha512-mlw8Nvq8HbGE5GX1BydqTZ1m8k5PciojwmzYN42isv5B5YBow0c+78V8yZrXkNpHlRqAdGir3BbtPwpPLpkr/A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@n8n/json-schema-to-zod/-/json-schema-to-zod-1.8.0.tgz",
+      "integrity": "sha512-7RELzFde2c7hrAZWC2A1b4qHOGaFR7Pouh3R/7CVENC9icjIDAnYWlxg5K53BJ9AitVgiWYlmOf0K/mf/cHZsg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "peerDependencies": {
         "zod": "^3.0.0"
       }
     },
     "node_modules/@n8n/n8n-nodes-langchain": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@n8n/n8n-nodes-langchain/-/n8n-nodes-langchain-2.16.1.tgz",
-      "integrity": "sha512-De7pziM200lY8hWT47LFpJpyJDSn4m9etsMBDyOl0gfTi8mFexH1FLG5s1M88KSxQJ8RuO8b/ZOe/kO3mnXHzA==",
+      "version": "2.18.3",
+      "resolved": "https://registry.npmjs.org/@n8n/n8n-nodes-langchain/-/n8n-nodes-langchain-2.18.3.tgz",
+      "integrity": "sha512-uDVc0iVMwc9pv41HA5eJcRhMxtqOqPgEgn3bFnKdDS8Ltqab3JP9wyuHcZn25VsoeX5Oq39S6QF9hFcdFZyfiA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@aws-sdk/client-sso-oidc": "3.808.0",
@@ -10021,12 +10006,12 @@
         "@microsoft/agents-hosting": "1.2.3",
         "@modelcontextprotocol/sdk": "1.26.0",
         "@mozilla/readability": "0.6.0",
-        "@n8n/ai-utilities": "0.10.0",
-        "@n8n/client-oauth2": "1.1.1",
-        "@n8n/config": "2.15.0",
+        "@n8n/ai-utilities": "0.12.0",
+        "@n8n/client-oauth2": "1.2.0",
+        "@n8n/config": "2.17.0",
         "@n8n/di": "0.10.0",
-        "@n8n/errors": "0.6.0",
-        "@n8n/json-schema-to-zod": "1.7.0",
+        "@n8n/errors": "0.7.0",
+        "@n8n/json-schema-to-zod": "1.8.0",
         "@n8n/typeorm": "0.3.20-16",
         "@n8n/typescript-config": "1.4.0",
         "@pinecone-database/pinecone": "^5.0.2",
@@ -10047,12 +10032,12 @@
         "js-tiktoken": "1.0.21",
         "jsdom": "23.0.1",
         "langchain": "1.2.30",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "mammoth": "1.11.0",
         "mime-types": "3.0.2",
         "mongodb": "^6.17.0",
-        "n8n-nodes-base": "2.16.0",
-        "n8n-workflow": "2.16.0",
+        "n8n-nodes-base": "2.18.3",
+        "n8n-workflow": "2.18.3",
         "openai": "^6.9.0",
         "pdf-parse": "1.1.1",
         "pg": "8.17.0",
@@ -12871,46 +12856,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/@n8n/n8n-nodes-langchain/node_modules/mysql2": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.17.0.tgz",
-      "integrity": "sha512-qF1KYPuytBGqAnMzaQ5/rW90iIqcjnrnnS7bvcJcdarJzlUTAiD9ZC0T7mwndacECseSQ6LcRbRvryXLp25m+g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "aws-ssl-profiles": "^1.1.2",
-        "denque": "^2.1.0",
-        "generate-function": "^2.3.1",
-        "iconv-lite": "^0.7.2",
-        "long": "^5.3.2",
-        "lru.min": "^1.1.3",
-        "named-placeholders": "^1.1.6",
-        "seq-queue": "^0.0.5",
-        "sql-escaper": "^1.3.1"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
-    },
-    "node_modules/@n8n/n8n-nodes-langchain/node_modules/mysql2/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/@n8n/n8n-nodes-langchain/node_modules/openai": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.22.0.tgz",
@@ -12971,15 +12916,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/@n8n/n8n-nodes-langchain/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@n8n/n8n-nodes-langchain/node_modules/zod-to-json-schema": {
       "version": "3.23.3",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.3.tgz",
@@ -12990,21 +12926,12 @@
       }
     },
     "node_modules/@n8n/permissions": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.56.0.tgz",
-      "integrity": "sha512-tyHplAqnEy2CDGKPu0UufVQI4s53UrYZGn6u0p/hdOQI5Ze0QbHiSly6g/n+bcz3YzdiHa4IbVjKqSTuha3hhw==",
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.57.0.tgz",
+      "integrity": "sha512-jq4whYbynMzCKjO/uk1kyPDnYZ9iOzBI/QLP27guaxVutynlmEHv9TGPlN52uorce6CFhhKA5MJXc0BIFPK7Ng==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "zod": "3.25.67"
-      }
-    },
-    "node_modules/@n8n/permissions/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@n8n/tournament": {
@@ -13113,14 +13040,14 @@
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@n8n/workflow-sdk": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@n8n/workflow-sdk/-/workflow-sdk-0.9.0.tgz",
-      "integrity": "sha512-+/R3NqfWMsC+3BJPAzom+vB6lQX9fhKrCrLnz2oJTFun32Jd21nSrC4tSc8vqPs1hPtCMx/86wssIRxMb4+PNg==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@n8n/workflow-sdk/-/workflow-sdk-0.11.3.tgz",
+      "integrity": "sha512-D76LOOCkny6/lWm+IAqX3bKSYPQwf4gJp/0fnsJQLHcSV1WxT5YbrizZaVyWhYeewAQGCa5jYALU55UBpov93w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@dagrejs/dagre": "^1.1.4",
         "acorn": "8.14.0",
-        "n8n-workflow": "2.16.0",
+        "n8n-workflow": "2.18.3",
         "uuid": "10.0.0",
         "zod": "3.25.67"
       }
@@ -13137,19 +13064,10 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/@n8n/workflow-sdk/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@napi-rs/canvas": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.98.tgz",
-      "integrity": "sha512-WDg3lxYMqlrg49sDVUlrHVfIEPsd5AjYDRuGD6Fu82K5agJx0UnWA+l5qd53GNLRiMN2WhOw7FLR+Er5QB/0SA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
       "license": "MIT",
       "optional": true,
       "workspaces": [
@@ -13163,23 +13081,23 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.98",
-        "@napi-rs/canvas-darwin-arm64": "0.1.98",
-        "@napi-rs/canvas-darwin-x64": "0.1.98",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.98",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.98",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.98",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.98",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.98",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.98",
-        "@napi-rs/canvas-win32-arm64-msvc": "0.1.98",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.98"
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.98.tgz",
-      "integrity": "sha512-O45Ifr0WZJUrSyg0QgB+67TiC0zYBRkBK+d43ZV4JtlwH3XttiVxLvlxEeULiH5y1MSELruspF0bjF6xXwJNPQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
       "cpu": [
         "arm64"
       ],
@@ -13197,9 +13115,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.98.tgz",
-      "integrity": "sha512-1b/nQhw6Isdv14JokUqat+i5wrAYD+ce3egiotedBGRUjVxYSj4s2uQCh2bFsyX5/9A5iTKVGsWoQhFft+j7Lg==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
       "cpu": [
         "arm64"
       ],
@@ -13217,9 +13135,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.98.tgz",
-      "integrity": "sha512-oefzfBM8mwnyYp6S+yNXwjCoLdkOalFG24mssHgvrJDS0FulOryyI35Q7GdJGmrzuL4oo1XW3ZTOcTBLdJ8Zkg==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
       "cpu": [
         "x64"
       ],
@@ -13237,9 +13155,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.98.tgz",
-      "integrity": "sha512-NDH5QXGmf8wlo5yhijCNGVFiJk7an5GvHwb2LHyfLQWY/6/S48i5+YtY6FPqPVVCUckNGudYOfXEJnb3/FiJGQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
       "cpu": [
         "arm"
       ],
@@ -13257,9 +13175,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.98.tgz",
-      "integrity": "sha512-KBLLM6tu1xs80LSAqdSLBKkgct0S23MCEf/aq8yxzg5imAceqp1ulKeELgWaYm27MgpUhm3Q7jmegX12FfphwA==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
       "cpu": [
         "arm64"
       ],
@@ -13277,9 +13195,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.98.tgz",
-      "integrity": "sha512-mfMNhjN5zDcJafqQ6sHj4Tc3YMTRxP5UA3MHtp/ssytBR/k6XO0x+1IIPtscnUKwha+ql1++WjDCGEgqu8OfWQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
       "cpu": [
         "arm64"
       ],
@@ -13297,9 +13215,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.98.tgz",
-      "integrity": "sha512-nfW8esrcaeuhrO3qGA5cwuyk4Ak6cn2eB0LtEYtqROIl+fz06CNGNCU0M95+Tspw5ZgfSbc98SaigT5r5B3LVQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
       "cpu": [
         "riscv64"
       ],
@@ -13317,9 +13235,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.98.tgz",
-      "integrity": "sha512-318UT8j6Gro2bTjtutjQXHWp9SLTNw+WRS4wQ6XIRPAyzBGnGHg7x2ndD+oqkPrrSRIbYLA5WoBcCasaF7lSTQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
       "cpu": [
         "x64"
       ],
@@ -13337,9 +13255,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.98.tgz",
-      "integrity": "sha512-0vZhI74UxnA4VqlW4UvM0dFRrjE1RLEe/OXSBjzytGIxV+yOG4exlrhGoIpAQaIpQQQXMCdb1EmbvPC1k9vEqQ==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
       "cpu": [
         "x64"
       ],
@@ -13357,9 +13275,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.98.tgz",
-      "integrity": "sha512-oiC/IxgFEEVcZ7VH7JXXlmgsqRvmFb57PIQ4gQck35IKFZCNUvdNCcN3OeoLP7Hpf5160MWJf9jj/+E5V0bSvw==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
       "cpu": [
         "arm64"
       ],
@@ -13377,9 +13295,9 @@
       }
     },
     "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.98",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.98.tgz",
-      "integrity": "sha512-ZqstKAJBSyZetU8udUvBQWPlGN9buawFvjuo9mgCAxzbOoJAgXX39ihec/nn42T5Vb6/qyn45eTimx5ND9kMEw==",
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
       "cpu": [
         "x64"
       ],
@@ -13395,6 +13313,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -16689,16 +16621,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.15",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.15.tgz",
-      "integrity": "sha512-BJdMBY5YO9iHh+lPLYdHv6LbX+J8IcPCYMl1IJdBt2KDWNHwONHrPVHk3ttYBqJd9wxv84wlbN0f7GlQzcQtNQ==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.4.0",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16706,18 +16638,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.14",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
-      "integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -16740,15 +16672,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.13.tgz",
-      "integrity": "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16756,13 +16688,13 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.13.tgz",
-      "integrity": "sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -16797,13 +16729,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.13.tgz",
-      "integrity": "sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16811,12 +16743,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.13.tgz",
-      "integrity": "sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16824,13 +16756,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.13.tgz",
-      "integrity": "sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16838,13 +16770,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.13.tgz",
-      "integrity": "sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16852,14 +16784,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
-      "integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/querystring-builder": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -16868,14 +16800,14 @@
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.14.tgz",
-      "integrity": "sha512-rtQ5es8r/5v4rav7q5QTsfx9CtCyzrz/g7ZZZBH2xtMmd6G/KQrLOWfSHTvFOUPlVy59RQvxeBYJaLRoybMEyA==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
+      "integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/chunked-blob-reader": "^5.2.2",
         "@smithy/chunked-blob-reader-native": "^4.2.3",
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16883,12 +16815,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
-      "integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -16911,12 +16843,12 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.13.tgz",
-      "integrity": "sha512-WdQ7HwUjINXETeh6dqUeob1UHIYx8kAn9PSp1HhM2WWegiZBYVy2WXIs1lB07SZLan/udys9SBnQGt9MQbDpdg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
+      "integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -16938,12 +16870,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
-      "integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16963,12 +16895,12 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.13.tgz",
-      "integrity": "sha512-cNm7I9NXolFxtS20ojROddOEpSAeI1Obq6pd1Kj5HtHws3s9Fkk8DdHDfQSs5KuxCewZuVK6UqrJnfJmiMzDuQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
+      "integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -16990,13 +16922,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
-      "integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17004,18 +16936,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.29",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
-      "integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-serde": "^4.2.17",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
-        "@smithy/url-parser": "^4.2.13",
-        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17023,19 +16955,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.1.tgz",
-      "integrity": "sha512-/zY+Gp7Qj2D2hVm3irkCyONER7E9MiX3cUUm/k2ZmhkzZkrPgwVS4aJ5NriZUEN/M0D1hhjrgjUmX04HhRwdWA==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/service-error-classification": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-middleware": "^4.2.13",
-        "@smithy/util-retry": "^4.3.1",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -17044,14 +16976,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.17",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
-      "integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17059,12 +16991,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
-      "integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17072,14 +17004,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
-      "integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17087,14 +17019,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
-      "integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/querystring-builder": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17102,12 +17034,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
-      "integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17115,12 +17047,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
-      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17128,12 +17060,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
-      "integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -17154,12 +17086,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
-      "integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17167,24 +17099,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
-      "integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
-      "integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17236,17 +17168,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
-      "integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.14",
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/middleware-stack": "^4.2.13",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/types": "^4.14.0",
-        "@smithy/util-stream": "^4.5.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17254,9 +17186,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
-      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -17266,13 +17198,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
-      "integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17368,14 +17300,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.45",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
-      "integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17383,17 +17315,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.50",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.50.tgz",
-      "integrity": "sha512-xpjncL5XozFA3No7WypTsPU1du0fFS8flIyO+Wh2nhCy7bpEapvU7BR55Bg+wrfw+1cRA+8G8UsTjaxgzrMzXg==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.15",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17401,13 +17333,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.0.tgz",
-      "integrity": "sha512-QQHGPKkw6NPcU6TJ1rNEEa201srPtZiX4k61xL163vvs9sTqW/XKz+UEuJ00uvPqoN+5Rs4Ka1UJ7+Mp03IXJw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17427,12 +17359,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
-      "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17440,13 +17372,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.1.tgz",
-      "integrity": "sha512-FwmicpgWOkP5kZUjN3y+3JIom8NLGqSAJBeoIgK0rIToI817TEBHCrd0A2qGeKQlgDeP+Jzn4i0H/NLAXGy9uQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.6.tgz",
+      "integrity": "sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.13",
-        "@smithy/types": "^4.14.0",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -17454,14 +17386,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.22",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
-      "integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.16",
-        "@smithy/node-http-handler": "^4.5.2",
-        "@smithy/types": "^4.14.0",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
@@ -17536,12 +17468,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.15.tgz",
-      "integrity": "sha512-oUt9o7n8hBv3BL56sLSneL0XeigZSuem0Hr78JaoK33D9oKieyCvVP8eTSe3j7g2mm/S1DvzxKieG7JEWNJUNg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
+      "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -19735,14 +19667,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -21799,9 +21731,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -25686,9 +25618,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -26900,20 +26832,20 @@
       }
     },
     "node_modules/n8n-core": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-2.16.1.tgz",
-      "integrity": "sha512-+sP/9H93M1vv/k5IE5zDCtItDMe4NBXyod9DuWZ6P/bkEfpvSDVWRaFDGPNEjpkdDWZDWeMD0/Hfg4uxx2KJxQ==",
+      "version": "2.18.3",
+      "resolved": "https://registry.npmjs.org/n8n-core/-/n8n-core-2.18.3.tgz",
+      "integrity": "sha512-Z6mPVWPRiNBnMq//3BnoNMqcm/DLfyxThnfLT+2dcozPuagk0Y35aqdUDwhs0lrZ/Yjn3+WGZe8fCuCVNIPp3A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@aws-sdk/client-s3": "3.808.0",
         "@langchain/core": "1.1.34",
-        "@n8n/backend-common": "1.16.0",
-        "@n8n/client-oauth2": "1.1.1",
-        "@n8n/config": "2.15.0",
-        "@n8n/constants": "0.20.0",
-        "@n8n/decorators": "1.16.0",
+        "@n8n/backend-common": "1.18.3",
+        "@n8n/client-oauth2": "1.2.0",
+        "@n8n/config": "2.17.0",
+        "@n8n/constants": "0.22.0",
+        "@n8n/decorators": "1.18.3",
         "@n8n/di": "0.10.0",
-        "@n8n/workflow-sdk": "0.9.0",
+        "@n8n/workflow-sdk": "0.11.3",
         "@sentry/node": "^10.36.0",
         "@sentry/node-native": "^10.36.0",
         "@sentry/profiling-node": "^10.36.0",
@@ -26929,10 +26861,10 @@
         "https-proxy-agent": "7.0.6",
         "iconv-lite": "0.6.3",
         "jsonwebtoken": "9.0.3",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "luxon": "3.7.2",
         "mime-types": "3.0.2",
-        "n8n-workflow": "2.16.0",
+        "n8n-workflow": "2.18.3",
         "nanoid": "3.3.8",
         "oauth-1.0a": "2.2.6",
         "p-cancelable": "2.1.1",
@@ -26943,14 +26875,16 @@
         "ssh2": "1.15.0",
         "uuid": "10.0.0",
         "winston": "3.14.2",
-        "xml2js": "0.6.2",
-        "zod": "3.25.67"
+        "xml2js": "0.6.2"
       },
       "bin": {
         "n8n-copy-static-files": "bin/copy-static-files",
         "n8n-generate-metadata": "bin/generate-metadata",
         "n8n-generate-node-defs": "bin/generate-node-defs",
         "n8n-generate-translations": "bin/generate-translations"
+      },
+      "peerDependencies": {
+        "zod": "3.25.67"
       }
     },
     "node_modules/n8n-core/node_modules/@langchain/core": {
@@ -27206,28 +27140,19 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/n8n-core/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/n8n-nodes-base": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/n8n-nodes-base/-/n8n-nodes-base-2.16.0.tgz",
-      "integrity": "sha512-lvZIWmm/vQWFFnRmit13PIjrBjkfFycls2fsMngBt+HBHZoh5Ori2089OF1EzBOB5/+GLpfg82X7LysQQ4Wtgg==",
+      "version": "2.18.3",
+      "resolved": "https://registry.npmjs.org/n8n-nodes-base/-/n8n-nodes-base-2.18.3.tgz",
+      "integrity": "sha512-IEi1sKq12AjMLVn9qpyTxIoGDYrpsBZfzvAD88fYQtJBbAxhJIP/COEaWplyV98dfLJHWctj8C+2RmZpeAGFrw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@aws-sdk/client-sso-oidc": "3.808.0",
         "@kafkajs/confluent-schema-registry": "3.8.0",
         "@mozilla/readability": "0.6.0",
-        "@n8n/config": "2.15.0",
+        "@n8n/config": "2.17.0",
         "@n8n/di": "0.10.0",
-        "@n8n/errors": "0.6.0",
-        "@n8n/imap": "0.16.0",
+        "@n8n/errors": "0.7.0",
+        "@n8n/imap": "0.17.0",
         "@thednp/dommatrix": "^2.0.12",
         "alasql": "4.4.0",
         "amqplib": "0.10.6",
@@ -27257,7 +27182,7 @@
         "jsonwebtoken": "9.0.3",
         "kafkajs": "2.2.4",
         "ldapts": "4.2.6",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "lossless-json": "1.0.5",
         "luxon": "3.7.2",
         "mailparser": "3.9.3",
@@ -27268,7 +27193,7 @@
         "mqtt": "5.7.2",
         "mssql": "10.0.2",
         "mysql2": "3.17.0",
-        "n8n-workflow": "2.16.0",
+        "n8n-workflow": "2.18.3",
         "node-html-markdown": "1.2.0",
         "node-ssh": "13.2.0",
         "nodemailer": "7.0.11",
@@ -27595,30 +27520,32 @@
       }
     },
     "node_modules/n8n-workflow": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.16.0.tgz",
-      "integrity": "sha512-JoDvHLvV4QZQBCDVQl5xkrGOmPmsacLO4TkJkErCzMmiEqIej+h14J6eCUY7gbxBj8V+GIBlpqyO63akJbXRQg==",
+      "version": "2.18.3",
+      "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.18.3.tgz",
+      "integrity": "sha512-v1iupP60fEFBeNKHOT++ME3FtORNTtiNk9N2sXL0rsAplCQtLYnuOWncRPRKprbGf9FBFwmMZngtoAOpC3F43Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@n8n/errors": "0.6.0",
-        "@n8n/expression-runtime": "0.8.0",
+        "@n8n/errors": "0.7.0",
+        "@n8n/expression-runtime": "0.10.1",
         "@n8n/tournament": "1.0.6",
         "ast-types": "0.16.1",
         "callsites": "3.1.0",
         "esprima-next": "5.8.4",
         "form-data": "4.0.4",
         "jmespath": "0.16.0",
-        "js-base64": "3.7.2",
+        "js-base64": "3.7.8",
         "jsonrepair": "3.13.2",
         "jssha": "3.3.1",
-        "lodash": "4.17.23",
+        "lodash": "4.18.1",
         "luxon": "3.7.2",
         "md5": "2.3.0",
         "recast": "0.22.0",
         "title-case": "3.0.3",
         "transliteration": "2.3.5",
         "uuid": "10.0.0",
-        "xml2js": "0.6.2",
+        "xml2js": "0.6.2"
+      },
+      "peerDependencies": {
         "zod": "3.25.67"
       }
     },
@@ -27638,14 +27565,11 @@
         "node": ">= 6"
       }
     },
-    "node_modules/n8n-workflow/node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
+    "node_modules/n8n-workflow/node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/named-placeholders": {
       "version": "1.1.6",
@@ -28325,9 +28249,9 @@
       "license": "MIT"
     },
     "node_modules/oauth4webapi": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
-      "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -30281,14 +30205,14 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -34292,9 +34216,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.48.3",
+  "version": "2.49.0",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -156,21 +156,21 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.28.0",
-    "@n8n/n8n-nodes-langchain": "2.16.1",
+    "@n8n/n8n-nodes-langchain": "2.18.3",
     "@supabase/supabase-js": "^2.57.4",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-rate-limit": "^7.1.5",
     "form-data": "^4.0.5",
     "lru-cache": "^11.2.1",
-    "n8n-core": "2.16.1",
-    "n8n-nodes-base": "2.16.0",
-    "n8n-workflow": "2.16.0",
+    "n8n-core": "2.18.3",
+    "n8n-nodes-base": "2.18.3",
+    "n8n-workflow": "2.18.3",
     "openai": "^4.77.0",
     "sql.js": "^1.13.0",
     "tslib": "^2.6.2",
     "uuid": "^10.0.0",
-    "zod": "3.24.1"
+    "zod": "3.25.67"
   },
   "optionalDependencies": {
     "@rollup/rollup-darwin-arm64": "^4.50.0",


### PR DESCRIPTION
## Summary

- Updates the n8n stack from **2.16.x** to **2.18.4** (the current `n8n@stable` / `n8n@latest`):
  - `n8n-nodes-base`, `n8n-core`, `n8n-workflow`, `@n8n/n8n-nodes-langchain` → **2.18.3** (the versions `n8n@stable` pins).
- Bumps `zod` from `3.24.1` to **3.25.67** to satisfy the new peer dependency declared by `n8n-core@2.18.3` and `n8n-workflow@2.18.3`. Same version `n8n@stable` itself depends on, so this just realigns us with upstream.
- Pins the four n8n packages to **exact versions (no caret)**. With `^2.18.3`, `npm install` resolved `n8n-core` to `2.19.0`, which is currently only on `@beta`/`@next` and pulls a different `zod` peer — that produced an `ERESOLVE` failure. The exact pin keeps us aligned with whichever versions `n8n@stable` is currently endorsing.
- Rebuilds `data/nodes.db`: **1,588 nodes** total — 820 core (675 `n8n-nodes-base` + 145 `@n8n/n8n-nodes-langchain`) + 768 community (668 verified + 100 npm). Community READMEs refreshed via `generate:docs:readme-only` (763/768 with READMEs, 581/768 with AI summaries). The AI-summary backfill for the newly-added community nodes still needs a separate local-LLM run; that is independent of this PR.
- README badges updated: n8n version `2.16.1 → 2.18.4`, tests `3336 → 5418`. Node count in the description updated to `1,588 (820 core + 768 community)`.
- `MEMORY_N8N_UPDATE.md`: fixed duplicated step numbers (the second `7/8/9` batch now reads `10/11/12`), refreshed the verified-on date stamp, and replaced stale `1,182 (933 unit + 249 integration)` test counts with `~5,418 (~4,661 unit + ~757 integration)`. The community-node backup/restore loop is unchanged — `npm run rebuild` still does `DELETE FROM nodes`, so this remains required.

## Test plan

- [x] `npm run update:n8n:check` — confirms the upstream bump set
- [x] `npm install` — clean (one warning on a transitive `@huggingface/inference` peer, unrelated to this change)
- [x] `npm run build` — clean
- [x] `npm run typecheck` — clean (validates the `zod 3.24 → 3.25` ecosystem move did not break our schemas)
- [x] `npm run rebuild` — succeeds; one pre-existing `EvaluationTrigger.node.ee.js` failure unchanged from prior runs (enterprise `.ee.js` file with no `name` property)
- [x] Community node backup → rebuild → restore round-trip verified: 693 community rows preserved across the base-table wipe, then upserted to 768 by `npm run fetch:community`
- [ ] CI: unit + integration tests (let CI handle this — fast workflow per `MEMORY_N8N_UPDATE.md`)

## Skipped in this PR

- `generate:docs:summary-only` (LLM-driven AI-summary backfill for the ~75 newly-added community nodes). Requires a local LLM server (vLLM / LM Studio / Ollama). Will be run as a follow-up; existing summaries are preserved in this PR by the upsert path in `fetch:community`.

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)