### PR TITLE
chore(security): add Dependabot config for npm, Actions, and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,74 @@
+# GitHub Dependabot Configuration
+# Automated dependency vulnerability scanning and updates
+
+version: 2
+updates:
+  # Monitor npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "czlonkowski"
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "security"
+    allow:
+      - dependency-type: "all"
+    rebase-strategy: "auto"
+
+  # Monitor GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "github-actions"
+      - "dependencies"
+    reviewers:
+      - "czlonkowski"
+
+  # Monitor Docker base images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "docker"
+      include: "scope"
+    labels:
+      - "docker"
+      - "dependencies"
+    reviewers:
+      - "czlonkowski"


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly Dependabot scans for:

- **npm** dependencies — grouped production/development minor+patch updates, `deps`/`deps-dev` commit prefixes
- **GitHub Actions** — `ci` commit prefix
- **Docker** base images — `docker` commit prefix

Ports the Dependabot configuration from #423. The remainder of that PR added rate limiting to `src/http-server.ts`, which was deprecated in v2.31.8 — the production single-session server already wires `express-rate-limit` into its sensitive routes — so only the Dependabot half is carried forward here. #423 is being closed in favor of this.

Credit to @guillegarciac for the configuration.

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)