### PR TITLE
fix(security): dependency audit — form-data CRLF fix + grouped security PRs (#903)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,16 +25,27 @@ updates:
       prefix-development: "deps-dev"
       include: "scope"
     groups:
+      # Version updates (weekly schedule): batch minor/patch bumps.
       production-dependencies:
+        applies-to: version-updates
         dependency-type: "production"
         update-types:
           - "minor"
           - "patch"
       development-dependencies:
+        applies-to: version-updates
         dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
+      # Security updates: batch the advisory-driven PRs into two grouped PRs
+      # (runtime vs dev) so the alert backlog cannot re-accumulate one-PR-per-CVE.
+      production-security:
+        applies-to: security-updates
+        dependency-type: "production"
+      development-security:
+        applies-to: security-updates
+        dependency-type: "development"
     labels:
       - "dependencies"
       - "security"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.61.0",
+  "version": "2.62.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.61.0",
+      "version": "2.62.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.28.0",
@@ -15,7 +15,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-rate-limit": "^7.1.5",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "ipaddr.js": "^1.9.1",
         "lru-cache": "^11.2.1",
         "n8n-core": "2.27.3",
@@ -18348,16 +18348,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-rate-limit": "^7.1.5",
-    "form-data": "^4.0.5",
+    "form-data": "^4.0.6",
     "ipaddr.js": "^1.9.1",
     "lru-cache": "^11.2.1",
     "n8n-core": "2.27.3",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -9,6 +9,7 @@
     "express": "^5.1.0",
     "express-rate-limit": "^7.1.5",
     "dotenv": "^16.5.0",
+    "form-data": "^4.0.6",
     "ipaddr.js": "^1.9.1",
     "lru-cache": "^11.2.1",
     "sql.js": "^1.13.0",


### PR DESCRIPTION
## Summary

Works #903 (dependency security audit on the default branch). Triage of the open Dependabot backlog (3 critical / 27 high / 29 medium / 8 low) against **actual runtime reachability** in this headless MCP documentation server.

### Key finding — one runtime-reachable, fixable alert

`form-data` is a **direct** dependency used at runtime by the form-trigger handler (`src/triggers/handlers/form-handler.ts`), which builds `multipart/form-data` from **request-supplied field names and filenames** (`fileObj.filename`, `fieldDef.fieldName`). `form-data <4.0.6` does not escape CRLF in those fields → multipart injection on the `/form/<webhookId>` path (GHSA CRLF-injection advisory, range `>=4.0.0 <4.0.6`).

**Fix:** bump direct `form-data` `^4.0.5 → ^4.0.6` (resolves to 4.0.6). Build passes; form-handler suite 48/48 green.

### Backlog hygiene

Enabled Dependabot **grouped security updates** (`applies-to: security-updates`, split runtime/dev) so advisory PRs batch instead of one-PR-per-CVE. Existing minor/patch groups pinned to `applies-to: version-updates`.

### Everything else — not runtime-reachable

The remaining critical/high alerts (`fast-xml-parser`, `ws`, `thrift`, `@grpc/grpc-js`, `tar`, `semver`, `utf7`, `nodemailer`, `hono`, `undici`, `protobufjs`, transitive `form-data` 4.0.0/2.5.5 …) all originate in the **n8n node package graph** (`@n8n/n8n-nodes-langchain`, `n8n-nodes-base`, `n8n-core`, `n8n-workflow`) — AWS SDK, Milvus, gRPC, IMAP, email, vector-store SDKs. n8n-mcp loads these **only to introspect node metadata during the database rebuild**; it never executes the nodes at runtime, so the vulnerable code paths (XML response parsing, IMAP UTF7 decode, SMTP send, etc.) are unreachable. Those four packages are already Dependabot-`ignore`d (managed via `npm run update:n8n`), so they clear when n8n ships upstream fixes.

`uuid@11.1.1` is already at the fixed version (`<11.1.1`), so no direct `uuid` action is needed.

## Verification
- `npm run build` — pass
- `form-handler.test.ts` — 48/48 pass
- `.github/dependabot.yml` — valid YAML

## Follow-up (not in this PR)
Dismissing the build-time-only critical/high alerts with documented "not runtime-reachable" reasoning to satisfy the issue's acceptance criterion — pending maintainer decision on bulk dismissal.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en