### PR TITLE
ci: skip live n8n integration tests when no instance is configured

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15  # Increased from 10 to accommodate larger database with community nodes
     env:
-      # Surfaced at job level so the integration step's `if:` can detect whether a
-      # live n8n instance is configured. The `secrets` context is not available in
-      # `if:` conditions, but `env` is — so we route the URL through env here.
-      N8N_API_URL: ${{ secrets.N8N_API_URL }}
+      # A boolean flag (not the secret itself) so the live-integration step's `if:`
+      # can detect whether an instance is configured without exposing the URL to
+      # every step. `secrets` is not usable in `if:`, but `env` is; evaluating the
+      # secret to a bool here keeps the actual value scoped to the step that needs it.
+      HAS_N8N_INSTANCE: ${{ secrets.N8N_API_URL != '' }}
     steps:
       - uses: actions/checkout@v7
       
@@ -87,20 +88,27 @@ jobs:
         timeout-minutes: 8
         continue-on-error: true
 
-      # Run integration tests separately (with MSW setup).
-      #
-      # Skipped when no live n8n instance is configured: much of this suite talks
-      # to a real instance via the N8N_API_* secrets, which are unavailable on
-      # Dependabot and fork PRs — there ~21/58 files fail outright, turning the
-      # required `test` check permanently red for dependency PRs. On in-repo PRs
-      # the secret is present, so the suite runs and remains a blocking gate.
-      # --retry=2 absorbs the occasional live-API flake ("expected false to be
-      # true") instead of failing the whole run.
-      - name: Run integration tests
-        if: ${{ env.N8N_API_URL != '' }}
-        run: npm run test:integration -- --retry=2 --reporter=default --reporter=junit
+      # Offline integration suites (database, security, mcp-protocol, workflow-diff,
+      # templates, docker, …). These need no live instance, so they always run and
+      # stay a blocking gate on every PR — Dependabot and forks included. Only the
+      # live n8n-api / ai-validation suites are excluded here (they run in the next
+      # step). MSW setup applies as configured.
+      - name: Run integration tests (offline suites)
+        run: npm run test:integration -- --exclude 'tests/integration/n8n-api/**' --exclude 'tests/integration/ai-validation/**' --reporter=default --reporter=junit
         env:
           CI: true
