### PR TITLE
fix: strip nodeGroups + sourceWorkflowId in cleanWorkflowForUpdate (n8n 2.x PUT rejects them)

### DIFF
--- a/src/services/n8n-validation.ts
+++ b/src/services/n8n-validation.ts
@@ -176,6 +176,10 @@ export function cleanWorkflowForUpdate(workflow: Workflow): Partial<Workflow> {
     // (workflow schema has additionalProperties:false) -> must be stripped,
     // otherwise every update fails with 400 "must NOT have additional properties".
     nodeGroups,
+    // n8n 2.25+ (migration AddSourceWorkflowId) returns `sourceWorkflowId` on GET
+    // but the PUT /workflows schema (additionalProperties:false) rejects it too.
+    // Without stripping, every workflow update fails with 400 on n8n >= 2.25.
+    sourceWorkflowId,
     // Keep everything else
     ...cleanedWorkflow
   } = workflow as any;

--- a/src/services/n8n-validation.ts
+++ b/src/services/n8n-validation.ts
@@ -172,6 +172,10 @@ export function cleanWorkflowForUpdate(workflow: Workflow): Partial<Workflow> {
     active,
     activeVersionId,
     activeVersion,
+    // n8n 2.x returns `nodeGroups` on GET /workflows but rejects it on PUT
+    // (workflow schema has additionalProperties:false) -> must be stripped,
+    // otherwise every update fails with 400 "must NOT have additional properties".
+    nodeGroups,
     // Keep everything else
     ...cleanedWorkflow
   } = workflow as any;

--- a/tests/unit/services/n8n-validation.test.ts
+++ b/tests/unit/services/n8n-validation.test.ts
@@ -386,11 +386,15 @@ describe('n8n-validation', () => {
           triggerCount: 5,
           shared: true,
           active: true,
+          activeVersionId: 'av123',
+          activeVersion: { foo: 'bar' },
+          nodeGroups: [], // n8n 2.x returns it on GET but rejects it on PUT
+          sourceWorkflowId: 'src-456', // n8n 2.25+ (migration AddSourceWorkflowId), rejected on PUT
           settings: { executionOrder: 'v1' },
         } as any;
 
         const cleaned = cleanWorkflowForUpdate(workflow);
-        
+
         // Should remove all these fields
         expect(cleaned).not.toHaveProperty('id');
         expect(cleaned).not.toHaveProperty('createdAt');
@@ -407,7 +411,11 @@ describe('n8n-validation', () => {
         expect(cleaned).not.toHaveProperty('triggerCount');
         expect(cleaned).not.toHaveProperty('shared');
         expect(cleaned).not.toHaveProperty('active');
-        
+        expect(cleaned).not.toHaveProperty('activeVersionId');
+        expect(cleaned).not.toHaveProperty('activeVersion');
+        expect(cleaned).not.toHaveProperty('nodeGroups');
+        expect(cleaned).not.toHaveProperty('sourceWorkflowId');
+
         // Should keep name and filter settings to safe properties
         expect(cleaned.name).toBe('Updated Workflow');
         expect(cleaned.settings).toEqual({ executionOrder: 'v1' });


### PR DESCRIPTION
## Problem

`cleanWorkflowForUpdate()` does not strip two read-only root fields that recent n8n versions return on `GET /workflows` but **reject** on `PUT /workflows` (the workflow schema is `additionalProperties: false`):

- **`nodeGroups`** — returned by n8n 2.x
- **`sourceWorkflowId`** — added in n8n 2.25+ (migration `AddSourceWorkflowId`)

Because the MCP server reconstructs the full workflow and PUTs it back, every workflow update fails with:

```
400 request/body must NOT have additional properties
```

This breaks all `n8n_update_*_workflow` operations against current n8n (reproduced on **n8n 2.57.1**).

## Verification

Enumerated empirically which root fields n8n 2.57.1's `PUT /workflows` rejects by sending the GET body field-by-field:

```
rejected: updatedAt, createdAt, id, description, active, isArchived, meta,
          nodeGroups, versionId, activeVersionId, versionCounter, triggerCount,
          sourceWorkflowId, shared, tags, activeVersion
accepted: name, nodes, connections, settings, staticData, pinData
```

`sourceWorkflowId` was the only rejected field not already stripped by the destructure.

## Change

- Add `nodeGroups` and `sourceWorkflowId` to the `cleanWorkflowForUpdate()` strip destructure.
- Extend the "remove all read-only and computed fields" unit test to assert both (plus `activeVersionId` / `activeVersion`).

All 104 tests in `tests/unit/services/n8n-validation.test.ts` pass.