### PR TITLE
ci(deps): ignore pinned @modelcontextprotocol/sdk and zod in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,15 @@ updates:
       # so the intent is unambiguous for the package we actually depend on.
       - dependency-name: "@n8n/*"
       - dependency-name: "@n8n/n8n-nodes-langchain"
+      # @modelcontextprotocol/sdk and zod are pinned to exact versions on purpose:
+      # zod v4 breaks the MCP SDK ("_zod" property errors) and the SDK/zod pair is
+      # verified by the "Fresh Install Dependency Check" CI guard (see issues
+      # #440, #444, #446, #447, #450). Their versions are also mirrored in
+      # package.runtime.json, which Dependabot cannot manage. A Dependabot bump
+      # therefore always fails CI, so exclude them and update via a manual,
+      # compatibility-tested change instead.
+      - dependency-name: "@modelcontextprotocol/sdk"
+      - dependency-name: "zod"
     rebase-strategy: "auto"
 
   # Monitor the UI apps package (its own lockfile; built by `npm run build:ui`).


### PR DESCRIPTION
## Why

`@modelcontextprotocol/sdk` and `zod` are pinned to exact versions on purpose:
- zod v4 breaks the MCP SDK (`_zod` property errors) — see issues #440, #444, #446, #447, #450.
- The SDK/zod pair is enforced by the **Fresh Install Dependency Check** CI guard.
- Their versions are mirrored in `package.runtime.json`, which **Dependabot cannot manage**.

Because of this, every weekly `production-dependencies` group PR that bumps the SDK (e.g. **#909**, `1.28.0 → 1.29.0`) fails the Fresh Install guard and cannot be merged — the group PR is perpetually red.

## Change

Add `@modelcontextprotocol/sdk` and `zod` to the Dependabot `ignore` list (same pattern already used for the n8n packages). The production group PR stays mergeable; these two are bumped manually with a compatibility-tested change that also mirrors `package.runtime.json`.

Security alerts for these packages still surface in the Security tab — only the auto-update PRs are suppressed.

Refs #903, #909

Conceived by Romuald Członkowski - www.aiadvisors.pl/en