### PR TITLE
test: cover GET→UPDATE workflow round-trips and n8n API quirks (#433)

### DIFF
--- a/tests/integration/n8n-api/README.md
+++ b/tests/integration/n8n-api/README.md
@@ -1,0 +1,39 @@
+# n8n API Integration Tests
+
+Live tests against a real n8n instance (`N8N_API_URL` + `N8N_API_KEY`).
+
+In CI these suites run only when those secrets are configured (see `.github/workflows/test.yml`). Offline unit tests in `tests/unit/services/n8n-validation.test.ts` always cover the same cleaning rules without a live API.
+
+## n8n API quirks (workflow updates)
+
+The Public API is **asymmetric** between read and write:
+
+| Behavior | GET | PUT / PATCH |
+|----------|-----|-------------|
+| `description` | May be returned | Rejected on some versions (Issue #431) |
+| Read-only fields (`id`, `createdAt`, `updatedAt`, `versionId`, `versionCounter`, `active`, `tags`, `meta`, `staticData`, `pinData`, `nodeGroups`, …) | Returned | Rejected (`additionalProperties: false` on many versions) |
+| `settings` | Returned | Empty `{}` rejected; omit → client injects `{ executionOrder: 'v1' }` |
+
+**Common failure mode (Issue #433):**
+
+```ts
+const wf = await client.getWorkflow(id);
+await client.updateWorkflow(id, { ...wf, name: 'New' }); // must clean first
+```
+
+`N8nApiClient.updateWorkflow()` always runs `cleanWorkflowForUpdate()` (allowlist of writable top-level fields + settings filter) before sending the body. Coverage:
+
+- **Unit:** `tests/unit/services/n8n-validation.test.ts` → `cleanWorkflowForUpdate` (always in CI)
+- **Live:** `tests/integration/n8n-api/workflows/update-workflow.test.ts` → GET→UPDATE / spread / minimal / edge cases (Issue #433)
+
+## Running locally
+
+```bash
+# Unit only (no n8n required)
+npm run test:unit -- tests/unit/services/n8n-validation.test.ts
+
+# Live n8n API suites
+export N8N_API_URL=https://your-n8n.example
+export N8N_API_KEY=...
+npm run test:integration:n8n
+```

--- a/tests/integration/n8n-api/workflows/update-workflow.test.ts
+++ b/tests/integration/n8n-api/workflows/update-workflow.test.ts
@@ -367,4 +367,299 @@ describe('Integration: handleUpdateWorkflow', () => {
       expect(actual.settings?.timezone).toBe('America/New_York');
     });
   });
+
+  // ======================================================================
+  // Issue #433 — GET→UPDATE round-trip + n8n API quirks
+  //
+  // Real-world agents and scripts commonly do:
+  //   const wf = await getWorkflow(id);
+  //   await updateWorkflow(id, { ...wf, name: 'New' });
+  //
+  // n8n's API is asymmetric:
+  // - GET returns read-only fields (id, createdAt, updatedAt, versionId,
+  //   description, active, tags, meta, staticData, pinData, …)
+  // - PUT/PATCH rejects many of those fields (additionalProperties: false
+  //   on some n8n versions; description was specifically rejected — #431)
+  // - settings is required for a stable update path; empty {} is rejected
+  //
+  // N8nApiClient.updateWorkflow() runs cleanWorkflowForUpdate() before PUT.
+  // These tests hit a live instance so regressions like #431 cannot slip by.
+  // ======================================================================
+
+  describe('GET-UPDATE Round Trip (Issue #433)', () => {
+    it('should handle a workflow returned from GET when passed straight to UPDATE', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - GET round-trip'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      // Full GET payload — includes read-only fields the PUT schema rejects
+      const fromGet = await client.getWorkflow(created.id);
+
+      // Must not throw: cleanWorkflowForUpdate strips read-only fields
+      const updated = await client.updateWorkflow(created.id, fromGet as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.name).toBe(fromGet.name);
+      expect(updated.nodes).toHaveLength(fromGet.nodes.length);
+    });
+
+    it('should handle workflow update with spread operator', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Spread operator'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const fromGet = await client.getWorkflow(created.id);
+      const newName = createTestWorkflowName('Update - Spread operator (renamed)');
+
+      // Common user pattern: spread entire GET response then override fields
+      const updated = await client.updateWorkflow(created.id, {
+        ...fromGet,
+        name: newName,
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.name).toBe(newName);
+
+      const actual = await client.getWorkflow(created.id);
+      expect(actual.name).toBe(newName);
+      expect(actual.nodes).toHaveLength(fromGet.nodes.length);
+    });
+
+    it('should handle partial settings update via nested spread', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Nested settings spread'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const fromGet = await client.getWorkflow(created.id);
+
+      const updated = await client.updateWorkflow(created.id, {
+        ...fromGet,
+        settings: {
+          ...fromGet.settings,
+          executionOrder: 'v1' as const,
+          timezone: 'UTC',
+        },
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+
+      const actual = await client.getWorkflow(created.id);
+      expect(actual.settings?.timezone).toBe('UTC');
+      expect(actual.nodes).toHaveLength(fromGet.nodes.length);
+    });
+  });
+
+  describe('n8n API Constraints (Issue #433)', () => {
+    it('should strip description on update even when present on GET / payload (Issue #431)', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Description strip'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const fromGet = await client.getWorkflow(created.id);
+
+      // description is read-only on write; client must clean it rather than 400
+      const updated = await client.updateWorkflow(created.id, {
+        ...fromGet,
+        description: 'Agent-supplied description that n8n PUT rejects',
+        name: createTestWorkflowName('Update - Description strip (ok)'),
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.name).toContain('Description strip (ok)');
+    });
+
+    it('should auto-supply settings when omitted from the update payload', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Missing settings'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const fromGet = await client.getWorkflow(created.id);
+
+      // Absolute required fields only — cleanWorkflowForUpdate adds settings defaults
+      const updated = await client.updateWorkflow(created.id, {
+        name: fromGet.name,
+        nodes: fromGet.nodes,
+        connections: fromGet.connections,
+        // deliberately no settings
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.nodes).toHaveLength(fromGet.nodes.length);
+    });
+
+    it('should handle all common read-only fields in a spread payload', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Read-only fields'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const fromGet = await client.getWorkflow(created.id);
+      const newName = createTestWorkflowName('Update - Read-only fields (cleaned)');
+
+      // Force-include fields that have historically broken updates when echoed
+      const updated = await client.updateWorkflow(created.id, {
+        ...fromGet,
+        name: newName,
+        createdAt: '2099-01-01T00:00:00.000Z',
+        updatedAt: '2099-01-01T00:00:00.000Z',
+        versionId: 'must-be-stripped',
+        versionCounter: 999,
+        active: true,
+        isArchived: false,
+        meta: { injected: true },
+        staticData: { junk: true },
+        pinData: { junk: true },
+        description: 'must-be-stripped',
+        activeVersionId: 'must-be-stripped',
+        nodeGroups: [],
+        availableInMCP: true,
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.name).toBe(newName);
+
+      const actual = await client.getWorkflow(created.id);
+      expect(actual.name).toBe(newName);
+      expect(actual.nodes).toHaveLength(fromGet.nodes.length);
+    });
+  });
+
+  describe('Minimal Updates (Issue #433)', () => {
+    it('should update with only required fields (name, nodes, connections)', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Minimal required'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const current = await client.getWorkflow(created.id);
+
+      const updated = await client.updateWorkflow(created.id, {
+        name: current.name,
+        nodes: current.nodes,
+        connections: current.connections,
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.nodes).toHaveLength(current.nodes.length);
+    });
+
+    it('should update with minimal changes (rename only + required graph)', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Minimal rename'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const current = await client.getWorkflow(created.id);
+      const newName = createTestWorkflowName('Update - Minimal rename (done)');
+
+      const updated = await client.updateWorkflow(created.id, {
+        name: newName,
+        nodes: current.nodes,
+        connections: current.connections,
+      } as any);
+
+      expect(updated.name).toBe(newName);
+
+      const actual = await client.getWorkflow(created.id);
+      expect(actual.name).toBe(newName);
+      expect(actual.nodes).toHaveLength(1);
+    });
+  });
+
+  describe('Edge Cases — settings filtering (Issue #433)', () => {
+    it('should succeed when settings contain only unknown properties (defaults applied)', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Unknown settings only'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const current = await client.getWorkflow(created.id);
+
+      // Unknown settings are filtered; empty remainder → { executionOrder: 'v1' }
+      // Note: callerPolicy is now whitelisted (n8n 1.119+); use truly unknown keys.
+      const updated = await client.updateWorkflow(created.id, {
+        name: current.name,
+        nodes: current.nodes,
+        connections: current.connections,
+        settings: {
+          totallyUnknownSetting: true,
+          anotherGarbageField: 42,
+        } as any,
+      });
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.nodes).toHaveLength(current.nodes.length);
+    });
+
+    it('should preserve valid settings while filtering unknown ones', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Mixed settings filter'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const current = await client.getWorkflow(created.id);
+
+      const updated = await client.updateWorkflow(created.id, {
+        name: current.name,
+        nodes: current.nodes,
+        connections: current.connections,
+        settings: {
+          executionOrder: 'v1' as const,
+          timezone: 'Europe/Berlin',
+          totallyUnknownSetting: 'drop-me',
+        } as any,
+      });
+
+      expect(updated.id).toBe(created.id);
+
+      const actual = await client.getWorkflow(created.id);
+      expect(actual.settings?.timezone).toBe('Europe/Berlin');
+      expect((actual.settings as any)?.totallyUnknownSetting).toBeUndefined();
+    });
+  });
 });

