### PR TITLE
fix(http): opt-in concurrent MCP sessions per instance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,6 +140,16 @@ ENABLE_MULTI_TENANT=false
 # Default: instance
 # MULTI_TENANT_SESSION_STRATEGY=instance
 
+# Allow multiple concurrent sessions for the SAME instance (instance strategy).
+# By default each `initialize` evicts other live sessions for that instance,
+# assuming one client per instance. Set to "true" when several MCP clients
+# (e.g. an automation agent + an IDE + a web client) target one instance at
+# once, so they don't mutually evict each other into "Session not found or
+# expired" drops. Sessions are then reclaimed by transport close, idle timeout,
+# and the N8N_MCP_MAX_SESSIONS cap instead.
+# Default: false
+# MULTI_TENANT_ALLOW_CONCURRENT_SESSIONS=false
+
 # =========================
 # N8N API CONFIGURATION
 # =========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.59.2] - 2026-06-19
+
+### Added
+
+- **`MULTI_TENANT_ALLOW_CONCURRENT_SESSIONS` env flag** (multi-tenant `instance` strategy). By default the instance strategy assumes one MCP session per instance and, on every `initialize`, eagerly evicts all other live sessions for that same instance (`reason: instance_reconnect`). When several MCP clients target the same instance concurrently — e.g. an automation agent, an IDE, and a web client all authenticated as one tenant — each client's `initialize` destroys the others' active sessions, so their next tool call fast-fails with `-32000 "Session not found or expired"` and the client reports a dropped connection. Set `MULTI_TENANT_ALLOW_CONCURRENT_SESSIONS=true` to skip the eager eviction and let concurrent same-instance sessions coexist; sessions are then reclaimed only by their natural lifecycle (transport close, the `SESSION_TIMEOUT_MINUTES` idle sweep, and the `N8N_MCP_MAX_SESSIONS` cap). Default `false` preserves the previous one-session-per-instance behavior. Hosted multi-client deployments should enable it.
+
+Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en
+
 ## [2.59.1] - 2026-06-19
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.59.1",
+  "version": "2.59.2",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.59.1",
+  "version": "2.59.2",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -604,11 +604,21 @@ export class SingleSessionHTTPServer {
 
           const isMultiTenantEnabled = process.env.ENABLE_MULTI_TENANT === 'true';
           const sessionStrategy = process.env.MULTI_TENANT_SESSION_STRATEGY || 'instance';
+          // Opt-in: let multiple MCP clients (e.g. an automation agent + an IDE +
+          // a web client) hold concurrent sessions for the SAME instance. The
+          // eager cleanup below assumes one session per instance and evicts the
+          // rest on every initialize — with several concurrent clients that means
+          // each one's initialize destroys the others' live sessions, surfacing as
+          // "Session not found or expired" drops. When enabled, sessions are
+          // reclaimed only by their natural lifecycle (transport close, idle
+          // timeout, MAX_SESSIONS cap) instead of by this eager pass.
+          const allowConcurrentSessions = process.env.MULTI_TENANT_ALLOW_CONCURRENT_SESSIONS === 'true';
 
           // EAGER CLEANUP: Remove existing sessions for the same instance only
-          // when instance-scoped sessions are requested. Shared strategy allows
-          // multiple MCP clients to use the same tenant/instance concurrently.
-          if (isMultiTenantEnabled && sessionStrategy === 'instance' && instanceContext?.instanceId) {
+          // when instance-scoped sessions are requested. Shared strategy, and the
+          // concurrent-sessions opt-in, both allow multiple MCP clients to use the
+          // same tenant/instance concurrently.
+          if (isMultiTenantEnabled && sessionStrategy === 'instance' && !allowConcurrentSessions && instanceContext?.instanceId) {
             const sessionsToRemove: string[] = [];
             for (const [existingSessionId, context] of Object.entries(this.sessionContexts)) {
               if (context?.instanceId === instanceContext.instanceId) {

--- a/tests/unit/http-server-session-management.test.ts
+++ b/tests/unit/http-server-session-management.test.ts
@@ -419,6 +419,50 @@ describe('HTTP Server Session Management', () => {
       expect((server as any).transports['session-a']).toBeUndefined();
       expect(oldTransport.close).toHaveBeenCalled();
     });
+
+    it('should keep same-instance sessions alive in instance mode when concurrent sessions are allowed', async () => {
+      mockConsoleManager.wrapOperation.mockImplementation(async (fn: () => Promise<any>) => {
+        return await fn();
+      });
+      process.env.ENABLE_MULTI_TENANT = 'true';
+      process.env.MULTI_TENANT_SESSION_STRATEGY = 'instance';
+      // Opt-in: allow several MCP clients to target the same instance at once
+      // (e.g. an automation agent + an IDE + a web client), instead of each
+      // initialize evicting the others' live sessions.
+      process.env.MULTI_TENANT_ALLOW_CONCURRENT_SESSIONS = 'true';
+      server = new SingleSessionHTTPServer();
+
+      const instanceContext = {
+        instanceId: 'tenant-a'
+      };
+
+      const existingTransport = {
+        close: vi.fn().mockResolvedValue(undefined)
+      };
+      (server as any).transports['session-a'] = existingTransport;
+      (server as any).servers['session-a'] = {};
+      (server as any).sessionMetadata['session-a'] = {
+        lastAccess: new Date(),
+        createdAt: new Date()
+      };
+      (server as any).sessionContexts['session-a'] = instanceContext;
+
+      const second = createMockReqRes();
+      second.req.method = 'POST';
+      second.req.body = {
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {},
+        id: 2
+      };
+
+      await server.handleRequest(second.req as any, second.res as any, instanceContext);
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // The pre-existing same-instance session must survive the new initialize.
+      expect((server as any).transports['session-a']).toBe(existingTransport);
+      expect(existingTransport.close).not.toHaveBeenCalled();
+    });
   });
 
   describe('Session Expiration and Cleanup', () => {

--- a/tests/unit/http-server-session-management.test.ts
+++ b/tests/unit/http-server-session-management.test.ts
@@ -457,7 +457,9 @@ describe('HTTP Server Session Management', () => {
       };
 
       await server.handleRequest(second.req as any, second.res as any, instanceContext);
-      await new Promise(resolve => setTimeout(resolve, 10));
+      // One macrotask tick drains the mocked onsessioninitialized callback
+      // (scheduled with setTimeout(0)); no real delay is needed.
+      await new Promise(resolve => setTimeout(resolve, 0));
 
       // The pre-existing same-instance session must survive the new initialize.
       expect((server as any).transports['session-a']).toBe(existingTransport);


### PR DESCRIPTION
## Summary

Multi-tenant `instance` session strategy evicts all other live sessions for an instance on every `initialize` (`reason: instance_reconnect`), assuming **one session per instance**. When several MCP clients target the same instance concurrently — e.g. an automation agent + an IDE + a web client authenticated as one tenant — each client's `initialize` destroys the others' active sessions, so their next tool call fast-fails with `-32000 "Session not found or expired"` and the client reports a dropped connection.

This adds an opt-in flag **`MULTI_TENANT_ALLOW_CONCURRENT_SESSIONS=true`** that skips the eager per-instance eviction, so concurrent same-instance sessions coexist. They're reclaimed by their natural lifecycle (transport `onclose`, the `SESSION_TIMEOUT_MINUTES` idle sweep, and the `N8N_MCP_MAX_SESSIONS` cap). **Default `false` preserves the previous one-session-per-instance behavior** — zero change for existing deployments.

## Changes

- `src/http-server-single-session.ts`: gate the eager `instance_reconnect` cleanup behind `!allowConcurrentSessions`.
- `tests/unit/http-server-session-management.test.ts`: new test asserting same-instance sessions survive a concurrent `initialize` when the flag is on (mirror of the existing eviction test, which still passes by default).
- `.env.example`, `CHANGELOG.md`: document the flag.
- version bump 2.59.1 → 2.59.2.

## Safety notes

- The eager cleanup is **not** load-bearing for the #542/#554 per-session memory leak (that was fixed by the `SharedDatabase` singleton); per-session footprint stays bounded and is freed by `removeSession`.
- Tenant isolation is preserved — each session keeps its own `instanceContext`/`configHash`; the eviction only ever matched same-`instanceId` sessions.
- For operators enabling it: `N8N_MCP_MAX_SESSIONS` is a global cap, so size it with headroom (and optionally lower `SESSION_TIMEOUT_MINUTES`) for the few-sessions-per-tenant steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)