### PR TITLE
feat(workflow): add mode="filtered" to n8n_get_workflow for single-node reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.59.0] - 2026-06-18
+
+### Added
+
+- **`n8n_get_workflow` gains `mode="filtered"`** for reading a single node (or a handful of nodes) without pulling the whole workflow. On large workflows with long Code-node source, `mode="full"`/`mode="active"` can return a payload big enough to be truncated client-side, leaving `jsCode`/`pythonCode` unreadable. The new mode takes a `nodeNames` array (matched against node names *or* node IDs) and returns only those nodes with their full config, plus light metadata (`nodeCount`, `returnedCount`, and a `notFound` list for any keys that matched nothing). Recommended flow: `mode="structure"` to discover node names, then `mode="filtered"` to pull the specific heavy node. Requested by @MiRaIOMeZaSu (#101).
+
+Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en
+
 ## [2.58.0] - 2026-06-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.58.0",
+  "version": "2.59.0",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.58.0",
+  "version": "2.59.0",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -819,6 +819,75 @@ export async function handleGetWorkflowMinimal(args: unknown, context?: Instance
 }
 
 /**
+ * Returns the full config of only the requested nodes, identified by node name or node ID.
+ * Large workflows with long Code-node source can exceed client-side response limits when
+ * fetched whole (issue #101); this mode lets a caller pull one heavy node's `parameters`
+ * without the rest of the graph. Discover node names cheaply with mode='structure' first.
+ *
+ * `nodeNames` accepts both node names and node IDs; any entries that match nothing are
+ * reported back in `notFound` so the caller knows the lookup was partial.
+ */
+export async function handleGetWorkflowFiltered(args: unknown, context?: InstanceContext): Promise<McpToolResponse> {
+  try {
+    const client = ensureApiConfigured(context);
+    const { id, nodeNames } = z.object({
+      id: z.string(),
+      nodeNames: z.array(z.string()).min(1)
+    }).parse(args);
+
+    const workflow = await client.getWorkflow(id);
+
+    const requested = new Set(nodeNames);
+    const matchedNodes = workflow.nodes.filter(
+      node => requested.has(node.name) || requested.has(node.id)
+    );
+
+    // Track which lookup keys actually resolved so partial requests are transparent.
+    const found = new Set<string>();
+    for (const node of matchedNodes) {
+      if (requested.has(node.name)) found.add(node.name);
+      if (requested.has(node.id)) found.add(node.id);
+    }
+    const notFound = nodeNames.filter(key => !found.has(key));
+
+    return {
+      success: true,
+      data: {
+        id: workflow.id,
+        name: workflow.name,
+        active: workflow.active,
+        isArchived: workflow.isArchived,
+        nodes: matchedNodes,
+        nodeCount: workflow.nodes.length,
+        returnedCount: matchedNodes.length,
+        ...(notFound.length > 0 ? { notFound } : {})
+      }
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        success: false,
+        error: 'Invalid input',
+        details: { errors: error.errors }
+      };
+    }
+
+    if (error instanceof N8nApiError) {
+      return {
+        success: false,
+        error: getUserFriendlyErrorMessage(error),
+        code: error.code
+      };
+    }
+
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error occurred'
+    };
+  }
+}
+
+/**
  * Returns the workflow's published (active) graph. n8n's draft/publish model exposes
  * the live version under `activeVersion`; this handler surfaces that as a single-shaped
  * response with `nodes`/`connections` populated from the published version. Use this when

--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -842,13 +842,9 @@ export async function handleGetWorkflowFiltered(args: unknown, context?: Instanc
       node => requested.has(node.name) || requested.has(node.id)
     );
 
-    // Track which lookup keys actually resolved so partial requests are transparent.
-    const found = new Set<string>();
-    for (const node of matchedNodes) {
-      if (requested.has(node.name)) found.add(node.name);
-      if (requested.has(node.id)) found.add(node.id);
-    }
-    const notFound = nodeNames.filter(key => !found.has(key));
+    // Report any requested keys that resolved to no node so partial requests are transparent.
+    const matchedKeys = new Set(matchedNodes.flatMap(node => [node.name, node.id]));
+    const notFound = nodeNames.filter(key => !matchedKeys.has(key));
 
     return {
       success: true,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1596,6 +1596,10 @@ export class N8NDocumentationMCPServer {
             return n8nHandlers.handleGetWorkflowMinimal(args, this.instanceContext);
           case 'active':
             return n8nHandlers.handleGetWorkflowActive(args, this.instanceContext);
+          case 'filtered':
+            // nodeNames is required for this mode; the handler's Zod schema enforces it
+            // and returns a graceful "Invalid input" response (consistent with the other modes).
+            return n8nHandlers.handleGetWorkflowFiltered(args, this.instanceContext);
           case 'full':
           default:
             return n8nHandlers.handleGetWorkflow(args, this.instanceContext);

--- a/src/mcp/tool-docs/workflow_management/n8n-get-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-get-workflow.ts
@@ -77,6 +77,7 @@ export const n8nGetWorkflowDoc: ToolDocumentation = {
       'mode="full" no longer carries the nested activeVersion payload — switch to mode="active" if you previously read it from there',
       'mode="active" returns NO_ACTIVE_VERSION for workflows that were never activated',
       'mode="filtered" requires a non-empty nodeNames array; unmatched entries are reported in notFound rather than erroring',
+      'mode="filtered" matches each nodeNames entry against node name OR node id in one namespace, so returnedCount can exceed nodeNames.length when names collide with another node\'s id or when a workflow has duplicate node names — disambiguate by the id on each returned node',
       'mode="details" adds database queries for execution stats',
       'Workflow must exist or returns 404 error',
       'Credentials are referenced by ID but values not included'

--- a/src/mcp/tool-docs/workflow_management/n8n-get-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-get-workflow.ts
@@ -13,6 +13,7 @@ export const n8nGetWorkflowDoc: ToolDocumentation = {
       'mode="details": Full workflow + execution stats',
       'mode="active": Published graph that is actually running (errors if workflow was never activated)',
       'mode="structure": Just nodes and connections (topology)',
+      'mode="filtered": Full config of only the nodes in nodeNames - read one heavy node (e.g. long Code source) without the whole workflow',
       'mode="minimal": Only id, name, active status, tags'
     ]
   },
@@ -24,22 +25,26 @@ export const n8nGetWorkflowDoc: ToolDocumentation = {
 - details: Full draft + execution statistics (success/error counts, last execution time)
 - active: The published (running) graph. On older n8n versions that don't have the draft/publish split, falls back to \`workflow.nodes\` when \`active: true\` so the mode stays usable across n8n versions. Returns \`code: 'NO_ACTIVE_VERSION'\` only for inactive workflows that were never published.
 - structure: Nodes and connections only - useful for topology analysis
+- filtered: Full config of only the nodes named in \`nodeNames\` (matched by node name or node ID). Returns those nodes plus light metadata, omitting the rest of the graph. Use it to read one heavy node - e.g. a Code node with long \`jsCode\`/\`pythonCode\` - on a large workflow that would otherwise be truncated client-side when fetched whole (issue #101).
 - minimal: Just id, name, active status, and tags - fastest response`,
     parameters: {
       id: { type: 'string', required: true, description: 'Workflow ID to retrieve' },
-      mode: { type: 'string', required: false, description: 'Detail level: "full" (default), "details", "active", "structure", "minimal"' }
+      mode: { type: 'string', required: false, description: 'Detail level: "full" (default), "details", "active", "structure", "filtered", "minimal"' },
+      nodeNames: { type: 'array', required: false, description: 'Required when mode="filtered". Node names or node IDs to return with full config. Discover node names cheaply with mode="structure" first.' }
     },
     returns: `Depends on mode:
 - full: Draft workflow object (id, name, active, nodes[], connections{}, settings, createdAt, updatedAt, activeVersionId)
 - details: Full draft + executionStats (successCount, errorCount, lastExecution, etc.)
 - active: Published graph as { id, name, active, activeVersionId, versionCreatedAt, versionName, nodes[], connections{}, settings, tags, createdAt, updatedAt }. \`versionCreatedAt\` is the version row's creation time (within ~1s of the publish event in current n8n). Returns { success: false, code: 'NO_ACTIVE_VERSION' } if the workflow has no published version.
 - structure: { nodes: [...], connections: {...} } - topology only
+- filtered: { id, name, active, isArchived, nodes[] (full config of matched nodes only), nodeCount (total in workflow), returnedCount, notFound? (lookup keys that matched nothing) }
 - minimal: { id, name, active, tags, createdAt, updatedAt }`,
     examples: [
       '// Get draft workflow (default)\nn8n_get_workflow({id: "abc123"})',
       '// Get draft + execution stats\nn8n_get_workflow({id: "abc123", mode: "details"})',
       '// Get the published/running graph\nn8n_get_workflow({id: "abc123", mode: "active"})',
       '// Get just the topology\nn8n_get_workflow({id: "abc123", mode: "structure"})',
+      '// Read one heavy node without the whole workflow\nn8n_get_workflow({id: "abc123", mode: "filtered", nodeNames: ["Process Data"]})',
       '// Quick metadata check\nn8n_get_workflow({id: "abc123", mode: "minimal"})'
     ],
     useCases: [
@@ -48,17 +53,20 @@ export const n8nGetWorkflowDoc: ToolDocumentation = {
       'Inspect what is actually running in production (mode=active)',
       'Diff draft vs published before promoting (mode=full + mode=active)',
       'Clone or compare workflow structure (mode=structure)',
+      'Read a single heavy node (e.g. long Code source) on a large workflow without client-side truncation (mode=filtered)',
       'List workflows with status (mode=minimal)'
     ],
     performance: `Response times vary by mode:
 - minimal: ~20-50ms (smallest response)
 - structure: ~30-80ms (nodes + connections only)
+- filtered: ~50-200ms (fetches the workflow, returns only matched nodes - keeps the response small even when the workflow is large)
 - full: ~50-200ms (draft, no activeVersion duplicate)
 - active: ~50-200ms (single-shaped published graph)
 - details: ~100-300ms (includes execution queries)`,
     bestPractices: [
       'Use mode="minimal" when listing or checking status',
       'Use mode="structure" for workflow analysis or cloning',
+      'Use mode="structure" to discover node names, then mode="filtered" to read a specific heavy node',
       'Use mode="full" (default) when editing the draft',
       'Use mode="active" when you need to reason about what is actually running, not what is being edited',
       'Use mode="details" for debugging execution issues',
@@ -68,6 +76,7 @@ export const n8nGetWorkflowDoc: ToolDocumentation = {
       'Requires N8N_API_URL and N8N_API_KEY configured',
       'mode="full" no longer carries the nested activeVersion payload — switch to mode="active" if you previously read it from there',
       'mode="active" returns NO_ACTIVE_VERSION for workflows that were never activated',
+      'mode="filtered" requires a non-empty nodeNames array; unmatched entries are reported in notFound rather than erroring',
       'mode="details" adds database queries for execution stats',
       'Workflow must exist or returns 404 error',
       'Credentials are referenced by ID but values not included'

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -97,6 +97,7 @@ export const n8nManagementTools: ToolDefinition[] = [
         nodeNames: {
           type: 'array',
           items: { type: 'string' },
+          minItems: 1,
           description: "For mode='filtered': node names or node IDs to return with full config. Returns only matching nodes (avoids client-side truncation on large workflows with long Code-node source). Discover names with mode='structure' first."
         }
       },

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -80,7 +80,7 @@ export const n8nManagementTools: ToolDefinition[] = [
   },
   {
     name: 'n8n_get_workflow',
-    description: `Get workflow by ID with different detail levels. n8n has a draft/publish model: the workflow body holds the draft (latest edits); use mode='active' to see the published graph that is actually running. Modes: 'full' (draft + metadata), 'details' (full + execution stats), 'active' (published graph only), 'structure' (nodes/connections topology), 'minimal' (id/name/active/tags).`,
+    description: `Get workflow by ID with different detail levels. n8n has a draft/publish model: the workflow body holds the draft (latest edits); use mode='active' to see the published graph that is actually running. Modes: 'full' (draft + metadata), 'details' (full + execution stats), 'active' (published graph only), 'structure' (nodes/connections topology), 'filtered' (full config of only the nodes named in nodeNames - use to read one heavy node without the whole workflow), 'minimal' (id/name/active/tags).`,
     inputSchema: {
       type: 'object',
       properties: {
@@ -90,9 +90,14 @@ export const n8nManagementTools: ToolDefinition[] = [
         },
         mode: {
           type: 'string',
-          enum: ['full', 'details', 'structure', 'minimal', 'active'],
+          enum: ['full', 'details', 'structure', 'minimal', 'active', 'filtered'],
           default: 'full',
-          description: 'Detail level: full=draft + metadata (activeVersionId pointer kept, heavy activeVersion payload stripped), details=full+execution stats, active=published graph (errors if workflow has no live version), structure=nodes/connections topology, minimal=metadata only'
+          description: 'Detail level: full=draft + metadata (activeVersionId pointer kept, heavy activeVersion payload stripped), details=full+execution stats, active=published graph (errors if workflow has no live version), structure=nodes/connections topology, filtered=full config of only the nodes listed in nodeNames, minimal=metadata only'
+        },
+        nodeNames: {
+          type: 'array',
+          items: { type: 'string' },
+          description: "For mode='filtered': node names or node IDs to return with full config. Returns only matching nodes (avoids client-side truncation on large workflows with long Code-node source). Discover names with mode='structure' first."
         }
       },
       required: ['id']

--- a/tests/unit/mcp/get-workflow-mode-dispatch.test.ts
+++ b/tests/unit/mcp/get-workflow-mode-dispatch.test.ts
@@ -9,6 +9,7 @@ const handlerMocks = vi.hoisted(() => ({
   handleGetWorkflowStructure: vi.fn().mockResolvedValue({ success: true, data: { mode: 'structure' } }),
   handleGetWorkflowMinimal: vi.fn().mockResolvedValue({ success: true, data: { mode: 'minimal' } }),
   handleGetWorkflowActive: vi.fn().mockResolvedValue({ success: true, data: { mode: 'active' } }),
+  handleGetWorkflowFiltered: vi.fn().mockResolvedValue({ success: true, data: { mode: 'filtered' } }),
 }));
 
 vi.mock('../../../src/mcp/handlers-n8n-manager', async (importOriginal) => {
@@ -70,5 +71,26 @@ describe('n8n_get_workflow mode dispatch', () => {
 
     expect(handlerMocks.handleGetWorkflowDetails).toHaveBeenCalledTimes(1);
     expect(handlerMocks.handleGetWorkflowActive).not.toHaveBeenCalled();
+  });
+
+  it('routes mode="filtered" to handleGetWorkflowFiltered', async () => {
+    // The global afterEach (tests/setup/global-setup.ts) runs vi.restoreAllMocks(), which
+    // strips the hoisted mockResolvedValue after the first test. Re-apply it here so the
+    // returned-data assertion is order-independent.
+    handlerMocks.handleGetWorkflowFiltered.mockResolvedValue({ success: true, data: { mode: 'filtered' } });
+
+    const result = await server.testExecuteTool('n8n_get_workflow', { id: 'wf-1', mode: 'filtered', nodeNames: ['Code'] });
+
+    expect(handlerMocks.handleGetWorkflowFiltered).toHaveBeenCalledTimes(1);
+    expect(handlerMocks.handleGetWorkflow).not.toHaveBeenCalled();
+    expect(result.data.mode).toBe('filtered');
+  });
+
+  it('still routes mode="filtered" to its handler when nodeNames is absent (handler does the Zod check)', async () => {
+    // The dispatch layer only requires id; nodeNames is validated inside the handler so a
+    // missing value yields a graceful { success: false } rather than a thrown dispatch error.
+    await server.testExecuteTool('n8n_get_workflow', { id: 'wf-1', mode: 'filtered' });
+
+    expect(handlerMocks.handleGetWorkflowFiltered).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/mcp/get-workflow-tool.test.ts
+++ b/tests/unit/mcp/get-workflow-tool.test.ts
@@ -17,9 +17,11 @@ describe('n8n_get_workflow tool definition', () => {
   });
 
   it('declares a nodeNames array param for mode="filtered"', () => {
-    const nodeNamesSchema = tool!.inputSchema.properties?.nodeNames as { type?: string; items?: { type?: string } };
+    const nodeNamesSchema = tool!.inputSchema.properties?.nodeNames as { type?: string; items?: { type?: string }; minItems?: number };
     expect(nodeNamesSchema?.type).toBe('array');
     expect(nodeNamesSchema?.items?.type).toBe('string');
+    // Mirror the handler's Zod .min(1) so JSON-schema clients validate the same constraint.
+    expect(nodeNamesSchema?.minItems).toBe(1);
   });
 
   it('opts the tool above the Claude Code default per-tool size cap (issue #777)', () => {

--- a/tests/unit/mcp/get-workflow-tool.test.ts
+++ b/tests/unit/mcp/get-workflow-tool.test.ts
@@ -8,12 +8,18 @@ describe('n8n_get_workflow tool definition', () => {
     expect(tool).toBeDefined();
   });
 
-  it('exposes the active mode alongside full/details/structure/minimal', () => {
+  it('exposes the active and filtered modes alongside full/details/structure/minimal', () => {
     const modeSchema = tool!.inputSchema.properties?.mode as { enum?: string[] };
     expect(modeSchema?.enum).toEqual(
-      expect.arrayContaining(['full', 'details', 'structure', 'minimal', 'active'])
+      expect.arrayContaining(['full', 'details', 'structure', 'minimal', 'active', 'filtered'])
     );
-    expect(modeSchema?.enum).toHaveLength(5);
+    expect(modeSchema?.enum).toHaveLength(6);
+  });
+
+  it('declares a nodeNames array param for mode="filtered"', () => {
+    const nodeNamesSchema = tool!.inputSchema.properties?.nodeNames as { type?: string; items?: { type?: string } };
+    expect(nodeNamesSchema?.type).toBe('array');
+    expect(nodeNamesSchema?.items?.type).toBe('string');
   });
 
   it('opts the tool above the Claude Code default per-tool size cap (issue #777)', () => {

--- a/tests/unit/mcp/handlers-n8n-manager.test.ts
+++ b/tests/unit/mcp/handlers-n8n-manager.test.ts
@@ -1087,6 +1087,92 @@ describe('handlers-n8n-manager', () => {
     });
   });
 
+  describe('handleGetWorkflowFiltered', () => {
+    const multiNodeWorkflow = () => createTestWorkflow({
+      nodes: [
+        { id: 'node1', name: 'Start', type: 'n8n-nodes-base.start', typeVersion: 1, position: [100, 100], parameters: {} },
+        { id: 'node2', name: 'Process Data', type: 'n8n-nodes-base.code', typeVersion: 2, position: [300, 100], parameters: { jsCode: 'return items;' } },
+        { id: 'node3', name: 'Save', type: 'n8n-nodes-base.set', typeVersion: 3, position: [500, 100], parameters: { value: 'x' } },
+      ],
+    });
+
+    it('returns only the requested node with its full config', async () => {
+      mockApiClient.getWorkflow.mockResolvedValue(multiNodeWorkflow());
+
+      const result = await handlers.handleGetWorkflowFiltered({ id: 'test-workflow-id', nodeNames: ['Process Data'] });
+
+      expect(result.success).toBe(true);
+      expect(result.data.nodes).toHaveLength(1);
+      expect(result.data.nodes[0].name).toBe('Process Data');
+      expect(result.data.nodes[0].parameters).toEqual({ jsCode: 'return items;' });
+      expect(result.data.nodeCount).toBe(3);
+      expect(result.data.returnedCount).toBe(1);
+      expect(result.data).not.toHaveProperty('notFound');
+    });
+
+    it('matches by node ID as well as node name', async () => {
+      mockApiClient.getWorkflow.mockResolvedValue(multiNodeWorkflow());
+
+      const result = await handlers.handleGetWorkflowFiltered({ id: 'test-workflow-id', nodeNames: ['node3'] });
+
+      expect(result.success).toBe(true);
+      expect(result.data.nodes).toHaveLength(1);
+      expect(result.data.nodes[0].name).toBe('Save');
+    });
+
+    it('returns multiple matched nodes and reports unmatched keys in notFound', async () => {
+      mockApiClient.getWorkflow.mockResolvedValue(multiNodeWorkflow());
+
+      const result = await handlers.handleGetWorkflowFiltered({
+        id: 'test-workflow-id',
+        nodeNames: ['Start', 'Process Data', 'Ghost'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data.returnedCount).toBe(2);
+      expect(result.data.nodes.map((n: any) => n.name)).toEqual(['Start', 'Process Data']);
+      expect(result.data.notFound).toEqual(['Ghost']);
+    });
+
+    it('returns an empty node list (no notFound) is impossible: all-unmatched still reports notFound', async () => {
+      mockApiClient.getWorkflow.mockResolvedValue(multiNodeWorkflow());
+
+      const result = await handlers.handleGetWorkflowFiltered({ id: 'test-workflow-id', nodeNames: ['Nope'] });
+
+      expect(result.success).toBe(true);
+      expect(result.data.returnedCount).toBe(0);
+      expect(result.data.nodes).toEqual([]);
+      expect(result.data.notFound).toEqual(['Nope']);
+    });
+
+    it('rejects an empty nodeNames array via the Zod catch path', async () => {
+      const result = await handlers.handleGetWorkflowFiltered({ id: 'test-workflow-id', nodeNames: [] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid input');
+      expect(result.details?.errors).toBeDefined();
+    });
+
+    it('rejects a missing nodeNames param', async () => {
+      const result = await handlers.handleGetWorkflowFiltered({ id: 'test-workflow-id' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid input');
+    });
+
+    it('maps N8nApiError through the friendly-message path', async () => {
+      mockApiClient.getWorkflow.mockRejectedValue(new N8nNotFoundError('Workflow', 'non-existent'));
+
+      const result = await handlers.handleGetWorkflowFiltered({ id: 'non-existent', nodeNames: ['Start'] });
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Workflow with ID non-existent not found',
+        code: 'NOT_FOUND',
+      });
+    });
+  });
+
   describe('handleDeleteWorkflow', () => {
     it('should delete workflow successfully', async () => {
       const testWorkflow = createTestWorkflow();

--- a/tests/unit/mcp/handlers-n8n-manager.test.ts
+++ b/tests/unit/mcp/handlers-n8n-manager.test.ts
@@ -1120,6 +1120,41 @@ describe('handlers-n8n-manager', () => {
       expect(result.data.nodes[0].name).toBe('Save');
     });
 
+    it('resolves a mix of name and id keys in a single call', async () => {
+      mockApiClient.getWorkflow.mockResolvedValue(multiNodeWorkflow());
+
+      // "Start" matches by name, "node2" matches by id - both must resolve and neither
+      // appears in notFound.
+      const result = await handlers.handleGetWorkflowFiltered({
+        id: 'test-workflow-id',
+        nodeNames: ['Start', 'node2'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data.returnedCount).toBe(2);
+      expect(result.data.nodes.map((n: any) => n.name)).toEqual(['Start', 'Process Data']);
+      expect(result.data).not.toHaveProperty('notFound');
+    });
+
+    it('returns every node sharing a duplicated name (returnedCount can exceed the key count)', async () => {
+      // n8n's editor enforces unique names, but imported/API-created workflows can carry
+      // duplicates. Pin the best-effort behavior: a single key returns all matches, so the
+      // caller must disambiguate by id. (Documented as a pitfall on the tool.)
+      mockApiClient.getWorkflow.mockResolvedValue(createTestWorkflow({
+        nodes: [
+          { id: 'a', name: 'Twin', type: 'n8n-nodes-base.set', typeVersion: 1, position: [0, 0], parameters: { v: 1 } },
+          { id: 'b', name: 'Twin', type: 'n8n-nodes-base.set', typeVersion: 1, position: [0, 0], parameters: { v: 2 } },
+        ],
+      }));
+
+      const result = await handlers.handleGetWorkflowFiltered({ id: 'test-workflow-id', nodeNames: ['Twin'] });
+
+      expect(result.success).toBe(true);
+      expect(result.data.returnedCount).toBe(2);
+      expect(result.data.nodes.map((n: any) => n.id)).toEqual(['a', 'b']);
+      expect(result.data).not.toHaveProperty('notFound');
+    });
+
     it('returns multiple matched nodes and reports unmatched keys in notFound', async () => {
       mockApiClient.getWorkflow.mockResolvedValue(multiNodeWorkflow());
 
@@ -1134,7 +1169,7 @@ describe('handlers-n8n-manager', () => {
       expect(result.data.notFound).toEqual(['Ghost']);
     });
 
-    it('returns an empty node list (no notFound) is impossible: all-unmatched still reports notFound', async () => {
+    it('reports every key in notFound when nothing matches', async () => {
       mockApiClient.getWorkflow.mockResolvedValue(multiNodeWorkflow());
 
       const result = await handlers.handleGetWorkflowFiltered({ id: 'test-workflow-id', nodeNames: ['Nope'] });


### PR DESCRIPTION
## Summary

Adds a `mode="filtered"` to `n8n_get_workflow` that returns the full config of only the node(s) named in a new `nodeNames` parameter, instead of the entire workflow.

Closes #101.

Addresses the request in [this comment](https://github.com/czlonkowski/n8n-mcp/issues/101#issuecomment-4737949605) from @MiRaIOMeZaSu: on large workflows with long Code-node source, `mode="full"`/`mode="active"` can return a payload big enough to be **truncated client-side**, leaving `jsCode`/`pythonCode` unreadable. There was previously no way to fetch a single node's full config — `structure` gives names cheaply but strips `parameters`, while `full`/`active` are exactly the payloads that get truncated. The original issue (hitting max conversation length while iterating on large workflows) has the same root cause: no way to pull just the node you need.

## What it does

- New `mode="filtered"` on `n8n_get_workflow`, requiring a `nodeNames: string[]` (min 1).
- `nodeNames` entries match against **node name OR node ID**.
- Returns only the matched nodes (full config) plus light metadata: `id`, `name`, `active`, `isArchived`, `nodes[]`, `nodeCount` (total in workflow), `returnedCount`, and `notFound` (lookup keys that matched nothing — partial requests stay transparent).
- Omits `connections` and the rest of the graph by design, so the response stays small even on large workflows.

Recommended flow: `mode="structure"` to discover node names → `mode="filtered"` to pull the specific heavy node.

```js
// Discover node names cheaply
n8n_get_workflow({ id: "abc123", mode: "structure" })
// Read one heavy Code node without the whole workflow
n8n_get_workflow({ id: "abc123", mode: "filtered", nodeNames: ["Process Data"] })
```

## Design notes

- Mirrors the existing `n8n_executions` `mode="filtered"` + `nodeNames` precedent for consistency.
- `nodeNames` is validated by the handler's Zod schema (`.min(1)`), which returns a graceful `{ success: false, error: "Invalid input" }` — same pattern as every other mode. The dispatch layer only requires `id`. The JSON schema also encodes `minItems: 1` so JSON-schema clients validate the same constraint.
- Name and ID share one match namespace, so `returnedCount` can exceed `nodeNames.length` on an id/name collision or a workflow with duplicate node names — documented as a tool pitfall; callers disambiguate by the `id` on each returned node.

## Changes

- `src/mcp/tools-n8n-manager.ts` — add `filtered` to the mode enum, add `nodeNames` param (`minItems: 1`), update description.
- `src/mcp/handlers-n8n-manager.ts` — new `handleGetWorkflowFiltered`.
- `src/mcp/server.ts` — dispatch `mode="filtered"`.
- `src/mcp/tool-docs/workflow_management/n8n-get-workflow.ts` — document the new mode, param, returns shape, and pitfalls.
- Version bumped 2.58.0 → 2.59.0 (`package.json` + `package.runtime.json`); CHANGELOG updated.

## Testing

- `npm run build` + `npm run typecheck` clean.
- Unit tests for `handleGetWorkflowFiltered` (match by name, by ID, mixed name+id in one call, duplicate names, multi-node + `notFound`, all-unmatched, empty/missing `nodeNames`, API-error path) and mode-dispatch routing; schema test pins the enum and `minItems`. Full unit suite green (the only failure is the pre-existing flaky `auth-timing-safe` wall-clock variance test, unrelated — passes in isolation).
- **Live-verified against a real n8n instance** (MCP tester): match-by-name, match-by-id, multi-node + `notFound`, all-unmatched, and missing/empty `nodeNames` (graceful "Invalid input") all pass, with full `jsCode` returned and no regression to `structure`/`full`.

## Review

- code-simplifier: collapsed the `notFound` computation to a single `matchedKeys` set.
- code-reviewer: no Critical/High; applied the doc note on the name/id namespace and added the mixed-key and duplicate-name tests.
- Copilot: added `minItems: 1` to the JSON schema. (Its other suggestion — stripping `activeVersion` for memory — is a no-op here: the API client has already parsed the full payload before the handler runs, and the filtered response builds a fresh object that never includes `activeVersion`.)

Requested by @MiRaIOMeZaSu (#101).

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)