### PR TITLE
docs: add Autohand Code setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ n8n-MCP works with multiple AI-powered IDEs and tools:
 - [Cursor](./docs/CURSOR_SETUP.md) - Step-by-step Cursor IDE setup
 - [Windsurf](./docs/WINDSURF_SETUP.md) - Windsurf integration with project rules
 - [Codex](./docs/CODEX_SETUP.md) - Codex integration guide
+- [Autohand Code](./docs/AUTOHAND_CODE_SETUP.md) - Autohand Code CLI setup
 - [Antigravity](./docs/ANTIGRAVITY_SETUP.md) - Antigravity integration guide
 
 ## Add Claude Skills (Optional)

--- a/docs/AUTOHAND_CODE_SETUP.md
+++ b/docs/AUTOHAND_CODE_SETUP.md
@@ -1,0 +1,31 @@
+# Autohand Code Setup
+
+Connect n8n-MCP to [Autohand Code](https://github.com/autohandai/code-cli/) for n8n workflow development.
+
+## Quick Setup via CLI
+
+On macOS, Linux, WSL, or Git Bash, add the documentation and validation tools with:
+
+```bash
+autohand mcp add n8n-mcp env MCP_MODE=stdio LOG_LEVEL=error DISABLE_CONSOLE_OUTPUT=true npx n8n-mcp
+```
+
+Add `--scope project` before `n8n-mcp` to save the server in the current project's `.autohand` configuration instead of your user configuration.
+
+For workflow management tools, also pass your n8n URL and API key through `env`:
+
+```bash
+autohand mcp add n8n-mcp env \
+  MCP_MODE=stdio \
+  LOG_LEVEL=error \
+  DISABLE_CONSOLE_OUTPUT=true \
+  N8N_API_URL=https://your-n8n-instance.com \
+  N8N_API_KEY=your-api-key \
+  npx n8n-mcp
+```
+
+Replace the URL and API key placeholders with your n8n instance details. Autohand Code starts the configured MCP server automatically; use `/mcp` inside a session to see its connection status and available tools.
+
+## Project Instructions
+
+For optimal results, add the instructions from the [main README's Claude Project Setup section](../README.md#claude-project-setup) to your project's `AGENTS.md`.


### PR DESCRIPTION
## What changed

Added a focused Autohand Code setup guide and linked it from the existing “Connect your IDE” list. The examples preserve n8n-MCP's required stdio environment variables and cover both documentation-only and full management configurations.

## Why

n8n-MCP already provides client-specific guides for Claude Code, Codex, Cursor, Windsurf, VS Code, and Antigravity. This gives Autohand Code users an equivalent, copy-pasteable setup path.

## Validation

- Verified the commands against the current Autohand Code MCP CLI implementation
- Ran `git diff --check`
