### PR TITLE
docs(railway): add upfront AUTH_TOKEN "Before You Deploy" callout (#152)

### DIFF
--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -17,6 +17,22 @@ Railway deployment provides:
 - ⚡ **Auto-scaling** - Railway handles the infrastructure
 - 📊 **Built-in monitoring** - Logs and metrics included
 
+## ⚠️ Before You Deploy
+
+`AUTH_TOKEN` is **required** — the server refuses to start without it. How you handle it depends on how you deploy:
+
+> ⚠️ **Required — `AUTH_TOKEN`**: Open your service's **Variables** tab and make sure `AUTH_TOKEN` is set to a secure value of at least 32 characters:
+> ```bash
+> # Generate a secure token locally:
+> openssl rand -base64 32
+> ```
+> - **Deploying via the one-click template?** A placeholder `AUTH_TOKEN` is created for you — you **must replace** it with your own secure value (the server warns every 5 minutes until you do).
+> - **Deploying from your own repo/Dockerfile?** Railway does **not** auto-create the variable — you **must add** `AUTH_TOKEN` yourself, or the server will not start.
+>
+> Either way, Railway redeploys automatically once the variable is saved. See [Configure Security](#2-configure-security) below for the full walkthrough.
+
+> 💡 **Optional**: To enable n8n workflow-management integration, also set `N8N_API_URL` and `N8N_API_KEY`. See [Optional: n8n Integration](#optional-n8n-integration).
+
 ## 🎯 Step-by-Step Deployment
 
 ### 1. Deploy to Railway


### PR DESCRIPTION
## Problem (#152)

Railway does not auto-create custom environment variables from the deploy template, so users don't realize `AUTH_TOKEN` must be set manually — and the server won't start without it. The requirement was buried mid-flow with nothing upfront.

## Fix

Adds a prominent **"⚠️ Before You Deploy"** callout near the top of `docs/RAILWAY_DEPLOYMENT.md`, matching the file's existing callout style: `AUTH_TOKEN` must be set in Railway's Variables tab (≥32 chars, `openssl rand -base64 32`), links to the existing Configure Security walkthrough, and notes the optional `N8N_API_URL` / `N8N_API_KEY`. Docs-only. Implements the maintainer's own proposal on the issue.

Closes #152

Conceived by Romuald Członkowski — https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)