### PR TITLE
fix(security): require complete tenant context on session restore (#844)

### DIFF
--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -1674,8 +1674,10 @@ export class SingleSessionHTTPServer {
    * point the transport and server will be initialized normally.
    *
    * @security Restored contexts are validated synchronously via
-   * validateInstanceContext. Embedders are responsible for not persisting
-   * hostnames they do not trust. See GHSA-4ggg-h7ph-26qr.
+   * validateInstanceContext, and must additionally carry BOTH n8nApiUrl and
+   * n8nApiKey — partial tenant contexts are rejected (GHSA-2cf7-hpwf-47h9
+   * hardening, #844). Embedders are responsible for not persisting hostnames
+   * they do not trust. See GHSA-4ggg-h7ph-26qr.
    *
    * @param sessions - Array of session state objects from exportSessionState()
    * @returns Number of sessions successfully restored
@@ -1744,6 +1746,25 @@ export class SingleSessionHTTPServer {
           const reason = validation.errors?.join(', ') || 'invalid context';
           logger.warn(
             `Skipping session ${sessionState.sessionId} - invalid context: ${reason}`
+          );
+          logSecurityEvent('session_restore_failed', {
+            sessionId: sessionState.sessionId,
+            reason
+          });
+          continue;
+        }
+
+        // SECURITY (GHSA-2cf7-hpwf-47h9 hardening, #844): require BOTH tenant
+        // credentials, mirroring the export-side guard. validateInstanceContext
+        // checks each field only when it is !== undefined, so a partial context
+        // carrying only one of n8nApiUrl/n8nApiKey passes validation and would
+        // restore as a partial tenant identity. The earlier no-context check
+        // above already skips sessions that carry no context at all, so this
+        // guard only applies to sessions whose context is present but incomplete.
+        if (!sessionState.context.n8nApiUrl || !sessionState.context.n8nApiKey) {
+          const reason = 'restored context missing required tenant credentials (both n8nApiUrl and n8nApiKey are required)';
+          logger.warn(
+            `Skipping session ${sessionState.sessionId} - ${reason}`
           );
           logSecurityEvent('session_restore_failed', {
             sessionId: sessionState.sessionId,

--- a/tests/unit/http-server/session-persistence.test.ts
+++ b/tests/unit/http-server/session-persistence.test.ts
@@ -4,13 +4,35 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the logger so we can assert on security-event emission. logSecurityEvent
+// in http-server-single-session.ts routes events through logger.info with a
+// `[SECURITY] <event>` prefix, so spying on logger.info lets us verify which
+// security events fire during restore.
+vi.mock('../../../src/utils/logger', () => ({
+  Logger: vi.fn().mockImplementation(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })),
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}));
+
 import { SingleSessionHTTPServer } from '../../../src/http-server-single-session';
 import { SessionState } from '../../../src/types/session-state';
+import { logger } from '../../../src/utils/logger';
 
 describe('SingleSessionHTTPServer - Session Persistence', () => {
   let server: SingleSessionHTTPServer;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     server = new SingleSessionHTTPServer();
   });
 
@@ -492,6 +514,163 @@ describe('SingleSessionHTTPServer - Session Persistence', () => {
       expect(metadata.lastAccess).toBeInstanceOf(Date);
       expect(metadata.createdAt.toISOString()).toBe(createdAt);
       expect(metadata.lastAccess.toISOString()).toBe(lastAccess);
+    });
+  });
+
+  describe('restoreSessionState() - partial tenant context hardening (#844)', () => {
+    // Helper: find logSecurityEvent emissions for a given event name.
+    // logSecurityEvent routes through logger.info(`[SECURITY] <event>`, details),
+    // so we inspect logger.info calls for the prefixed message.
+    const securityEventsFor = (event: string) =>
+      vi.mocked(logger.info).mock.calls.filter(
+        (call) => call[0] === `[SECURITY] ${event}`
+      );
+
+    it('should reject a context carrying only n8nApiUrl (key absent)', () => {
+      // Field is entirely absent (undefined), not empty string. This passes
+      // validateInstanceContext (which only checks fields that are !== undefined)
+      // but must still be rejected as a partial tenant identity.
+      const sessions: SessionState[] = [
+        {
+          sessionId: 'url-only-session',
+          metadata: {
+            createdAt: new Date().toISOString(),
+            lastAccess: new Date().toISOString()
+          },
+          context: {
+            n8nApiUrl: 'https://url-only.example.com',
+            instanceId: 'partial-instance'
+            // n8nApiKey absent
+          } as any
+        }
+      ];
+
+      const count = server.restoreSessionState(sessions);
+
+      expect(count).toBe(0);
+      const serverAny = server as any;
+      expect(serverAny.sessionMetadata['url-only-session']).toBeUndefined();
+      expect(serverAny.sessionContexts['url-only-session']).toBeUndefined();
+    });
+
+    it('should reject a context carrying only n8nApiKey (url absent)', () => {
+      const sessions: SessionState[] = [
+        {
+          sessionId: 'key-only-session',
+          metadata: {
+            createdAt: new Date().toISOString(),
+            lastAccess: new Date().toISOString()
+          },
+          context: {
+            n8nApiKey: 'key-only-secret',
+            instanceId: 'partial-instance'
+            // n8nApiUrl absent
+          } as any
+        }
+      ];
+
+      const count = server.restoreSessionState(sessions);
+
+      expect(count).toBe(0);
+      const serverAny = server as any;
+      expect(serverAny.sessionMetadata['key-only-session']).toBeUndefined();
+      expect(serverAny.sessionContexts['key-only-session']).toBeUndefined();
+    });
+
+    it('should emit a session_restore_failed security event for a partial context', () => {
+      const sessions: SessionState[] = [
+        {
+          sessionId: 'partial-event-session',
+          metadata: {
+            createdAt: new Date().toISOString(),
+            lastAccess: new Date().toISOString()
+          },
+          context: {
+            n8nApiUrl: 'https://partial.example.com'
+            // n8nApiKey absent
+          } as any
+        }
+      ];
+
+      server.restoreSessionState(sessions);
+
+      const events = securityEventsFor('session_restore_failed');
+      expect(events.length).toBeGreaterThanOrEqual(1);
+
+      const partialEvent = events.find(
+        (call) => (call[1] as any)?.sessionId === 'partial-event-session'
+      );
+      expect(partialEvent).toBeDefined();
+      expect((partialEvent![1] as any).reason).toContain(
+        'missing required tenant credentials'
+      );
+    });
+
+    it('should restore a complete context normally (control)', () => {
+      const sessions: SessionState[] = [
+        {
+          sessionId: 'complete-session',
+          metadata: {
+            createdAt: new Date().toISOString(),
+            lastAccess: new Date().toISOString()
+          },
+          context: {
+            n8nApiUrl: 'https://complete.example.com',
+            n8nApiKey: 'complete-key',
+            instanceId: 'complete-instance'
+          }
+        }
+      ];
+
+      const count = server.restoreSessionState(sessions);
+
+      expect(count).toBe(1);
+      const serverAny = server as any;
+      expect(serverAny.sessionMetadata['complete-session']).toBeDefined();
+      expect(serverAny.sessionContexts['complete-session']).toMatchObject({
+        n8nApiUrl: 'https://complete.example.com',
+        n8nApiKey: 'complete-key',
+        instanceId: 'complete-instance'
+      });
+
+      // The partial-context guard must NOT have fired for a complete context.
+      const events = securityEventsFor('session_restore_failed');
+      const completeEvent = events.find(
+        (call) => (call[1] as any)?.sessionId === 'complete-session'
+      );
+      expect(completeEvent).toBeUndefined();
+    });
+
+    it('should leave a no-context (single-tenant/stdio) session unaffected', () => {
+      // A session with no context at all is handled by the earlier null-context
+      // check and is skipped (not restored) WITHOUT being misclassified by the
+      // partial-credential guard. The guard must never run for it.
+      const sessions: any[] = [
+        {
+          sessionId: 'no-context-session',
+          metadata: {
+            createdAt: new Date().toISOString(),
+            lastAccess: new Date().toISOString()
+          }
+          // context omitted entirely
+        }
+      ];
+
+      const count = server.restoreSessionState(sessions);
+
+      // No-context sessions are not restorable (no instance to reconnect to).
+      expect(count).toBe(0);
+      const serverAny = server as any;
+      expect(serverAny.sessionMetadata['no-context-session']).toBeUndefined();
+
+      // The earlier `!sessionState.context` branch logs a plain warning and does
+      // NOT emit a session_restore_failed security event, so the partial-context
+      // guard provably did not run for this no-context session.
+      const events = securityEventsFor('session_restore_failed');
+      const noContextEvent = events.find(
+        (call) => (call[1] as any)?.sessionId === 'no-context-session'
+      );
+      expect(noContextEvent).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Problem (#844)

Defense-in-depth follow-up to **GHSA-2cf7-hpwf-47h9**. `restoreSessionState()` in `src/http-server-single-session.ts` validated a restored `InstanceContext` only through `validateInstanceContext()`, which checks each field **only when it is `!== undefined`**. A persisted session carrying just one of `n8nApiUrl` / `n8nApiKey` therefore passed validation and was restored as a **partial tenant identity** — an asymmetry with the export side, which already refuses to persist a partial context.

Not exploitable on a single consistent build (export won't write partial state and downstream resolution fails closed), but it closes the symmetry gap against older / divergent / tampered persisted state.

## Fix

In `restoreSessionState()`, after the existing `validateInstanceContext` and null-context checks, add a presence guard mirroring the export-side guard, reusing the existing `session_restore_failed` security event. Single-tenant / stdio sessions (no context) still pass through untouched.

## Tests

- New cases: url-only and key-only partial contexts are rejected, a `session_restore_failed` event is emitted, complete contexts restore normally, no-context sessions are unaffected.
- `npm run typecheck` clean; session-persistence suite passes (18 tests).

Closes #844

Conceived by Romuald Członkowski — https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)