### PR TITLE
docs: add AiAdvisors services footer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,3 +436,9 @@ See [Acknowledgments](./docs/ACKNOWLEDGMENTS.md) for credits and template attrib
 <div align="center">
   <strong>Built with care for the n8n community</strong>
 </div>
+
+---
+
+> 💼 **Need it built for you?**
+>
+> Work with [AiAdvisors](https://www.aiadvisors.pl/en) — automation audits, builds, and operations by the team behind n8n-mcp and n8n-skills.


### PR DESCRIPTION
## Summary

Adds a closing call-to-action footer at the end of the README, pointing readers to AiAdvisors for automation audits, builds, and operations.

Rendered:

> 💼 **Need it built for you?**
>
> Work with [AiAdvisors](https://www.aiadvisors.pl/en) — automation audits, builds, and operations by the team behind n8n-mcp and n8n-skills.

## Changes

- `README.md`: +6 lines (footer only), branched fresh off `main`.

Concieved by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)