### PR TITLE
fix: strip `nodeGroups` in cleanWorkflowForUpdate to prevent 400 on update

### DIFF
--- a/src/services/n8n-validation.ts
+++ b/src/services/n8n-validation.ts
@@ -172,6 +172,7 @@ export function cleanWorkflowForUpdate(workflow: Workflow): Partial<Workflow> {
     active,
     activeVersionId,
     activeVersion,
+    nodeGroups,
     // Keep everything else
     ...cleanedWorkflow
   } = workflow as any;


### PR DESCRIPTION
## What
Adds `nodeGroups` to the destructure in `cleanWorkflowForUpdate()` so it is stripped before the `PUT /workflows/{id}` request.

## Why
Recent n8n versions return a top-level `nodeGroups` field on workflows (alongside the `activeVersion`/`versionCounter` versioning fields). `cleanWorkflowForUpdate()` strips every other read-only/computed field but not `nodeGroups`, so it leaked into the update body. The n8n public API validates the body against the `workflow` schema (`additionalProperties: false`), which does not list `nodeGroups`, and rejects it with:

```
400 request/body must NOT have additional properties
```

This breaks **100% of write operations** (`n8n_update_partial_workflow`, `n8n_update_full_workflow`, `n8n_autofix_workflow`, version restore) on affected instances.

Fixes #838.

## Reproduction (verified against a live instance)
| PUT body | Result |
|---|---|
| `{name, nodes, connections, settings}` **+ `nodeGroups`** | `400 ... must NOT have additional properties` |
| `{name, nodes, connections, settings}` (no `nodeGroups`) | `200 OK` |

After this patch, `cleanWorkflowForUpdate({…, nodeGroups: [], versionCounter: 9, activeVersion: {…}})` returns only `{name, nodes, connections, settings}` and updates succeed end-to-end.

## Diff
```diff
     active,
     activeVersionId,
     activeVersion,
+    nodeGroups,
     // Keep everything else
     ...cleanedWorkflow
   } = workflow as any;
```

## Note / possible follow-up
This is the minimal fix. The denylist approach breaks whenever n8n adds a new top-level field (this is the second occurrence after the versioning set). A more durable fix would invert to an **allowlist** — keep only `{name, nodes, connections, settings, staticData}` — so future n8n field additions can't reintroduce this class of bug. Happy to follow up with that if preferred.