### PR TITLE
fix: scope Code node primitive return checks

### DIFF
--- a/src/services/node-specific-validators.ts
+++ b/src/services/node-specific-validators.ts
@@ -27,6 +27,21 @@ const MAX_CODE_LENGTH = 200_000;
  */
 const MAX_SHORT_INPUT_LENGTH = 2_000;
 
+/**
+ * Max distance the function-head detector scans backward from a `{` to find the
+ * matching `(`. A real parameter list is short; capping the walk keeps brace
+ * scanning linear on adversarial input (e.g. many unmatched `) {`).
+ */
+const MAX_PARAM_SCAN = 2_000;
+
+/**
+ * Detects a top-level primitive return in a JS Code node. Keyword literals
+ * require a trailing word boundary so identifiers that merely start with one
+ * (e.g. `return trueItems`) are not misflagged. Module-level + flagless so it
+ * can be reused without `lastIndex` state.
+ */
+const JS_PRIMITIVE_RETURN_RE = /return\s+(?:(?:true|false|null|undefined)\b|\d+|['"`])/m;
+
 export interface NodeValidationContext {
   config: Record<string, any>;
   errors: ValidationError[];
@@ -1389,7 +1404,8 @@ export class NodeSpecificValidators {
     // Detect a *real* top-level return. For JS, scan the stripped view so a
     // return that only appears inside a comment, string, or nested function
     // body (e.g. `// return "x"`) does not satisfy the "must return data" check.
-    const returnScanCode = language === 'javaScript'
+    // Skip the strip for very large code (mirrors hasTopLevelPrimitiveReturn).
+    const returnScanCode = (language === 'javaScript' && code.length <= MAX_CODE_LENGTH)
       ? this.stripNestedJavaScriptFunctionBodies(code)
       : code;
     const hasReturn = /return\s+/.test(returnScanCode);
@@ -1479,11 +1495,11 @@ export class NodeSpecificValidators {
 
   private static hasTopLevelPrimitiveReturn(code: string): boolean {
     if (code.length > MAX_CODE_LENGTH) {
-      return /return\s+(true|false|null|undefined|\d+|['"`])/m.test(code);
+      return JS_PRIMITIVE_RETURN_RE.test(code);
     }
 
     const topLevelCode = this.stripNestedJavaScriptFunctionBodies(code);
-    return /return\s+(true|false|null|undefined|\d+|['"`])/m.test(topLevelCode);
+    return JS_PRIMITIVE_RETURN_RE.test(topLevelCode);
   }
 
   private static stripNestedJavaScriptFunctionBodies(code: string): string {
@@ -1643,14 +1659,18 @@ export class NodeSpecificValidators {
     while (i >= 0 && /\s/.test(code[i])) i--;
     if (i < 0 || code[i] !== ')') return false;
 
+    // Bound the backward walk: a real parameter list is short, so cap the scan
+    // distance. Without this, adversarial input (many unmatched `) {`) would
+    // make each brace walk to the start of the file — quadratic overall.
+    const scanFloor = Math.max(0, i - MAX_PARAM_SCAN);
     let depth = 0;
     let j = i;
-    for (; j >= 0; j--) {
+    for (; j >= scanFloor; j--) {
       const c = code[j];
       if (c === ')') depth++;
       else if (c === '(') { depth--; if (depth === 0) break; }
     }
-    if (j < 0) return false; // unbalanced — bail
+    if (depth !== 0) return false; // unbalanced, or matching '(' beyond the scan window
 
     // `head` is the text immediately before the matching `(` (the name area).
     const head = code.slice(Math.max(0, j - 60), j);

--- a/src/services/node-specific-validators.ts
+++ b/src/services/node-specific-validators.ts
@@ -1386,8 +1386,14 @@ export class NodeSpecificValidators {
     suggestions: string[],
     mode: string = 'runOnceForAllItems'
   ): void {
-    const hasReturn = /return\s+/.test(code);
-    
+    // Detect a *real* top-level return. For JS, scan the stripped view so a
+    // return that only appears inside a comment, string, or nested function
+    // body (e.g. `// return "x"`) does not satisfy the "must return data" check.
+    const returnScanCode = language === 'javaScript'
+      ? this.stripNestedJavaScriptFunctionBodies(code)
+      : code;
+    const hasReturn = /return\s+/.test(returnScanCode);
+
     if (!hasReturn) {
       errors.push({
         type: 'missing_required',
@@ -1617,8 +1623,9 @@ export class NodeSpecificValidators {
   }
 
   // Identifiers that look like `name(...) {` but are control flow, not function bodies.
+  // `await` covers `for await (... of ...) {` (the head's trailing word is `await`).
   private static readonly NON_FUNCTION_HEADS = new Set([
-    'if', 'for', 'while', 'switch', 'catch', 'with',
+    'if', 'for', 'while', 'switch', 'catch', 'with', 'await',
   ]);
 
   private static startsJavaScriptFunctionBody(code: string, openBraceIndex: number): boolean {

--- a/src/services/node-specific-validators.ts
+++ b/src/services/node-specific-validators.ts
@@ -1622,18 +1622,39 @@ export class NodeSpecificValidators {
   ]);
 
   private static startsJavaScriptFunctionBody(code: string, openBraceIndex: number): boolean {
-    const prefix = code.slice(Math.max(0, openBraceIndex - 500), openBraceIndex);
-
     // Arrow function: ... => {
+    const prefix = code.slice(Math.max(0, openBraceIndex - 500), openBraceIndex);
     if (/=>\s*$/.test(prefix)) return true;
 
-    // function declaration/expression, incl. generators: function* gen(...) {, async function(...) {
-    if (/(?:^|[^\w$])(?:async\s+)?function\s*\*?(?:\s+[\w$]+)?\s*\([^)]*\)\s*$/.test(prefix)) return true;
+    // function declarations/expressions and method shorthand look like
+    // `<keyword/name>(<params>) {`. The param list can contain nested parens
+    // (e.g. a default value that calls another function:
+    // `function f(x = a.b()) {`), so locate the matching `(` by scanning
+    // backward with a paren counter rather than a greedy `\([^)]*\)` regex
+    // that stops at the first inner `)`.
+    let i = openBraceIndex - 1;
+    while (i >= 0 && /\s/.test(code[i])) i--;
+    if (i < 0 || code[i] !== ')') return false;
 
-    // Method shorthand / class method / getter-setter / (async) generator method:
-    //   foo(...) {, async foo(...) {, *gen(...) {, get foo() {, set foo(v) {
-    // Exclude control-flow keywords whose head also looks like `name(...)`.
-    const methodHead = /(?:^|[^\w$.])(?:(?:async|get|set)\s+)?\*?\s*([\w$]+)\s*\([^)]*\)\s*$/.exec(prefix);
+    let depth = 0;
+    let j = i;
+    for (; j >= 0; j--) {
+      const c = code[j];
+      if (c === ')') depth++;
+      else if (c === '(') { depth--; if (depth === 0) break; }
+    }
+    if (j < 0) return false; // unbalanced — bail
+
+    // `head` is the text immediately before the matching `(` (the name area).
+    const head = code.slice(Math.max(0, j - 60), j);
+
+    // function declaration/expression, incl. generators: function, function*,
+    // async function, function gen.
+    if (/(?:^|[^\w$])(?:async\s+)?function\s*\*?(?:\s+[\w$]+)?\s*$/.test(head)) return true;
+
+    // Method shorthand / class method / getter-setter / (async) generator method.
+    // Exclude control-flow keywords whose head also looks like `name(`.
+    const methodHead = /(?:^|[^\w$.])(?:(?:async|get|set)\s+)?\*?\s*([\w$]+)\s*$/.exec(head);
     if (methodHead && !this.NON_FUNCTION_HEADS.has(methodHead[1])) return true;
 
     return false;

--- a/src/services/node-specific-validators.ts
+++ b/src/services/node-specific-validators.ts
@@ -1656,7 +1656,18 @@ export class NodeSpecificValidators {
     // backward with a paren counter rather than a greedy `\([^)]*\)` regex
     // that stops at the first inner `)`.
     let i = openBraceIndex - 1;
-    while (i >= 0 && /\s/.test(code[i])) i--;
+    // Skip whitespace and any block comment between the `)` and the `{`
+    // (e.g. `function f() /* note */ {`).
+    while (i >= 0) {
+      if (/\s/.test(code[i])) { i--; continue; }
+      if (code[i] === '/' && i > 0 && code[i - 1] === '*') {
+        i -= 2; // step onto the char before the closing `*/`
+        while (i >= 1 && !(code[i - 1] === '/' && code[i] === '*')) i--;
+        i -= 2; // step before the opening `/*`
+        continue;
+      }
+      break;
+    }
     if (i < 0 || code[i] !== ')') return false;
 
     // Bound the backward walk: a real parameter list is short, so cap the scan
@@ -1704,8 +1715,9 @@ export class NodeSpecificValidators {
     while (j >= 0 && /\s/.test(code[j])) j--;
     if (j < 0) return true; // start of input → regex
     const c = code[j];
-    // After a value (identifier/number/`)`/`]`/`.`), `/` is division...
-    if (/[\w$)\].]/.test(c)) {
+    // After a value (identifier / number / `)` / `]` / `.` / a closing string or
+    // template quote), `/` is division...
+    if (/[\w$)\].'"`]/.test(c)) {
       // ...unless the trailing word is a keyword that precedes a regex.
       if (/[\w$]/.test(c)) {
         let k = j;

--- a/src/services/node-specific-validators.ts
+++ b/src/services/node-specific-validators.ts
@@ -1484,7 +1484,10 @@ export class NodeSpecificValidators {
     let result = '';
     let braceDepth = 0;
     const functionBodyDepths: number[] = [];
-    let state: 'code' | 'single' | 'double' | 'template' | 'lineComment' | 'blockComment' = 'code';
+    let state: 'code' | 'single' | 'double' | 'template' | 'lineComment' | 'blockComment' | 'regex' = 'code';
+    // Tracks whether we are inside a `[...]` character class while in regex state,
+    // so an unescaped `/` inside the class does not prematurely end the literal.
+    let inRegexClass = false;
 
     for (let i = 0; i < code.length; i++) {
       const char = code[i];
@@ -1526,6 +1529,28 @@ export class NodeSpecificValidators {
         continue;
       }
 
+      if (state === 'regex') {
+        // A real regex literal never spans a raw newline; hitting one means we
+        // misclassified a division operator — bail back to code on this line.
+        if (char === '\n') {
+          state = 'code';
+          result += '\n';
+          continue;
+        }
+        result += ' ';
+        if (char === '\\') {
+          if (next !== undefined) {
+            result += ' ';
+            i++;
+          }
+          continue;
+        }
+        if (char === '[') inRegexClass = true;
+        else if (char === ']') inRegexClass = false;
+        else if (char === '/' && !inRegexClass) state = 'code';
+        continue;
+      }
+
       if (char === '/' && next === '/') {
         result += '  ';
         i++;
@@ -1537,6 +1562,15 @@ export class NodeSpecificValidators {
         result += '  ';
         i++;
         state = 'blockComment';
+        continue;
+      }
+
+      // Regex literal (not division). Blank its contents so `{`/`}` inside it
+      // (e.g. str.replace(/}/g, '')) do not skew brace depth.
+      if (char === '/' && this.regexLiteralStartsHere(code, i)) {
+        result += ' ';
+        inRegexClass = false;
+        state = 'regex';
         continue;
       }
 
@@ -1582,10 +1616,58 @@ export class NodeSpecificValidators {
     return result;
   }
 
+  // Identifiers that look like `name(...) {` but are control flow, not function bodies.
+  private static readonly NON_FUNCTION_HEADS = new Set([
+    'if', 'for', 'while', 'switch', 'catch', 'with',
+  ]);
+
   private static startsJavaScriptFunctionBody(code: string, openBraceIndex: number): boolean {
     const prefix = code.slice(Math.max(0, openBraceIndex - 500), openBraceIndex);
-    return /=>\s*$/.test(prefix)
-      || /(?:^|[^\w$])(?:async\s+)?function(?:\s+[\w$]+)?\s*\([^)]*\)\s*$/.test(prefix);
+
+    // Arrow function: ... => {
+    if (/=>\s*$/.test(prefix)) return true;
+
+    // function declaration/expression, incl. generators: function* gen(...) {, async function(...) {
+    if (/(?:^|[^\w$])(?:async\s+)?function\s*\*?(?:\s+[\w$]+)?\s*\([^)]*\)\s*$/.test(prefix)) return true;
+
+    // Method shorthand / class method / getter-setter / (async) generator method:
+    //   foo(...) {, async foo(...) {, *gen(...) {, get foo() {, set foo(v) {
+    // Exclude control-flow keywords whose head also looks like `name(...)`.
+    const methodHead = /(?:^|[^\w$.])(?:(?:async|get|set)\s+)?\*?\s*([\w$]+)\s*\([^)]*\)\s*$/.exec(prefix);
+    if (methodHead && !this.NON_FUNCTION_HEADS.has(methodHead[1])) return true;
+
+    return false;
+  }
+
+  // Keywords after which a `/` begins a regex literal rather than division.
+  private static readonly REGEX_PRECEDING_KEYWORDS = new Set([
+    'return', 'typeof', 'instanceof', 'in', 'of', 'new', 'delete', 'void',
+    'do', 'else', 'yield', 'await', 'case', 'throw',
+  ]);
+
+  /**
+   * Decide whether a `/` at `slashIndex` (already known not to start `//` or `/*`)
+   * begins a regex literal vs. a division operator, by inspecting the previous
+   * significant token. Used only to keep brace counting balanced, so erring toward
+   * "regex" is bounded by the newline bail-out in the scanner.
+   */
+  private static regexLiteralStartsHere(code: string, slashIndex: number): boolean {
+    let j = slashIndex - 1;
+    while (j >= 0 && /\s/.test(code[j])) j--;
+    if (j < 0) return true; // start of input → regex
+    const c = code[j];
+    // After a value (identifier/number/`)`/`]`/`.`), `/` is division...
+    if (/[\w$)\].]/.test(c)) {
+      // ...unless the trailing word is a keyword that precedes a regex.
+      if (/[\w$]/.test(c)) {
+        let k = j;
+        while (k >= 0 && /[\w$]/.test(code[k])) k--;
+        const word = code.slice(k + 1, j + 1);
+        return this.REGEX_PRECEDING_KEYWORDS.has(word);
+      }
+      return false;
+    }
+    return true; // after ( , = : [ ! & | ? { } ; etc. → regex
   }
   
   private static validateN8nVariables(

--- a/src/services/node-specific-validators.ts
+++ b/src/services/node-specific-validators.ts
@@ -1417,14 +1417,7 @@ export class NodeSpecificValidators {
         });
       }
 
-      // Skip primitive return check when helper functions are present,
-      // since we can't distinguish top-level vs nested returns without AST.
-      // Matches: function name(), const/let/var name = [async] function/arrow.
-      // Length guard caps CodeQL polynomial-ReDoS exposure on the
-      // alternation with nested `[^)]*` groups.
-      const hasHelperFunctions = code.length <= MAX_CODE_LENGTH
-        && /(?:function\s+\w+\s*\(|(?:const|let|var)\s+\w+\s*=\s*(?:async\s+)?(?:function|\([^)]*\)\s*=>|\w+\s*=>))/.test(code);
-      if (!isRunOncePerItem && !hasHelperFunctions && /return\s+(true|false|null|undefined|\d+|['"`])/m.test(code)) {
+      if (!isRunOncePerItem && this.hasTopLevelPrimitiveReturn(code)) {
         errors.push({
           type: 'invalid_value',
           property: 'jsCode',
@@ -1476,6 +1469,123 @@ export class NodeSpecificValidators {
         });
       }
     }
+  }
+
+  private static hasTopLevelPrimitiveReturn(code: string): boolean {
+    if (code.length > MAX_CODE_LENGTH) {
+      return /return\s+(true|false|null|undefined|\d+|['"`])/m.test(code);
+    }
+
+    const topLevelCode = this.stripNestedJavaScriptFunctionBodies(code);
+    return /return\s+(true|false|null|undefined|\d+|['"`])/m.test(topLevelCode);
+  }
+
+  private static stripNestedJavaScriptFunctionBodies(code: string): string {
+    let result = '';
+    let braceDepth = 0;
+    const functionBodyDepths: number[] = [];
+    let state: 'code' | 'single' | 'double' | 'template' | 'lineComment' | 'blockComment' = 'code';
+
+    for (let i = 0; i < code.length; i++) {
+      const char = code[i];
+      const next = code[i + 1];
+      const inFunctionBody = functionBodyDepths.length > 0;
+
+      if (state === 'lineComment') {
+        result += char === '\n' ? '\n' : ' ';
+        if (char === '\n') state = 'code';
+        continue;
+      }
+
+      if (state === 'blockComment') {
+        result += char === '\n' ? '\n' : ' ';
+        if (char === '*' && next === '/') {
+          result += ' ';
+          i++;
+          state = 'code';
+        }
+        continue;
+      }
+
+      if (state === 'single' || state === 'double' || state === 'template') {
+        result += char === '\n' ? '\n' : ' ';
+        if (char === '\\') {
+          if (next) {
+            result += next === '\n' ? '\n' : ' ';
+            i++;
+          }
+          continue;
+        }
+        if (
+          (state === 'single' && char === "'") ||
+          (state === 'double' && char === '"') ||
+          (state === 'template' && char === '`')
+        ) {
+          state = 'code';
+        }
+        continue;
+      }
+
+      if (char === '/' && next === '/') {
+        result += '  ';
+        i++;
+        state = 'lineComment';
+        continue;
+      }
+
+      if (char === '/' && next === '*') {
+        result += '  ';
+        i++;
+        state = 'blockComment';
+        continue;
+      }
+
+      if (char === "'") {
+        result += inFunctionBody ? ' ' : char;
+        state = 'single';
+        continue;
+      }
+
+      if (char === '"') {
+        result += inFunctionBody ? ' ' : char;
+        state = 'double';
+        continue;
+      }
+
+      if (char === '`') {
+        result += inFunctionBody ? ' ' : char;
+        state = 'template';
+        continue;
+      }
+
+      if (char === '{') {
+        if (this.startsJavaScriptFunctionBody(code, i)) {
+          functionBodyDepths.push(braceDepth + 1);
+        }
+        braceDepth++;
+        result += functionBodyDepths.length > 0 ? ' ' : char;
+        continue;
+      }
+
+      if (char === '}') {
+        result += inFunctionBody ? ' ' : char;
+        if (functionBodyDepths[functionBodyDepths.length - 1] === braceDepth) {
+          functionBodyDepths.pop();
+        }
+        braceDepth = Math.max(0, braceDepth - 1);
+        continue;
+      }
+
+      result += inFunctionBody ? (char === '\n' ? '\n' : ' ') : char;
+    }
+
+    return result;
+  }
+
+  private static startsJavaScriptFunctionBody(code: string, openBraceIndex: number): boolean {
+    const prefix = code.slice(Math.max(0, openBraceIndex - 500), openBraceIndex);
+    return /=>\s*$/.test(prefix)
+      || /(?:^|[^\w$])(?:async\s+)?function(?:\s+[\w$]+)?\s*\([^)]*\)\s*$/.test(prefix);
   }
   
   private static validateN8nVariables(

--- a/tests/unit/services/node-specific-validators.test.ts
+++ b/tests/unit/services/node-specific-validators.test.ts
@@ -2120,6 +2120,30 @@ return [{"json": {"result": result}}]
         expect(primitiveErrors).toHaveLength(0);
       });
 
+      it('should treat division after a string literal as division, not a regex', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'const ratio = "10" / 2;\nreturn [{json: {ratio}}];'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const missing = context.errors.filter(e => e.message === 'Code must return data for the next node');
+        expect(missing).toHaveLength(0);
+      });
+
+      it('should recognize a helper body when a block comment sits before its brace', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'function normalize() /* note */ { return null; }\nreturn [{json: {v: normalize()}}];'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const primitiveErrors = context.errors.filter(e => e.message === 'Cannot return primitive values directly');
+        expect(primitiveErrors).toHaveLength(0);
+      });
+
       it('should still error on primitive top-level return when helper functions exist', () => {
         context.config = {
           language: 'javaScript',

--- a/tests/unit/services/node-specific-validators.test.ts
+++ b/tests/unit/services/node-specific-validators.test.ts
@@ -2108,6 +2108,18 @@ return [{"json": {"result": result}}]
         );
       });
 
+      it('should not flag an identifier that merely starts with a primitive keyword', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'function f(x){ return x; }\nconst trueItems = [{json: {}}];\nreturn trueItems;'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const primitiveErrors = context.errors.filter(e => e.message === 'Cannot return primitive values directly');
+        expect(primitiveErrors).toHaveLength(0);
+      });
+
       it('should still error on primitive top-level return when helper functions exist', () => {
         context.config = {
           language: 'javaScript',

--- a/tests/unit/services/node-specific-validators.test.ts
+++ b/tests/unit/services/node-specific-validators.test.ts
@@ -2033,6 +2033,30 @@ return [{"json": {"result": result}}]
         expect(primitiveErrors).toHaveLength(0);
       });
 
+      it('should not error on a helper whose params contain nested parentheses', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'function normalize(item = $input.first()) { return null; }\nreturn [{json: {v: normalize()}}];'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const primitiveErrors = context.errors.filter(e => e.message === 'Cannot return primitive values directly');
+        expect(primitiveErrors).toHaveLength(0);
+      });
+
+      it('should not error on an arrow helper with a function-call default param', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'const pick = (x = Math.max(1, 2)) => { return false; };\nreturn [{json: {v: pick()}}];'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const primitiveErrors = context.errors.filter(e => e.message === 'Cannot return primitive values directly');
+        expect(primitiveErrors).toHaveLength(0);
+      });
+
       it('should still error on a real primitive return when a regex literal is present', () => {
         context.config = {
           language: 'javaScript',

--- a/tests/unit/services/node-specific-validators.test.ts
+++ b/tests/unit/services/node-specific-validators.test.ts
@@ -2057,6 +2057,44 @@ return [{"json": {"result": result}}]
         expect(primitiveErrors).toHaveLength(0);
       });
 
+      it('should flag a primitive return inside a for-await block (not treat it as a function body)', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'for await (const item of source) { return "bad"; }'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        expect(context.errors).toContainEqual(
+          expect.objectContaining({ message: 'Cannot return primitive values directly' })
+        );
+      });
+
+      it('should not flag a valid for-await loop with a top-level array return', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'const results = [];\nfor await (const x of items) { results.push(x); }\nreturn [{json: {results}}];'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const primitiveErrors = context.errors.filter(e => e.message === 'Cannot return primitive values directly');
+        expect(primitiveErrors).toHaveLength(0);
+      });
+
+      it('should report missing return when the only return is in a comment or string', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: '// return "bad"\nconst x = 1;'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        expect(context.errors).toContainEqual(
+          expect.objectContaining({ message: 'Code must return data for the next node' })
+        );
+      });
+
       it('should still error on a real primitive return when a regex literal is present', () => {
         context.config = {
           language: 'javaScript',

--- a/tests/unit/services/node-specific-validators.test.ts
+++ b/tests/unit/services/node-specific-validators.test.ts
@@ -2024,6 +2024,19 @@ return [{"json": {"result": result}}]
         }));
       });
 
+      it('should still check primitive returns in very large code blocks', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: `${'const padding = 1;\n'.repeat(12000)}return "too large";`
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        expect(context.errors).toContainEqual(expect.objectContaining({
+          message: 'Cannot return primitive values directly'
+        }));
+      });
+
       it('should not error on bare object return in runOnceForEachItem mode', () => {
         context.config = {
           language: 'javaScript',

--- a/tests/unit/services/node-specific-validators.test.ts
+++ b/tests/unit/services/node-specific-validators.test.ts
@@ -1985,6 +1985,67 @@ return [{"json": {"result": result}}]
         expect(primitiveErrors).toHaveLength(0);
       });
 
+      it('should not error on primitive return inside object-method shorthand', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'const o = { foo() { return 1; } };\nreturn [{json: o}];'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const primitiveErrors = context.errors.filter(e => e.message === 'Cannot return primitive values directly');
+        expect(primitiveErrors).toHaveLength(0);
+      });
+
+      it('should not error on primitive return inside class methods', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'class A { m() { return false; } }\nreturn [{json: {}}];'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const primitiveErrors = context.errors.filter(e => e.message === 'Cannot return primitive values directly');
+        expect(primitiveErrors).toHaveLength(0);
+      });
+
+      it('should not error on primitive return inside generator functions', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'function* gen() { return 1; }\nreturn [{json: {}}];'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const primitiveErrors = context.errors.filter(e => e.message === 'Cannot return primitive values directly');
+        expect(primitiveErrors).toHaveLength(0);
+      });
+
+      it('should not error when a helper uses a regex literal containing braces', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: "const clean = (s) => { s = s.replace(/[/{}]/g, ''); return false; };\nreturn [{json: {ok: clean('x')}}];"
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const primitiveErrors = context.errors.filter(e => e.message === 'Cannot return primitive values directly');
+        expect(primitiveErrors).toHaveLength(0);
+      });
+
+      it('should still error on a real primitive return when a regex literal is present', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: "const m = 'a'.match(/b/);\nreturn 7;"
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        expect(context.errors).toContainEqual(
+          expect.objectContaining({ message: 'Cannot return primitive values directly' })
+        );
+      });
+
       it('should still error on primitive top-level return when helper functions exist', () => {
         context.config = {
           language: 'javaScript',

--- a/tests/unit/services/node-specific-validators.test.ts
+++ b/tests/unit/services/node-specific-validators.test.ts
@@ -1948,6 +1948,32 @@ return [{"json": {"result": result}}]
         expect(primitiveErrors).toHaveLength(0);
       });
 
+      it('should still error on primitive top-level return when helper functions exist', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'const isValid = (item) => { return false; };\nconst items = $input.all();\nif (!items.length) return "empty";\nreturn items.filter(isValid).map(i => ({json: i.json}));'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        expect(context.errors).toContainEqual(expect.objectContaining({
+          message: 'Cannot return primitive values directly'
+        }));
+      });
+
+      it('should still error on primitive try-block return when helper functions exist', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: 'function normalize(item) { return null; }\ntry {\n  const items = $input.all();\n  return "bad";\n} catch (error) {\n  return [{json: {error: error.message}}];\n}'
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        expect(context.errors).toContainEqual(expect.objectContaining({
+          message: 'Cannot return primitive values directly'
+        }));
+      });
+
       it('should still error on primitive return without helper functions', () => {
         context.config = {
           language: 'javaScript',

--- a/tests/unit/services/node-specific-validators.test.ts
+++ b/tests/unit/services/node-specific-validators.test.ts
@@ -1948,6 +1948,43 @@ return [{"json": {"result": result}}]
         expect(primitiveErrors).toHaveLength(0);
       });
 
+      it('should not error on primitive-looking returns in comments or strings', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: [
+            'const quoted = "not code: return \\"bad\\"";',
+            'const templated = `not code: return false`;',
+            '// return "bad";',
+            '/* return null; */',
+            'return [{json: {quoted, templated}}];',
+          ].join('\n')
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const primitiveErrors = context.errors.filter(e => e.message === 'Cannot return primitive values directly');
+        expect(primitiveErrors).toHaveLength(0);
+      });
+
+      it('should not error on primitive helper returns inside nested blocks', () => {
+        context.config = {
+          language: 'javaScript',
+          jsCode: [
+            'const normalize = (value) => {',
+            '  /* helper can return primitives */',
+            '  if (!value) { return ""; }',
+            '  return value;',
+            '};',
+            'return [{json: {value: normalize("ok")}}];',
+          ].join('\n')
+        };
+
+        NodeSpecificValidators.validateCode(context);
+
+        const primitiveErrors = context.errors.filter(e => e.message === 'Cannot return primitive values directly');
+        expect(primitiveErrors).toHaveLength(0);
+      });
+
       it('should still error on primitive top-level return when helper functions exist', () => {
         context.config = {
           language: 'javaScript',


### PR DESCRIPTION
﻿This tightens the Code node return validator a bit.

The previous fix for helper functions avoided false positives by skipping primitive-return checks whenever a helper function was present. That fixed the noisy case, but it also meant a snippet like this could slip through:

```js
const isValid = (item) => { return false; };
if (!items.length) return "empty";
```

This keeps ignoring returns inside nested helper function bodies, but still checks returns from the actual Code node flow, including returns inside top-level try/catch blocks.

I ran:

```
node node_modules\vitest\vitest.mjs run tests\unit\services\node-specific-validators.test.ts --coverage.enabled=false
node node_modules\typescript\bin\tsc --noEmit --pretty false
node node_modules\typescript\bin\tsc -p tsconfig.build.json --pretty false
```

Small note: `npm ci` currently fails for me on main because the lockfile looks out of sync with `package.json`, so I installed without rewriting the lockfile to run the checks.