+
+      # Live n8n-API + AI-validation suites hit a real instance via the N8N_API_*
+      # secrets, which are unavailable on Dependabot and fork PRs (there every file
+      # here fails outright, turning the required `test` check permanently red). Skip
+      # them when no instance is configured; on in-repo PRs the secret is present so
+      # they run and remain a blocking gate. Secrets are scoped to this step only.
+      - name: Run integration tests (live n8n instance)
+        if: ${{ env.HAS_N8N_INSTANCE == 'true' }}
+        run: npm run test:integration -- tests/integration/n8n-api tests/integration/ai-validation --reporter=default --reporter=junit
+        env:
+          CI: true
+          N8N_API_URL: ${{ secrets.N8N_API_URL }}
           N8N_API_KEY: ${{ secrets.N8N_API_KEY }}
           N8N_TEST_WEBHOOK_GET_URL: ${{ secrets.N8N_TEST_WEBHOOK_GET_URL }}
           N8N_TEST_WEBHOOK_POST_URL: ${{ secrets.N8N_TEST_WEBHOOK_POST_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15  # Increased from 10 to accommodate larger database with community nodes
     env:
-      # A boolean flag (not the secret itself) so the live-integration step's `if:`
-      # can detect whether an instance is configured without exposing the URL to
-      # every step. `secrets` is not usable in `if:`, but `env` is; evaluating the
-      # secret to a bool here keeps the actual value scoped to the step that needs it.
-      HAS_N8N_INSTANCE: ${{ secrets.N8N_API_URL != '' }}
+      # A boolean flag (not the secrets themselves) recording whether a live n8n
+      # instance is configured, so the live-integration step can gate on it without
+      # the N8N_API_* values being exposed to every step in the job. The live tests
+      # need BOTH the URL and the key (getN8nCredentials() throws if either is
+      # missing), and both are empty on Dependabot/fork PRs — so require both here,
+      # otherwise a partially-configured instance would run the step and then fail.
+      HAS_N8N_INSTANCE: ${{ secrets.N8N_API_URL != '' && secrets.N8N_API_KEY != '' }}
     steps:
       - uses: actions/checkout@v7
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15  # Increased from 10 to accommodate larger database with community nodes
+    env:
+      # Surfaced at job level so the integration step's `if:` can detect whether a
+      # live n8n instance is configured. The `secrets` context is not available in
+      # `if:` conditions, but `env` is — so we route the URL through env here.
+      N8N_API_URL: ${{ secrets.N8N_API_URL }}
     steps:
       - uses: actions/checkout@v7
       
@@ -82,12 +87,20 @@ jobs:
         timeout-minutes: 8
         continue-on-error: true
 
-      # Run integration tests separately (with MSW setup)
+      # Run integration tests separately (with MSW setup).
+      #
+      # Skipped when no live n8n instance is configured: much of this suite talks
+      # to a real instance via the N8N_API_* secrets, which are unavailable on
+      # Dependabot and fork PRs — there ~21/58 files fail outright, turning the
+      # required `test` check permanently red for dependency PRs. On in-repo PRs
+      # the secret is present, so the suite runs and remains a blocking gate.
+      # --retry=2 absorbs the occasional live-API flake ("expected false to be
+      # true") instead of failing the whole run.
       - name: Run integration tests
-        run: npm run test:integration -- --reporter=default --reporter=junit
+        if: ${{ env.N8N_API_URL != '' }}
+        run: npm run test:integration -- --retry=2 --reporter=default --reporter=junit
         env:
           CI: true
-          N8N_API_URL: ${{ secrets.N8N_API_URL }}
           N8N_API_KEY: ${{ secrets.N8N_API_KEY }}
           N8N_TEST_WEBHOOK_GET_URL: ${{ secrets.N8N_TEST_WEBHOOK_GET_URL }}
           N8N_TEST_WEBHOOK_POST_URL: ${{ secrets.N8N_TEST_WEBHOOK_POST_URL }}


### PR DESCRIPTION
## Problem

The `test` job's integration step talks to a live n8n instance via the `N8N_API_*` secrets. Those secrets are unavailable on **Dependabot and fork PRs**, so the live suites fail outright and the required `test` check goes **permanently red** — the dependency PRs we most want to auto-merge can never turn green. A couple of live-API cases also flake intermittently even when the instance is up.

## Change

Split the integration run and gate only the live part:

- **Offline suites** (database, security, mcp-protocol, workflow-diff, templates, docker, `flexible-instance-config`, …) — run in their own step that **always executes and stays a blocking gate on every PR**, Dependabot/forks included. They need no secrets (verified green with none set).
- **Live suites** (`tests/integration/n8n-api/**`, `tests/integration/ai-validation/**`) — run in a separate step gated on a job-level boolean `HAS_N8N_INSTANCE`. It's derived from **both** `N8N_API_URL` and `N8N_API_KEY` (the live tests' `getN8nCredentials()` throws if either is missing), so a partial config won't run-and-fail. Skipped when no instance is configured; blocking on in-repo PRs where the secrets exist. The `N8N_API_*` secrets are scoped to this step only, not the whole job.

Unit tests, lint, and typecheck remain always-on blocking gates.

## Why not blanket `continue-on-error`

That would drop the gate for *every* PR, including the offline suites that catch real regressions. This keeps the offline suites gating everywhere and only relaxes the genuinely instance-dependent tests where they can't run.

## Notes

- No `--retry` is added: the base Vitest config sets `retry: 0` on purpose ("fix flaky tests, don't mask them"). The two flaky live-API cases in `update-partial-workflow.test.ts` (moveNode/disableNode) should be fixed with proper eventual-consistency waits — tracked as a follow-up.

Refs #903

Conceived by Romuald Członkowski - www.aiadvisors.pl/en