### PR TITLE
fix: coerce empty optional params to undefined in list handlers

### DIFF
--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -987,10 +987,13 @@ export async function handleListWorkflows(args: unknown, context?: InstanceConte
 
     const response = await client.listWorkflows({
       limit: input.limit || 100,
-      cursor: input.cursor,
+      // Coerce empty strings to undefined so axios omits them from the
+      // query string. The n8n API rejects empty optional query params
+      // (e.g. `?cursor=`) with VALIDATION_ERROR. See issue #774.
+      cursor: input.cursor || undefined,
       active: input.active,
       tags: tagsParam as any,  // API expects string, not array
-      projectId: input.projectId,
+      projectId: input.projectId || undefined,
       excludePinnedData: input.excludePinnedData ?? true
     });
     
@@ -1603,10 +1606,13 @@ export async function handleListExecutions(args: unknown, context?: InstanceCont
     
     const response = await client.listExecutions({
       limit: input.limit || 100,
-      cursor: input.cursor,
-      workflowId: input.workflowId,
-      projectId: input.projectId,
-      status: input.status as ExecutionStatus | undefined,
+      // Coerce empty strings to undefined so axios omits them from the
+      // query string. The n8n API rejects empty optional query params
+      // (e.g. `?cursor=`, `?workflowId=`) with VALIDATION_ERROR. See issue #774.
+      cursor: input.cursor || undefined,
+      workflowId: input.workflowId || undefined,
+      projectId: input.projectId || undefined,
+      status: (input.status || undefined) as ExecutionStatus | undefined,
       includeData: input.includeData || false
     });
     


### PR DESCRIPTION
Closes #774.

`handleListWorkflows` and `handleListExecutions` passed optional query params (`cursor`, `projectId`, `workflowId`, `status`) straight through to the n8n API even when an MCP client like opencode serialised them as \`\"\"\`. axios then put \`?cursor=\` / \`?projectId=\` / etc. on the wire, and the n8n API rejected those with `VALIDATION_ERROR` (\"Empty value found for query parameter ...\", \"An invalid cursor was provided\" if a placeholder like \"0\" was sent).

Replace the bare passthroughs with `input.<field> || undefined`. Non-empty values are unchanged; empty strings get dropped from the query string by axios.

## Verification

```
npm run typecheck   # exit 0
npm test -- tests/unit/mcp/handlers-n8n-manager.test.ts   # 71 passed
```

Concieved by Romuald Członkowski - https://www.aiadvisors.pl/en