### PR TITLE
feat: MCPB bundle with generated manifest and release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,6 +265,46 @@ jobs:
           echo "id=$RELEASE_ID" >> $GITHUB_OUTPUT
           echo "upload_url=https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets{?name,label}" >> $GITHUB_OUTPUT
 
+  package-mcpb:
+    name: Package MCPB Bundle
+    runs-on: ubuntu-latest
+    needs: [detect-version-change, create-release]
+    if: needs.detect-version-change.outputs.version-changed == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        # See test.yml for the --legacy-peer-deps rationale (mappersmith / diff conflict).
+        run: npm ci --legacy-peer-deps
+
+      # Build so dist/mcp/index.js exists at pack time: `mcpb pack` runs existsSync
+      # on the manifest entry_point against the source dir, and dist/ is gitignored.
+      - name: Build project
+        run: npm run build
+
+      - name: Generate MCPB manifest from package.json + tool registry
+        run: npm run generate:mcpb-manifest
+
+      - name: Validate and pack MCPB bundle
+        run: |
+          VERSION="${{ needs.detect-version-change.outputs.new-version }}"
+          npx -y @anthropic-ai/mcpb validate manifest.json
+          npx -y @anthropic-ai/mcpb pack . "n8n-mcp-${VERSION}.mcpb"
+
+      - name: Upload MCPB bundle to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.detect-version-change.outputs.new-version }}"
+          gh release upload "v$VERSION" "n8n-mcp-${VERSION}.mcpb" --clobber
+
   build-and-verify:
     name: Build and Verify
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ out/
 .cache/
 .parcel-cache/
 
