### PR TITLE
chore(deps): harden Dependabot config (ignore n8n pkgs, cover ui-apps)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,12 @@
 
 version: 2
 updates:
-  # Monitor npm dependencies
+  # Monitor root npm dependencies
+  #
+  # NOTE: package.runtime.json (the slim manifest the Docker/npm runtime images
+  # install from) is a non-standard file Dependabot cannot manage directly. When
+  # bumping a runtime dependency here, mirror the change into package.runtime.json
+  # so the published images pick it up.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -35,6 +40,36 @@ updates:
       - "security"
     allow:
       - dependency-type: "all"
+    ignore:
+      # The n8n packages are updated via `npm run update:n8n`, which also rebuilds
+      # data/nodes.db while preserving community nodes (see scripts/update-n8n-deps.js).
+      # A plain Dependabot bump would ship a stale node catalog, so exclude them here.
+      - dependency-name: "n8n"
+      - dependency-name: "n8n-core"
+      - dependency-name: "n8n-workflow"
+      - dependency-name: "n8n-nodes-base"
+      - dependency-name: "@n8n/*"
+    rebase-strategy: "auto"
+
+  # Monitor the UI apps package (its own lockfile; built by `npm run build:ui`).
+  # Not a root npm workspace, so Dependabot needs a separate entry to see it.
+  - package-ecosystem: "npm"
+    directory: "/ui-apps"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "czlonkowski"
+    commit-message:
+      prefix: "deps(ui)"
+      prefix-development: "deps-dev(ui)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "ui"
     rebase-strategy: "auto"
 
   # Monitor GitHub Actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,7 +48,11 @@ updates:
       - dependency-name: "n8n-core"
       - dependency-name: "n8n-workflow"
       - dependency-name: "n8n-nodes-base"
+      # The "@n8n/*" wildcard covers current and future scoped packages
+      # (dependency-name supports "*" globs); the explicit entry is listed too
+      # so the intent is unambiguous for the package we actually depend on.
       - dependency-name: "@n8n/*"
+      - dependency-name: "@n8n/n8n-nodes-langchain"
     rebase-strategy: "auto"
 
   # Monitor the UI apps package (its own lockfile; built by `npm run build:ui`).
@@ -67,6 +71,17 @@ updates:
       prefix: "deps(ui)"
       prefix-development: "deps-dev(ui)"
       include: "scope"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "ui"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ version: 2
 updates:
   # Monitor root npm dependencies
   #
-  # NOTE: package.runtime.json (the slim manifest the Docker/npm runtime images
+  # NOTE: package.runtime.json (the slim manifest the published runtime images
   # install from) is a non-standard file Dependabot cannot manage directly. When
   # bumping a runtime dependency here, mirror the change into package.runtime.json
   # so the published images pick it up.
@@ -89,6 +89,7 @@ updates:
       - "dependencies"
     reviewers:
       - "czlonkowski"
+    rebase-strategy: "auto"
 
   # Monitor Docker base images
   - package-ecosystem: "docker"
@@ -107,3 +108,4 @@ updates:
       - "dependencies"
     reviewers:
       - "czlonkowski"
+    rebase-strategy: "auto"


### PR DESCRIPTION
Follow-up to #867. A Codex review of the Dependabot PRs that #867's config generated (#868–#873) surfaced three coverage/safety gaps in `.github/dependabot.yml`:

### Changes
1. **Ignore the n8n packages** (`n8n`, `n8n-core`, `n8n-workflow`, `n8n-nodes-base`, `@n8n/*`).
   These are updated via `npm run update:n8n`, which also rebuilds `data/nodes.db` while preserving community nodes (`scripts/update-n8n-deps.js`). A plain Dependabot bump would merge a **stale node catalog** — so they're excluded here and stay on the dedicated flow.
2. **Add a `/ui-apps` npm update block.** `ui-apps/` has its own `package-lock.json` (React/Vite, built by `npm run build:ui`) and is not a root workspace, so Dependabot wasn't monitoring it.
3. **Document `package.runtime.json`.** The Docker/npm runtime images install from this non-standard manifest, which Dependabot can't manage directly — added a note to mirror runtime-dep bumps into it.

### Why
Without (1), Dependabot would soon open `n8n*` PRs that pass CI but ship an out-of-date node database. (2) and (3) close real coverage holes so UI and runtime dependencies actually receive security updates.

Validated as well-formed YAML (4 update blocks: `npm:/`, `npm:/ui-apps`, `github-actions:/`, `docker:/`).

Conceived by Romuald Członkowski - https://www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)