--- a/tests/unit/services/n8n-validation.test.ts
+++ b/tests/unit/services/n8n-validation.test.ts
@@ -777,6 +777,139 @@ describe('n8n-validation', () => {
         const cleaned = cleanWorkflowForUpdate(workflow);
         expect(cleaned.nodes![0].webhookId).toBeUndefined();
       });
+
+      // ====================================================================
+      // Issue #433 — GET→spread→UPDATE patterns (unit-level, always run in CI)
+      //
+      // n8n API quirks these tests lock in:
+      // - GET returns read-only fields (id, createdAt, versionId, description, …)
+      // - PUT/PATCH reject those fields (additionalProperties: false on some versions)
+      // - description is returned by GET but rejected on update (Issue #431)
+      // - empty settings {} is rejected; missing settings get { executionOrder: 'v1' }
+      // Users commonly do: updateWorkflow(id, { ...await getWorkflow(id), name: 'x' })
+      // ====================================================================
+
+      it('should clean a full GET-shaped response for safe PUT (Issue #433)', () => {
+        // Simulate the object shape returned by GET, then spread + rename
+        const getResponse = {
+          id: 'wf-abc',
+          name: 'Original Name',
+          description: 'Returned by GET but not writable on PUT',
+          nodes: [
+            {
+              id: 'webhook-1',
+              name: 'Webhook',
+              type: 'n8n-nodes-base.webhook',
+              typeVersion: 2,
+              position: [250, 300],
+              parameters: { path: 'test' },
+              webhookId: 'existing-wh',
+            },
+          ],
+          connections: {},
+          settings: { executionOrder: 'v1', timezone: 'UTC' },
+          active: false,
+          isArchived: false,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-06-01T00:00:00.000Z',
+          versionId: 'ver-123',
+          versionCounter: 9,
+          meta: { templateCredsSetupCompleted: true },
+          staticData: { 'node:Webhook': { data: 1 } },
+          pinData: {},
+          tags: [{ id: 't1', name: 'prod' }],
+          triggerCount: 1,
+          shared: [],
+          activeVersionId: 'av-1',
+          nodeGroups: [],
+          availableInMCP: false,
+        } as any;
+
+        const cleaned = cleanWorkflowForUpdate({
+          ...getResponse,
+          name: 'Renamed via spread',
+        });
+
+        expect(cleaned.name).toBe('Renamed via spread');
+        expect(cleaned.nodes).toHaveLength(1);
+        expect(cleaned.connections).toEqual({});
+        expect(cleaned.settings).toEqual({ executionOrder: 'v1', timezone: 'UTC' });
+        // nodeGroups is allowlisted for n8n 2.28+: empty array means ungroup everything
+        // and is intentionally forwarded (omitting the key would backfill stored groups).
+        expect(cleaned.nodeGroups).toEqual([]);
+
+        // Read-only / computed fields must never reach PUT
+        for (const key of [
+          'id',
+          'description',
+          'active',
+          'isArchived',
+          'createdAt',
+          'updatedAt',
+          'versionId',
+          'versionCounter',
+          'meta',
+          'staticData',
+          'pinData',
+          'tags',
+          'triggerCount',
+          'shared',
+          'activeVersionId',
+          'availableInMCP',
+        ]) {
+          expect(cleaned).not.toHaveProperty(key);
+        }
+
+        expect(Object.keys(cleaned).sort()).toEqual([
+          'connections',
+          'name',
+          'nodeGroups',
+          'nodes',
+          'settings',
+        ]);
+      });
+
+      it('should allow minimal payload (name/nodes/connections only) with settings defaults (Issue #433)', () => {
+        const cleaned = cleanWorkflowForUpdate({
+          name: 'Minimal',
+          nodes: [],
+          connections: {},
+        } as any);
+
+        expect(cleaned).toEqual({
+          name: 'Minimal',
+          nodes: [],
+          connections: {},
+          settings: { executionOrder: 'v1' },
+        });
+      });
+
+      it('should replace empty settings objects with minimal defaults (Issue #433 / #431)', () => {
+        const cleaned = cleanWorkflowForUpdate({
+          name: 'Empty Settings',
+          nodes: [],
+          connections: {},
+          settings: {},
+        } as any);
+
+        expect(cleaned.settings).toEqual({ executionOrder: 'v1' });
+      });
+
+      it('should default settings when only unknown settings properties remain (Issue #433)', () => {
+        const cleaned = cleanWorkflowForUpdate({
+          name: 'Filtered Settings',
+          nodes: [],
+          connections: {},
+          settings: {
+            totallyUnknownSetting: true,
+            anotherGarbageField: 42,
+          },
+        } as any);
+
+        expect(cleaned.settings).toEqual({ executionOrder: 'v1' });
+        expect(cleaned.settings).not.toHaveProperty('totallyUnknownSetting');
+        expect(cleaned.settings).not.toHaveProperty('anotherGarbageField');
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #433 — improves test coverage for the real-world **GET → spread → UPDATE** pattern that allowed Issue #431 (`description` / read-only fields on PUT) to ship without a red CI signal.

## Problem

Existing update tests cherry-pick writable fields:

```ts
await updateWorkflow(id, {
  name: current.name,
  nodes: current.nodes,
  connections: current.connections,
});
```

Agents and scripts more often do:

```ts
const wf = await getWorkflow(id);
await updateWorkflow(id, { ...wf, name: 'New' });
```

n8n’s Public API is asymmetric (GET returns fields PUT rejects). Without round-trip coverage, cleaning regressions can pass unit cherry-picks and still break production updates.

## Changes

### Unit (`tests/unit/services/n8n-validation.test.ts`) — always run in CI

- Clean a full GET-shaped payload (id, description, versionCounter, nodeGroups, tags, …)
- Minimal payload → settings default `{ executionOrder: 'v1' }`
- Empty `settings: {}` → same default
- Only unknown settings keys → default after filter

### Integration (`tests/integration/n8n-api/workflows/update-workflow.test.ts`) — live n8n when secrets present

| Suite | Cases |
|-------|--------|
| GET-UPDATE Round Trip | straight GET→UPDATE, spread rename, nested settings spread |
| n8n API Constraints | description strip (#431), missing settings auto-default, forced read-only echo |
| Minimal Updates | required fields only; rename + graph |
| Edge Cases | unknown-only settings; preserve valid + drop unknown |

Uses `N8nApiClient.updateWorkflow()` (runs `cleanWorkflowForUpdate`) against a real instance — the path users hit.

### Docs

- `tests/integration/n8n-api/README.md` — n8n read/write quirks table + how to run unit vs live suites

## Acceptance criteria (#433)

- [x] GET-UPDATE round-trip tests (3)
- [x] n8n API constraint tests (3)
- [x] Minimal payload tests (2)
- [x] Edge case tests (2)
- [x] Unit coverage always in CI (no live n8n required)
- [x] API quirks documented in test comments + README

## Test plan

- [x] `npx vitest run tests/unit/services/n8n-validation.test.ts --coverage.enabled=false` → **112 passed**
- [ ] Live suite (maintainer CI with `N8N_API_*` secrets): `npm run test:integration:n8n -- tests/integration/n8n-api/workflows/update-workflow.test.ts`

## Notes

- Edge-case examples in the original issue used `callerPolicy` as “filtered”; that key is now **whitelisted** (n8n 1.119+). Tests use truly unknown settings keys instead.
- Issue was previously claimed with no PR; this implements the agreed coverage.