+# MCPB bundle (built artifact — produced by `mcpb pack`, attached to releases)
+*.mcpb
+
 # IDE and editor files
 .vscode/
 .idea/

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,0 +1,15 @@
+# MCPB bundle ignore file (.mcpbignore) — gitignore semantics, combined with
+# mcpb's built-in default exclusions (node_modules, .git, *.map, lockfiles, ...).
+#
+# This is an npx-based bundle: the server is fetched from npm at runtime via
+# `npx -y n8n-mcp` (see manifest.json), so NO project code ships inside the .mcpb.
+# The packed bundle should contain only manifest.json (and icon.png, if added).
+#
+# Strategy: exclude everything, then re-include the few files the bundle needs.
+# A later "!" re-include overrides an earlier broad exclude — order matters.
+
+*
+
+# Files the bundle actually needs:
+!manifest.json
+!icon.png

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,182 @@
+{
+  "manifest_version": "0.3",
+  "name": "n8n-mcp",
+  "display_name": "n8n-MCP",
+  "version": "2.59.3",
+  "description": "MCP server providing AI assistants with comprehensive access to n8n node documentation and workflow management capabilities",
+  "author": {
+    "name": "Romuald Członkowski",
+    "url": "https://www.aiadvisors.pl/en"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/czlonkowski/n8n-mcp"
+  },
+  "homepage": "https://www.n8n-mcp.com/",
+  "documentation": "https://github.com/czlonkowski/n8n-mcp#readme",
+  "support": "https://github.com/czlonkowski/n8n-mcp/issues",
+  "license": "MIT",
+  "keywords": [
+    "n8n",
+    "mcp",
+    "workflow",
+    "automation",
+    "ai",
+    "documentation",
+    "model-context-protocol"
+  ],
+  "privacy_policies": [
+    "https://n8n.io/legal/privacy/"
+  ],
+  "server": {
+    "type": "node",
+    "entry_point": "dist/mcp/index.js",
+    "mcp_config": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "n8n-mcp"
+      ],
+      "env": {
+        "MCP_MODE": "stdio",
+        "LOG_LEVEL": "error",
+        "DISABLE_CONSOLE_OUTPUT": "true",
+        "N8N_API_URL": "${user_config.n8n_api_url}",
+        "N8N_API_KEY": "${user_config.n8n_api_key}",
+        "N8N_MCP_TELEMETRY_DISABLED": "${user_config.n8n_mcp_telemetry_disabled}"
+      }
+    }
+  },
+  "user_config": {
+    "n8n_api_url": {
+      "type": "string",
+      "title": "n8n Instance URL",
+      "description": "URL of your n8n instance (e.g., https://your-n8n.com or http://localhost:5678). Leave empty for documentation-only mode.",
+      "required": false
+    },
+    "n8n_api_key": {
+      "type": "string",
+      "title": "n8n API Key",
+      "description": "API key from your n8n instance Settings > API. Required for workflow management features.",
+      "required": false,
+      "sensitive": true
+    },
+    "n8n_mcp_telemetry_disabled": {
+      "type": "boolean",
+      "title": "Disable Telemetry",
+      "description": "Enable to turn off anonymous usage telemetry. Telemetry is on by default.",
+      "required": false,
+      "default": false
+    }
+  },
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
+    "runtimes": {
+      "node": ">=20"
+    }
+  },
+  "tools_generated": false,
+  "tools": [
+    {
+      "name": "tools_documentation",
+      "description": "Get documentation for n8n MCP tools."
+    },
+    {
+      "name": "search_nodes",
+      "description": "Search n8n nodes by keyword with optional real-world examples."
+    },
+    {
+      "name": "get_node",
+      "description": "Get node info with progressive detail levels and multiple modes."
+    },
+    {
+      "name": "validate_node",
+      "description": "Validate n8n node configuration."
+    },
+    {
+      "name": "get_template",
+      "description": "Get template by ID."
+    },
+    {
+      "name": "search_templates",
+      "description": "Search templates with multiple modes."
+    },
+    {
+      "name": "validate_workflow",
+      "description": "Full workflow validation: structure, connections, expressions, AI tools."
+    },
+    {
+      "name": "n8n_create_workflow",
+      "description": "Create workflow."
+    },
+    {
+      "name": "n8n_get_workflow",
+      "description": "Get workflow by ID with different detail levels."
+    },
+    {
+      "name": "n8n_update_full_workflow",
+      "description": "Full workflow update."
+    },
+    {
+      "name": "n8n_update_partial_workflow",
+      "description": "Update workflow incrementally with diff operations."
+    },
+    {
+      "name": "n8n_delete_workflow",
+      "description": "Permanently delete a workflow."
+    },
+    {
+      "name": "n8n_list_workflows",
+      "description": "List workflows (minimal metadata only)."
+    },
+    {
+      "name": "n8n_validate_workflow",
+      "description": "Validate workflow by ID."
+    },
+    {
+      "name": "n8n_autofix_workflow",
+      "description": "Automatically fix common workflow validation errors."
+    },
+    {
+      "name": "n8n_test_workflow",
+      "description": "Test/trigger workflow execution."
+    },
+    {
+      "name": "n8n_executions",
+      "description": "Manage workflow executions: get details, list, or delete."
+    },
+    {
+      "name": "n8n_health_check",
+      "description": "Check n8n instance health and API connectivity."
+    },
+    {
+      "name": "n8n_workflow_versions",
+      "description": "Manage workflow version history, rollback, and cleanup."
+    },
+    {
+      "name": "n8n_deploy_template",
+      "description": "Deploy a workflow template from n8n.io directly to your n8n instance."
+    },
+    {
+      "name": "n8n_manage_datatable",
+      "description": "Manage n8n data tables and rows."
+    },
+    {
+      "name": "n8n_manage_credentials",
+      "description": "Manage n8n credentials."
+    },
+    {
+      "name": "n8n_generate_workflow",
+      "description": "Generate an n8n workflow from a natural language description using AI."
+    },
+    {
+      "name": "n8n_audit_instance",
+      "description": "Security audit of n8n instance."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "build:ui": "cd ui-apps && npm install && npm run build",
     "build:all": "npm run sync:skills && npm run build:ui && npm run build",
     "sync:skills": "npx tsx scripts/sync-skills.ts",
+    "generate:mcpb-manifest": "node scripts/generate-mcpb-manifest.js",
+    "build:mcpb": "npm run build && npm run generate:mcpb-manifest && npx -y @anthropic-ai/mcpb validate manifest.json && npx -y @anthropic-ai/mcpb pack .",
     "rebuild": "node dist/scripts/rebuild.js",
     "rebuild:optimized": "node dist/scripts/rebuild-optimized.js",
     "validate": "node dist/scripts/validate.js",

--- a/scripts/generate-mcpb-manifest.js
+++ b/scripts/generate-mcpb-manifest.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * generate-mcpb-manifest.js
+ *
+ * Generates manifest.json for the MCPB (MCP Bundle) used for one-click install
+ * in Claude Desktop and other MCP hosts.
+ *
+ * The version and the advertised tool list are derived from the single sources
+ * of truth (package.json and the live MCP tool registry) so the bundle metadata
+ * can never drift from the server, the way the hand-maintained manifest did.
+ *
+ * The project must be built first: the tool list is read from dist/mcp/*.js.
+ *
+ * Usage:
+ *   node scripts/generate-mcpb-manifest.js          # write manifest.json
+ *   node scripts/generate-mcpb-manifest.js --check  # exit 1 if manifest.json is stale
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const MANIFEST_PATH = path.join(ROOT, 'manifest.json');
+
+/**
+ * Load the full tool registry from the built output. Both arrays are plain
+ * data (their only import is a TypeScript type), so requiring them has no
+ * side effects.
+ */
+function loadTools() {
+  const docToolsPath = path.join(ROOT, 'dist/mcp/tools.js');
+  const mgmtToolsPath = path.join(ROOT, 'dist/mcp/tools-n8n-manager.js');
+
+  for (const p of [docToolsPath, mgmtToolsPath]) {
+    if (!fs.existsSync(p)) {
+      console.error(`✖ ${path.relative(ROOT, p)} not found. Run "npm run build" first.`);
+      process.exit(1);
+    }
+  }
+
+  const docTools = require(docToolsPath).n8nDocumentationToolsFinal;
+  const mgmtTools = require(mgmtToolsPath).n8nManagementTools;
+  return [...docTools, ...mgmtTools];
+}
+
+/** Reduce a (possibly multi-line, multi-sentence) tool description to one tidy line. */
+function shortDescription(description) {
+  const oneLine = String(description).replace(/\s+/g, ' ').trim();
+  const match = oneLine.match(/^(.*?[.!?])(\s|$)/);
+  let sentence = match ? match[1] : oneLine;
+  if (sentence.length > 160) {
+    sentence = sentence.slice(0, 157).trimEnd() + '...';
+  }
+  return sentence;
+}
+
+function buildManifest() {
+  const pkg = require(path.join(ROOT, 'package.json'));
+  const tools = loadTools().map(t => ({
+    name: t.name,
+    description: shortDescription(t.description),
+  }));
+
+  return {
+    manifest_version: '0.3',
+    name: 'n8n-mcp',
+    display_name: 'n8n-MCP',
+    version: pkg.version,
+    description:
+      'MCP server providing AI assistants with comprehensive access to n8n node ' +
+      'documentation and workflow management capabilities',
+    author: {
+      name: 'Romuald Członkowski',
+      url: 'https://www.aiadvisors.pl/en',
+    },
+    repository: {
+      type: 'git',
+      url: 'https://github.com/czlonkowski/n8n-mcp',
+    },
+    homepage: 'https://www.n8n-mcp.com/',
+    documentation: 'https://github.com/czlonkowski/n8n-mcp#readme',
+    support: 'https://github.com/czlonkowski/n8n-mcp/issues',
+    license: 'MIT',
+    keywords: ['n8n', 'mcp', 'workflow', 'automation', 'ai', 'documentation', 'model-context-protocol'],
+    privacy_policies: ['https://n8n.io/legal/privacy/'],
+    server: {
+      type: 'node',
+      // Required by the v0.3 schema. This bundle launches via npx (see mcp_config
+      // below), so entry_point is documentation-only; it must still resolve on disk
+      // at pack time, which is why the bundle is packed after "npm run build".
+      entry_point: 'dist/mcp/index.js',
+      mcp_config: {
+        command: 'npx',
+        args: ['-y', 'n8n-mcp'],
+        env: {
+          MCP_MODE: 'stdio',
+          LOG_LEVEL: 'error',
+          DISABLE_CONSOLE_OUTPUT: 'true',
+          N8N_API_URL: '${user_config.n8n_api_url}',
+          N8N_API_KEY: '${user_config.n8n_api_key}',
+          N8N_MCP_TELEMETRY_DISABLED: '${user_config.n8n_mcp_telemetry_disabled}',
+        },
+      },
+    },
+    user_config: {
+      n8n_api_url: {
+        type: 'string',
+        title: 'n8n Instance URL',
+        description:
+          'URL of your n8n instance (e.g., https://your-n8n.com or http://localhost:5678). ' +
+          'Leave empty for documentation-only mode.',
+        required: false,
+      },
+      n8n_api_key: {
+        type: 'string',
+        title: 'n8n API Key',
+        description: 'API key from your n8n instance Settings > API. Required for workflow management features.',
+        required: false,
+        sensitive: true,
+      },
+      n8n_mcp_telemetry_disabled: {
+        type: 'boolean',
+        title: 'Disable Telemetry',
+        description: 'Enable to turn off anonymous usage telemetry. Telemetry is on by default.',
+        required: false,
+        default: false,
+      },
+    },
+    compatibility: {
+      claude_desktop: '>=0.10.0',
+      platforms: ['darwin', 'win32', 'linux'],
+      runtimes: {
+        // npx needs a host Node install; declaring it lets hosts fail fast with a
+        // clear message instead of npx erroring at launch.
+        node: '>=20',
+      },
+    },
+    tools_generated: false,
+    tools,
+  };
+}
+
+function serialize(manifest) {
+  return JSON.stringify(manifest, null, 2) + '\n';
+}
+
+function main() {
+  const check = process.argv.includes('--check');
+  const output = serialize(buildManifest());
+
+  if (check) {
+    const existing = fs.existsSync(MANIFEST_PATH) ? fs.readFileSync(MANIFEST_PATH, 'utf8') : '';
+    if (existing !== output) {
+      console.error('✖ manifest.json is out of date. Run: npm run generate:mcpb-manifest');
+      process.exit(1);
+    }
+    console.log('✓ manifest.json is up to date');
+    return;
+  }
+
+  fs.writeFileSync(MANIFEST_PATH, output);
+  const manifest = buildManifest();
+  console.log(`✓ Wrote manifest.json (version ${manifest.version}, ${manifest.tools.length} tools)`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds one-click **MCPB (MCP Bundle)** install for Claude Desktop and other MCP hosts. This builds on and brings current the work in #541 by @bryankthompson — thanks to Bryan for the original implementation and testing.

The core change is that the manifest is **generated** from `package.json` and the live MCP tool registry, so its advertised version and tool list can never drift from the server. The original hand-written manifest was already 26 versions and 4 tools stale on arrival.

## Why a new branch instead of pushing onto #541

PR #541 branched 188 commits back (v2.31.3, 20 tools). Layering fixes on it would re-introduce the very drift this fixes, and its `release.yml` predates the current pipeline. So these corrections are based on current `main`. This can merge to supersede #541, or the files can be applied after #541 is rebased.

## What the MCPB-spec research found

Researched the current `anthropics/mcpb` spec (the `mcpb-manifest-v0.3.schema.json` and `MANIFEST.md`), which corrected a couple of assumptions and surfaced a blocking packaging bug:

- **`manifest_version: "0.3"` is correct** — 0.3 is current; 0.4 is gated to `uv` servers. (No change needed here — the original PR had this right.)
- 🔴 **Blocking:** `mcpb pack` runs `existsSync` on the manifest `entry_point` against the source dir. Because `dist/` is gitignored, packing **fails on a clean CI checkout** — it only succeeded locally for the original author. Fixed by building before packing in CI.
- `user_config` supports `type: "boolean"`, so the telemetry toggle becomes a checkbox instead of asking users to type the literal string `true`.
- Empty optional `user_config` values are implementation-defined; verified the server treats empty `N8N_API_URL`/`N8N_API_KEY` safely (Zod rejects them → documentation-only mode), and empty telemetry keeps telemetry on.

## Changes

- **`scripts/generate-mcpb-manifest.js`** (new) — generates `manifest.json` from `package.json` + the live tool registry (`tools.ts`/`tools-n8n-manager.ts`). Includes a `--check` mode for CI drift detection.
- **`manifest.json`** (new, generated) — v0.3 spec: correct version, all **24** tools, **boolean** telemetry toggle, `compatibility` block (node ≥20), `license`, `keywords`; dropped the hardcoded node count.
- **`.mcpbignore`** — allowlist so the npx-based bundle ships **only** `manifest.json`.
- **`.gitignore`** — ignore `*.mcpb` (build artifact; the original PR committed a stale binary into the repo).
- **`.github/workflows/release.yml`** — new `package-mcpb` job: build → generate → validate → pack → upload `n8n-mcp-<version>.mcpb` as a GitHub Release asset.
- **`package.json`** — `generate:mcpb-manifest` and `build:mcpb` scripts.

## Verification

- `mcpb validate` passes
- `mcpb pack` produces a bundle containing **only `manifest.json`** (87 files ignored by the allowlist)
- `npm run generate:mcpb-manifest -- --check` reports in sync
- `npm run typecheck` passes
- `release.yml` parses; `package-mcpb` job registered

## Follow-up (not in this PR)

- A custom `icon.png` (512×512) can be dropped at repo root; `.mcpbignore` already re-includes it and the manifest can reference it.

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)