### PR TITLE
fix(validation): strip nodeGroups in cleanWorkflowForUpdate

### DIFF
--- a/src/services/n8n-validation.ts
+++ b/src/services/n8n-validation.ts
@@ -172,6 +172,7 @@ export function cleanWorkflowForUpdate(workflow: Workflow): Partial<Workflow> {
     active,
     activeVersionId,
     activeVersion,
+    nodeGroups, // n8n 2.x returns this but rejects it in PUT (Issue #831)
     // Keep everything else
     ...cleanedWorkflow
   } = workflow as any;

--- a/tests/unit/services/n8n-validation.test.ts
+++ b/tests/unit/services/n8n-validation.test.ts
@@ -429,6 +429,22 @@ describe('n8n-validation', () => {
         expect(cleaned.name).toBe('Test Workflow');
       });
 
+      it('should exclude nodeGroups field for n8n 2.x API compatibility (Issue #831)', () => {
+        const workflow = {
+          name: 'Test Workflow',
+          nodes: [],
+          connections: {},
+          versionId: 'v123',
+          nodeGroups: [], // n8n 2.x returns this but rejects it in PUT
+        } as any;
+
+        const cleaned = cleanWorkflowForUpdate(workflow);
+
+        expect(cleaned).not.toHaveProperty('nodeGroups');
+        expect(cleaned).not.toHaveProperty('versionId');
+        expect(cleaned.name).toBe('Test Workflow');
+      });
+
       it('should exclude description field for n8n API compatibility (Issue #431)', () => {
         const workflow = {
           name: 'Test Workflow',


### PR DESCRIPTION
## Summary

Fixes #831.

n8n 2.x returns `nodeGroups` in `GET /workflows/{id}`, but the public API's `PUT /workflows/{id}` rejects it with:

```
400: request/body must NOT have additional properties
```

This breaks `n8n_update_partial_workflow` — including `activateWorkflow` / `deactivateWorkflow` operations — against n8n 2.x instances (reproduced on n8n 2.23.2 with n8n-mcp 2.57.1).

## Change

- Add `nodeGroups` to the read-only field strip list in `cleanWorkflowForUpdate()` (`src/services/n8n-validation.ts`), matching the existing pattern for `versionCounter`, `description`, etc.
- Add a unit test mirroring the existing Issue #431 / versionCounter coverage.

## Testing

- `npx vitest run tests/unit/services/n8n-validation.test.ts` — 105 passed, 0 failed
- `tsc --noEmit` — clean
- Reproduced the original failure against a live n8n 2.23.2 instance via `n8n_update_partial_workflow` `activateWorkflow`; the PUT body minus `nodeGroups` is accepted (per the reproduction in #831).

🤖 Generated with [Claude Code](https://claude.com/claude-code)