### PR TITLE
fix(generators): emit valid IF v2 and AI Agent configs (#374)

### DIFF
--- a/src/services/example-generator.ts
+++ b/src/services/example-generator.ts
@@ -443,9 +443,19 @@ return results;`
     },
     
     // If - Conditional logic
+    // IF v2.2+ requires conditions.options (version/leftValue/caseSensitive/typeValidation),
+    // a combinator ('and'|'or'), and a stable id on each condition;
+    // see node-sanitizer.ts / n8n-validation.ts / type-structures.ts.
     'nodes-base.if': {
       minimal: {
         conditions: {
+          options: {
+            version: 2,
+            leftValue: '',
+            caseSensitive: true,
+            typeValidation: 'strict'
+          },
+          combinator: 'and',
           conditions: [
             {
               id: '1',
@@ -461,6 +471,13 @@ return results;`
       },
       common: {
         conditions: {
+          options: {
+            version: 2,
+            leftValue: '',
+            caseSensitive: true,
+            typeValidation: 'strict'
+          },
+          combinator: 'and',
           conditions: [
             {
               id: '1',

--- a/src/services/task-templates.ts
+++ b/src/services/task-templates.ts
@@ -440,22 +440,24 @@ try {
     'ai_agent_workflow': {
       task: 'ai_agent_workflow',
       description: 'Create an AI agent that can use tools',
-      nodeType: 'nodes-langchain.agent',
+      nodeType: '@n8n/n8n-nodes-langchain.agent',
       configuration: {
-        text: '',
-        outputType: 'output',
-        systemMessage: 'You are a helpful assistant.'
+        promptType: 'define',
+        text: '={{ $json.query }}',
+        options: {
+          systemMessage: 'You are a helpful assistant.'
+        }
       },
       userMustProvide: [
         {
           property: 'text',
           description: 'The input prompt for the agent',
-          example: '{{ $json.query }}'
+          example: '={{ $json.query }}'
         }
       ],
       optionalEnhancements: [
         {
-          property: 'systemMessage',
+          property: 'options.systemMessage',
           description: 'Customize the agent\'s behavior'
         }
       ],
@@ -500,9 +502,20 @@ return results;`
       description: 'Filter items based on conditions',
       nodeType: 'nodes-base.if',
       configuration: {
+        // IF v2.2+ requires conditions.options, a combinator ('and'|'or'), and a
+        // stable id per condition; see node-sanitizer.ts / n8n-validation.ts /
+        // type-structures.ts for the enforced shape.
         conditions: {
+          options: {
+            version: 2,
+            leftValue: '',
+            caseSensitive: true,
+            typeValidation: 'strict'
+          },
+          combinator: 'and',
           conditions: [
             {
+              id: '1',
               leftValue: '',
               rightValue: '',
               operator: {
@@ -684,11 +697,13 @@ return results;`
     'multi_tool_ai_agent': {
       task: 'multi_tool_ai_agent',
       description: 'AI agent with multiple tools for complex automation',
-      nodeType: 'nodes-langchain.agent',
+      nodeType: '@n8n/n8n-nodes-langchain.agent',
       configuration: {
+        promptType: 'define',
         text: '={{ $json.query }}',
-        outputType: 'output',
-        systemMessage: 'You are an intelligent assistant with access to multiple tools. Use them wisely to complete tasks.'
+        options: {
+          systemMessage: 'You are an intelligent assistant with access to multiple tools. Use them wisely to complete tasks.'
+        }
       },
       userMustProvide: [
         {

--- a/tests/unit/services/example-generator.test.ts
+++ b/tests/unit/services/example-generator.test.ts
@@ -1,9 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ExampleGenerator } from '@/services/example-generator';
 import type { NodeExamples } from '@/services/example-generator';
+import { validateConditionNodeStructure } from '@/services/n8n-validation';
+import { validateNodeMetadata } from '@/services/node-sanitizer';
+import { EnhancedConfigValidator } from '@/services/enhanced-config-validator';
+import type { WorkflowNode } from '@/types/n8n-api';
 
 // Mock the database
 vi.mock('better-sqlite3');
+
+// The IF node declares `conditions` as a `filter`-type property (verified in the
+// node DB), which is what makes EnhancedConfigValidator enforce the combinator field.
+const IF_FILTER_PROPERTIES = [
+  { name: 'conditions', displayName: 'Conditions', type: 'filter' }
+];
 
 describe('ExampleGenerator', () => {
   beforeEach(() => {
@@ -282,6 +292,60 @@ describe('ExampleGenerator', () => {
       expect(examples.minimal?.alwaysOutputData).toBe(true);
       expect(examples.common?.responseCode).toBe(200);
     });
+  });
+
+  // Regression for issue #374: the IF example previously omitted conditions.options
+  // and the combinator field, so generated configs failed n8n's own validators and
+  // rendered an empty IF node. Run every IF example variant through the
+  // condition-node validator, sanitizer metadata check, and EnhancedConfigValidator
+  // (the one users actually hit, which enforces the filter combinator).
+  describe('issue #374 — IF examples are valid for v2.2+', () => {
+    it.each(['minimal', 'common'] as const)(
+      'IF example "%s" passes all validators including EnhancedConfigValidator',
+      (variant) => {
+        const examples = ExampleGenerator.getExamples('nodes-base.if');
+        const config = examples[variant]!;
+        expect(config).toBeDefined();
+
+        const node: WorkflowNode = {
+          id: 'if-node',
+          name: 'IF',
+          type: 'n8n-nodes-base.if',
+          typeVersion: 2.2,
+          position: [0, 0],
+          parameters: config
+        };
+
+        expect(validateConditionNodeStructure(node)).toEqual([]);
+        expect(validateNodeMetadata(node)).toEqual([]);
+
+        // EnhancedConfigValidator enforces the filter `combinator` field, which was
+        // still missing before this fix. Without combinator this result is invalid.
+        const result = EnhancedConfigValidator.validateWithMode(
+          'nodes-base.if',
+          config,
+          IF_FILTER_PROPERTIES,
+          'operation',
+          'ai-friendly'
+        );
+        expect(result.valid).toBe(true);
+        expect(
+          result.errors.filter(e => /combinator|filter/i.test(`${e.property} ${e.message}`))
+        ).toEqual([]);
+
+        // The previously-missing options block and combinator must be present.
+        expect(config.conditions.options).toEqual({
+          version: 2,
+          leftValue: '',
+          caseSensitive: true,
+          typeValidation: 'strict'
+        });
+        expect(config.conditions.combinator).toBe('and');
+        for (const c of config.conditions.conditions) {
+          expect(c).toHaveProperty('id');
+        }
+      }
+    );
   });
 
   describe('getTaskExample', () => {

--- a/tests/unit/services/task-templates.test.ts
+++ b/tests/unit/services/task-templates.test.ts
@@ -1,9 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TaskTemplates } from '@/services/task-templates';
 import type { TaskTemplate } from '@/services/task-templates';
+import { validateConditionNodeStructure } from '@/services/n8n-validation';
+import { validateNodeMetadata } from '@/services/node-sanitizer';
+import { EnhancedConfigValidator } from '@/services/enhanced-config-validator';
+import type { WorkflowNode } from '@/types/n8n-api';
 
 // Mock the database
 vi.mock('better-sqlite3');
+
+// Property definitions matching how the real nodes declare these fields, so
+// EnhancedConfigValidator runs its filter/structure checks the way users hit them.
+// The IF node declares `conditions` as a `filter`-type property (verified in the node DB),
+// which is what triggers the combinator requirement.
+const IF_FILTER_PROPERTIES = [
+  { name: 'conditions', displayName: 'Conditions', type: 'filter' }
+];
+const AGENT_PROPERTIES = [
+  { name: 'promptType', displayName: 'Prompt', type: 'options', options: [{ value: 'define' }, { value: 'auto' }] },
+  { name: 'text', displayName: 'Text', type: 'string' },
+  { name: 'options', displayName: 'Options', type: 'collection' }
+];
 
 describe('TaskTemplates', () => {
   beforeEach(() => {
@@ -121,8 +138,16 @@ describe('TaskTemplates', () => {
     it('should have AI agent workflow template', () => {
       const template = TaskTemplates.getTaskTemplate('ai_agent_workflow');
 
-      expect(template?.nodeType).toBe('nodes-langchain.agent');
-      expect(template?.configuration).toHaveProperty('systemMessage');
+      // Must use the full package-prefixed node type and the current
+      // promptType + options.systemMessage shape (see issue #374).
+      expect(template?.nodeType).toBe('@n8n/n8n-nodes-langchain.agent');
+      expect(template?.configuration).toMatchObject({
+        promptType: 'define',
+        text: '={{ $json.query }}',
+        options: { systemMessage: expect.any(String) }
+      });
+      expect(template?.configuration).not.toHaveProperty('systemMessage');
+      expect(template?.configuration).not.toHaveProperty('outputType');
     });
 
     it('should have error handling pattern templates', () => {
@@ -365,5 +390,87 @@ describe('TaskTemplates', () => {
       // AI calls: longer waits for rate limits
       expect(aiTemplate?.configuration.waitBetweenTries).toBe(5000);
     });
+  });
+
+  // Regression for issue #374: the static generator emitted invalid IF and
+  // AI Agent configs. These tests run the generated configs through the same
+  // validators n8n-mcp enforces so the bug cannot silently return.
+  describe('issue #374 — generated configs are valid', () => {
+    it('filter_data IF config passes the condition-node validator and sanitizer metadata check', () => {
+      const template = TaskTemplates.getTaskTemplate('filter_data');
+      expect(template).toBeDefined();
+
+      // IF v2.2+ is what the validator/sanitizer guard on; the template config
+      // must satisfy the conditions.options + per-condition id requirements.
+      const node: WorkflowNode = {
+        id: 'filter-data-node',
+        name: 'Filter Data',
+        type: 'n8n-nodes-base.if',
+        typeVersion: 2.2,
+        position: [0, 0],
+        parameters: template!.configuration
+      };
+
+      expect(validateConditionNodeStructure(node)).toEqual([]);
+      expect(validateNodeMetadata(node)).toEqual([]);
+
+      // EnhancedConfigValidator is the validator users actually hit. It requires a
+      // `combinator` on filter-type properties — the field that was still missing
+      // before this fix. This assertion fails without combinator, passes with it.
+      const result = EnhancedConfigValidator.validateWithMode(
+        'nodes-base.if',
+        template!.configuration,
+        IF_FILTER_PROPERTIES,
+        'operation',
+        'ai-friendly'
+      );
+      expect(result.valid).toBe(true);
+      expect(
+        result.errors.filter(e => /combinator|filter/i.test(`${e.property} ${e.message}`))
+      ).toEqual([]);
+
+      // Explicit checks on the fields that were previously missing.
+      const conditions = template!.configuration.conditions;
+      expect(conditions.options).toEqual({
+        version: 2,
+        leftValue: '',
+        caseSensitive: true,
+        typeValidation: 'strict'
+      });
+      expect(conditions.combinator).toBe('and');
+      expect(conditions.conditions[0]).toHaveProperty('id');
+    });
+
+    it.each(['ai_agent_workflow', 'multi_tool_ai_agent'])(
+      '%s uses the package-prefixed agent type and current promptType/options shape',
+      (taskName) => {
+        const template = TaskTemplates.getTaskTemplate(taskName);
+        expect(template).toBeDefined();
+
+        // Correct, package-prefixed node type (was missing the @n8n/ prefix).
+        expect(template!.nodeType).toBe('@n8n/n8n-nodes-langchain.agent');
+
+        // Current shape: promptType + text + options.systemMessage, matching the
+        // 1.5k real-world agent nodes in the template DB (systemMessage lives
+        // under the options collection in the current node).
+        expect(template!.configuration).toMatchObject({
+          promptType: 'define',
+          text: expect.stringContaining('{{'),
+          options: { systemMessage: expect.any(String) }
+        });
+
+        // Validate through EnhancedConfigValidator: the options.systemMessage shape
+        // must produce a clean result. (The node-specific-validators top-level
+        // systemMessage hint is only an info-level suggestion and must not flip valid.)
+        const result = EnhancedConfigValidator.validateWithMode(
+          template!.nodeType,
+          template!.configuration,
+          AGENT_PROPERTIES,
+          'operation',
+          'ai-friendly'
+        );
+        expect(result.valid).toBe(true);
+      }
+    );
   });
 });


### PR DESCRIPTION
## Problem (#374)

The static example/template generators emitted node configurations that n8n rejects:

1. **IF node** — the generated `conditions` object omitted the `conditions.options` block (`version` / `leftValue` / `caseSensitive` / `typeValidation`) and the per-condition `id` that IF v2+ requires. The result rendered as an empty IF node and failed the project's own `node-sanitizer` checks.
2. **AI Agent** — task templates used `nodeType: 'nodes-langchain.agent'` (missing the `@n8n/` package prefix) with a flat `text/outputType/systemMessage` config instead of the current `promptType` + `options.systemMessage` shape.

## Fix

- `src/services/example-generator.ts` — add the required `conditions.options` block + condition `id`s to the `nodes-base.if` minimal/common examples.
- `src/services/task-templates.ts` — same fix for the `filter_data` template; correct the AI Agent `nodeType` to `@n8n/n8n-nodes-langchain.agent` and switch to the `promptType` + `options.systemMessage` shape.

## Tests

- Regression tests run the generated IF example and task templates through the validators and assert valid output.
- `npm run typecheck` clean; `example-generator` + `task-templates` suites pass (76 tests).

Closes #374

Conceived by Romuald Członkowski — https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)