### PR TITLE
fix: stale hardcoded version in health check, deprecated API, typos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ ALWAYS prefer editing an existing file to creating a new one.
 NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 - When you make changes to MCP server, you need to ask the user to reload it before you test
 - When the user asks to review issues, you should use GH CLI to get the issue and all the comments
-- When the task can be divided into separated subtasks, you should spawn separate sub-agents to handle them in paralel
+- When the task can be divided into separated subtasks, you should spawn separate sub-agents to handle them in parallel
 - Use the best sub-agent for the task as per their descriptions
 - Do not use hyperbolic or dramatic language in comments and documentation
-- Add to every commit and PR: Concieved by Romuald Członkowski - and then link to www.aiadvisors.pl/en. Don't add it in conversations
+- Add to every commit and PR: Conceived by Romuald Członkowski - and then link to www.aiadvisors.pl/en. Don't add it in conversations

--- a/src/database/shared-database.ts
+++ b/src/database/shared-database.ts
@@ -8,7 +8,7 @@
  * Memory impact: Reduces per-session memory from ~900MB to near-zero by sharing
  * a single ~68MB database connection across all sessions.
  *
- * Issue: https://github.com/czlonkowski/n8n-mcp/issues/XXX
+ * See shared-database implementation for memory optimization details.
  */
 
 import path from 'path';

--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -1415,7 +1415,7 @@ export class SingleSessionHTTPServer {
       logger.info('POST /mcp request completed - checking response status', {
         responseHeadersSent: res.headersSent,
         responseStatusCode: res.statusCode,
-        responseFinished: res.finished
+        responseFinished: res.writableEnded
       });
     });
     

--- a/src/mcp-engine.ts
+++ b/src/mcp-engine.ts
@@ -8,6 +8,7 @@
 import { Request, Response } from 'express';
 import { SingleSessionHTTPServer } from './http-server-single-session';
 import { logger } from './utils/logger';
+import { PROJECT_VERSION } from './utils/version';
 import { InstanceContext } from './types/instance-context';
 import { SessionState } from './types/session-state';
 import type { AdditionalTool } from './types/additional-tools';
@@ -102,7 +103,7 @@ export class N8NMCPEngine {
           total: Math.round(memoryUsage.heapTotal / 1024 / 1024),
           unit: 'MB'
         },
-        version: '2.24.1'
+        version: PROJECT_VERSION
       };
     } catch (error) {
       logger.error('Health check failed:', error);
@@ -111,7 +112,7 @@ export class N8NMCPEngine {
         uptime: 0,
         sessionActive: false,
         memoryUsage: { used: 0, total: 0, unit: 'MB' },
-        version: '2.24.1'
+        version: PROJECT_VERSION
       };
     }
   }

--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -2318,7 +2318,7 @@ export class WorkflowValidator {
 
     // Access connections from the workflow structure, not the node
     // We need to access this.currentWorkflow.connections[startNode]
-    const connections = (this as any).currentWorkflow?.connections[startNode];
+    const connections = this.currentWorkflow?.connections[startNode];
     if (!connections) return false;
 
     for (const [outputType, outputs] of Object.entries(connections)) {


### PR DESCRIPTION
A few things I spotted:

- \`healthCheck()\` was returning a hardcoded version \`'2.24.1'\` in both the healthy and unhealthy branches, but package.json is at 2.62.0. Imported \`PROJECT_VERSION\` from \`utils/version\` instead.
- \`res.finished\` was deprecated in Node 13.4.0 — changed to \`res.writableEnded\`
- fixed "paralel" and "Concieved" typos in CLAUDE.md
- replaced the placeholder \`issues/XXX\` link in shared-database.ts with an inline description
- removed an unnecessary \`(this as any)\` cast in workflow-validator — \`currentWorkflow\` is already typed as a private field on the class