### PR TITLE
docs: note npm_config_cache workaround for multiple npx MCP clients

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -58,7 +58,7 @@ Add to Claude Desktop config:
 > **Note**: npx will download and run the latest version automatically. The package includes a pre-built database with all n8n node information.
 
 > **Running multiple MCP clients at once (e.g. Claude Desktop + Claude Code)?**
-> Launching n8n-mcp via `npx` from two clients simultaneously can hit npm cache lock conflicts. Give each client its own npm cache directory by adding `npm_config_cache` to its `env`:
+> Launching n8n-mcp via `npx` from two clients simultaneously can hit npm cache lock conflicts. Give **each client a different** `npm_config_cache` directory (the path must be unique per client — don't reuse one path) in its `env`:
 > ```json
 > {
 >   "mcpServers": {
@@ -68,7 +68,8 @@ Add to Claude Desktop config:
 >       "env": {
 >         "npm_config_cache": "/path/to/a/separate/cache",
 >         "MCP_MODE": "stdio",
->         "LOG_LEVEL": "error"
+>         "LOG_LEVEL": "error",
+>         "DISABLE_CONSOLE_OUTPUT": "true"
 >       }
 >     }
 >   }

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -57,6 +57,24 @@ Add to Claude Desktop config:
 
 > **Note**: npx will download and run the latest version automatically. The package includes a pre-built database with all n8n node information.
 
+> **Running multiple MCP clients at once (e.g. Claude Desktop + Claude Code)?**
+> Launching n8n-mcp via `npx` from two clients simultaneously can hit npm cache lock conflicts. Give each client its own npm cache directory by adding `npm_config_cache` to its `env`:
+> ```json
+> {
+>   "mcpServers": {
+>     "n8n-mcp": {
+>       "command": "npx",
+>       "args": ["n8n-mcp"],
+>       "env": {
+>         "npm_config_cache": "/path/to/a/separate/cache",
+>         "MCP_MODE": "stdio",
+>         "LOG_LEVEL": "error"
+>       }
+>     }
+>   }
+> }
+> ```
+
 **Configuration file locations:**
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`


### PR DESCRIPTION
Ports the useful tip from #552 into `docs/SELF_HOSTING.md`.

Running n8n-mcp via `npx` from two MCP clients at once (e.g. Claude Desktop + Claude Code) can hit npm cache lock conflicts. The fix is to give each client its own `npm_config_cache` directory. This note is added to the npx section of the self-hosting guide.

#552 could not be merged directly: since it was opened, the npx setup section was moved out of `README.md` into `docs/SELF_HOSTING.md`, and the branch fell ~178 commits behind and conflicted throughout `README.md`. This PR re-homes just the substantive note.

Credit to @D1g1t4lWaveRider for surfacing and documenting the issue.

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)