### PR TITLE
feat(http): add stateless dual-era MCP transport with SDK v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,12 @@ MCP_MODE=stdio
 PORT=3000
 HOST=0.0.0.0
 
+# Streamable HTTP transport lifecycle
+# - stateful (default): issue MCP session IDs and retain per-session transports
+# - stateless: process each POST independently; no session IDs or resumability
+# Stateless mode is recommended for API-style and horizontally scaled clients.
+# MCP_HTTP_TRANSPORT_MODE=stateful
+
 # Base URL Configuration (optional)
 # Set this when running behind a proxy or when the server is accessed via a different URL
 # than what it binds to. If not set, URLs will be auto-detected from proxy headers (if TRUST_PROXY is set)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Dual-era stateless MCP transport.** The HTTP MCP endpoint now uses the split TypeScript SDK v2 server packages and serves both initialize-era clients and MCP 2026-07-28 clients from the same request-scoped handler. Existing stateless tenant isolation is preserved, while modern clients can use the new discovery-based protocol without a separate endpoint. The embedded outgoing MCP client remains on SDK v1 only for its WebSocket transport, which SDK v2 no longer provides.
+
 ## [2.68.1] - 2026-08-04
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ COPY .env.example ./
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 COPY docker/parse-config.js /app/docker/
 COPY docker/n8n-mcp /usr/local/bin/
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/n8n-mcp
+RUN chmod 0755 /usr/local/bin/docker-entrypoint.sh /usr/local/bin/n8n-mcp
 
 # Add container labels
 LABEL org.opencontainers.image.source="https://github.com/czlonkowski/n8n-mcp"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ COPY tsconfig*.json ./
 RUN --mount=type=cache,target=/root/.npm \
     echo '{}' > package.json && \
     npm install --no-save typescript@^5.8.3 @types/node@^22.15.30 @types/express@^5.0.3 \
-        @modelcontextprotocol/sdk@1.28.0 dotenv@^16.5.0 express@^5.1.0 axios@^1.18.1 \
+        @modelcontextprotocol/sdk@1.28.0 @modelcontextprotocol/node@^2.0.0 \
+        @modelcontextprotocol/server@^2.0.0 @modelcontextprotocol/server-legacy@^2.0.0 \
+        dotenv@^16.5.0 express@^5.1.0 axios@^1.18.1 \
         n8n-workflow@2.32.1 uuid@^11.1.1 @types/uuid@^10.0.0 \
         openai@^4.77.0 zod@3.25.67 lru-cache@^11.2.1 @supabase/supabase-js@^2.57.4
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -11,7 +11,9 @@ COPY docker/docker-entrypoint.sh /usr/local/bin/
 COPY .env.example ./
 
 # Install only runtime dependencies
-RUN npm install --production @modelcontextprotocol/sdk better-sqlite3 express dotenv
+RUN npm install --production @modelcontextprotocol/sdk @modelcontextprotocol/node \
+    @modelcontextprotocol/server @modelcontextprotocol/server-legacy \
+    better-sqlite3 express dotenv
 
 # Make entrypoint executable
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh

--- a/docs/N8N_DEPLOYMENT.md
+++ b/docs/N8N_DEPLOYMENT.md
@@ -58,6 +58,7 @@ For development or custom testing:
 # Set environment variables
 export N8N_MODE=true
 export MCP_MODE=http                       # Required for HTTP mode
+export MCP_HTTP_TRANSPORT_MODE=stateless  # Optional; stateful remains the default
 export N8N_API_URL=http://localhost:5678  # Your n8n instance URL
 export N8N_API_KEY=your-api-key-here       # Your n8n API key
 export WEBHOOK_SECURITY_MODE=moderate      # Required when N8N_API_URL is localhost or RFC1918
@@ -85,6 +86,7 @@ curl http://localhost:3001/mcp
 |----------|----------|-------------|---------------|
 | `N8N_MODE` | Yes | Enables n8n integration mode | `true` |
 | `MCP_MODE` | Yes | Enables HTTP mode for n8n MCP Client | `http` |
+| `MCP_HTTP_TRANSPORT_MODE` | No | `stateful` retains MCP sessions; `stateless` processes each POST independently | `stateless` |
 | `N8N_API_URL` | Yes* | URL of your n8n instance | `http://localhost:5678` |
 | `N8N_API_KEY` | Yes* | n8n API key for workflow management | `n8n_api_xxx...` |
 | `WEBHOOK_SECURITY_MODE` | No | SSRF gate (`strict` default, `moderate`, `permissive`). Set to `moderate` when `N8N_API_URL` is localhost or an RFC1918 host on the same network. | `moderate` |
@@ -92,6 +94,18 @@ curl http://localhost:3001/mcp
 | `AUTH_TOKEN` | Yes | **MUST match MCP_AUTH_TOKEN exactly** | `secure-random-32-char-token` |
 | `PORT` | No | Port for the HTTP server | `3000` (default) |
 | `LOG_LEVEL` | No | Logging verbosity | `info`, `debug`, `error` |
+
+### Stateless Streamable HTTP
+
+Set `MCP_HTTP_TRANSPORT_MODE=stateless` for API-style clients that do not need
+resumable streams or unsolicited server messages. Every POST is authenticated
+and, in multi-tenant mode, must include the complete tenant header set. The
+server does not issue `Mcp-Session-Id`; stale client-supplied session IDs are
+ignored. `GET /mcp` and `DELETE /mcp` return `405` in this mode, while the
+legacy `/sse` endpoint remains available for explicitly stateful clients.
+
+`N8N_MODE` controls protocol and tool-description compatibility and is
+independent of the transport lifecycle. It can be used with either mode.
 
 *Required only for workflow management features. Documentation tools work without these.
 

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -129,6 +129,7 @@ These are automatically set by the Railway template:
 | Variable | Default Value | Description |
 |----------|--------------|-------------|
 | `N8N_MODE` | `false` | Enable n8n integration mode for MCP Client Tool |
+| `MCP_HTTP_TRANSPORT_MODE` | `stateful` | Use `stateless` for independent request processing without resumability |
 | `N8N_API_URL` | - | URL of your n8n instance (for workflow management) |
 | `N8N_API_KEY` | - | API key from n8n Settings → API |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "2.68.1",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/node": "^2.0.0",
         "@modelcontextprotocol/sdk": "1.28.0",
+        "@modelcontextprotocol/server": "^2.0.0",
+        "@modelcontextprotocol/server-legacy": "^2.0.0",
         "@n8n/n8n-nodes-langchain": "2.32.4",
         "@supabase/supabase-js": "^2.57.4",
         "dotenv": "^16.5.0",
@@ -6374,6 +6377,48 @@
         "zod-to-json-schema": "^3.24.1"
       }
     },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.28.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
@@ -6430,6 +6475,83 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-legacy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server-legacy/-/server-legacy-2.0.0.tgz",
+      "integrity": "sha512-LnffC1BSqFMHtMQxEz92lqDpHWma+ErV3ghdHDgdkCyYzVcCYKcUT5loq4kflty+Bf9C9qjJqbnphyBWyCqo8Q==",
+      "deprecated": "This package is a frozen copy of v1's SSE transport and OAuth Authorization Server helpers for migration purposes only. Use StreamableHTTP from @modelcontextprotocol/server and a dedicated OAuth server in production. Will not receive new features.",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "express-rate-limit": "^8.2.1",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-legacy/node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server-legacy/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@mongodb-js/saslprep": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^9.9.0",
+        "@modelcontextprotocol/client": "^2.0.0",
+        "@modelcontextprotocol/core": "^2.0.0",
         "@secretlint/secretlint-rule-preset-recommend": "9.3.4",
         "@testing-library/jest-dom": "^6.6.4",
         "@types/better-sqlite3": "^7.6.13",
@@ -6375,6 +6377,35 @@
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.24.1"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@modelcontextprotocol/core": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,10 @@
     "vitest": "^3.2.6"
   },
   "dependencies": {
+    "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/sdk": "1.28.0",
+    "@modelcontextprotocol/server": "^2.0.0",
+    "@modelcontextprotocol/server-legacy": "^2.0.0",
     "@n8n/n8n-nodes-langchain": "2.32.4",
     "@supabase/supabase-js": "^2.57.4",
     "dotenv": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,8 @@
     "package.runtime.json"
   ],
   "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
+    "@modelcontextprotocol/core": "^2.0.0",
     "@faker-js/faker": "^9.9.0",
     "@secretlint/secretlint-rule-preset-recommend": "9.3.4",
     "@testing-library/jest-dom": "^6.6.4",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -4,7 +4,10 @@
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {
+    "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/sdk": "1.28.0",
+    "@modelcontextprotocol/server": "^2.0.0",
+    "@modelcontextprotocol/server-legacy": "^2.0.0",
     "@supabase/supabase-js": "^2.57.4",
     "express": "^5.1.0",
     "express-rate-limit": "^7.1.5",
@@ -15,10 +18,11 @@
     "sql.js": "^1.13.0",
     "tslib": "^2.6.2",
     "uuid": "^11.1.1",
-    "axios": "^1.7.7"
+    "axios": "^1.7.7",
+    "zod": "3.25.67"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "optionalDependencies": {
     "better-sqlite3": "^11.10.0"

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.63.2",
+  "version": "2.66.0",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.66.0",
+  "version": "2.68.1",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/scripts/analyze-optimization.sh
+++ b/scripts/analyze-optimization.sh
@@ -25,7 +25,7 @@ fi
 
 # Check runtime dependencies
 echo -e "\n🎯 Runtime-only dependencies:"
-RUNTIME_DEPS="@modelcontextprotocol/sdk better-sqlite3 sql.js express dotenv"
+RUNTIME_DEPS="@modelcontextprotocol/sdk @modelcontextprotocol/server @modelcontextprotocol/node better-sqlite3 sql.js express dotenv"
 RUNTIME_SIZE=0
 for dep in $RUNTIME_DEPS; do
     if [ -d "node_modules/$dep" ]; then

--- a/scripts/demo-optimization.sh
+++ b/scripts/demo-optimization.sh
@@ -18,7 +18,9 @@ cat > $DEMO_DIR/package.json << 'EOF'
   "private": true,
   "main": "dist/mcp/index.js",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@modelcontextprotocol/sdk": "1.28.0",
+    "@modelcontextprotocol/server": "^2.0.0",
+    "@modelcontextprotocol/node": "^2.0.0",
     "better-sqlite3": "^11.10.0",
     "sql.js": "^1.13.0",
     "express": "^5.1.0",

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -282,7 +282,13 @@ class ReleaseAutomationTester {
         success(`Runtime dependencies: ${depCount} packages`);
         
         // List key dependencies
-        const keyDeps = ['@modelcontextprotocol/sdk', 'express', 'sql.js'];
+        const keyDeps = [
+          '@modelcontextprotocol/server',
+          '@modelcontextprotocol/node',
+          '@modelcontextprotocol/sdk',
+          'express',
+          'sql.js',
+        ];
         for (const dep of keyDeps) {
           if (runtimeJson.dependencies[dep]) {
             success(`Key dependency: ${dep} (${runtimeJson.dependencies[dep]})`);

--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -47,6 +47,18 @@ interface MultiTenantHeaders {
 const MAX_SESSIONS = Math.max(1, parseInt(process.env.N8N_MCP_MAX_SESSIONS || '100', 10));
 const SESSION_CLEANUP_INTERVAL = 5 * 60 * 1000; // 5 minutes
 
+export type HttpTransportMode = 'stateful' | 'stateless';
+
+export function getHttpTransportMode(value = process.env.MCP_HTTP_TRANSPORT_MODE): HttpTransportMode {
+  const normalized = value?.trim().toLowerCase() || 'stateful';
+  if (normalized !== 'stateful' && normalized !== 'stateless') {
+    throw new Error(
+      `Invalid MCP_HTTP_TRANSPORT_MODE "${value}". Expected "stateful" or "stateless".`
+    );
+  }
+  return normalized;
+}
+
 interface SessionMetrics {
   totalSessions: number;
   activeSessions: number;
@@ -118,15 +130,19 @@ export class SingleSessionHTTPServer {
   private authToken: string | null = null;
   private cleanupTimer: NodeJS.Timeout | null = null;
   private additionalTools?: AdditionalTool[];
+  private readonly transportMode: HttpTransportMode;
 
   constructor(options?: SingleSessionHTTPServerOptions) {
     this.additionalTools = options?.additionalTools;
+    this.transportMode = getHttpTransportMode();
     // Validate environment on construction
     this.validateEnvironment();
     // No longer pre-create session - will be created per initialize request following SDK pattern
     
-    // Start periodic session cleanup
-    this.startSessionCleanup();
+    // Stateless requests never populate the session maps.
+    if (this.transportMode === 'stateful') {
+      this.startSessionCleanup();
+    }
   }
   
   /**
@@ -557,6 +573,11 @@ export class SingleSessionHTTPServer {
           }
         }
 
+        if (this.transportMode === 'stateless') {
+          await this.handleStatelessRequest(req, res, instanceContext, startTime);
+          return;
+        }
+
         const sessionId = req.headers['mcp-session-id'] as string | undefined;
         const isInitialize = req.body ? isInitializeRequest(req.body) : false;
 
@@ -853,6 +874,65 @@ export class SingleSessionHTTPServer {
       }
     });
   }
+
+  /**
+   * Handle one Streamable HTTP request without retaining transport or tenant
+   * state. Authentication and instance-context validation happen in the
+   * shared Express route before this method is called.
+   */
+  private async handleStatelessRequest(
+    req: express.Request,
+    res: express.Response,
+    instanceContext: InstanceContext | undefined,
+    startTime: number
+  ): Promise<void> {
+    const server = new N8NDocumentationMCPServer(instanceContext, undefined, {
+      additionalTools: this.additionalTools,
+    });
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+    let cleanedUp = false;
+
+    const cleanup = async (): Promise<void> => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      try {
+        await transport.close();
+      } catch (error) {
+        logger.warn('Stateless transport cleanup failed', { error });
+      }
+      try {
+        await server.close();
+      } catch (error) {
+        logger.warn('Stateless server cleanup failed', { error });
+      }
+    };
+
+    if (typeof res.once === 'function') {
+      res.once('finish', () => { void cleanup(); });
+      res.once('close', () => { void cleanup(); });
+    }
+
+    try {
+      logger.info('handleRequest: Creating request-scoped stateless transport', {
+        requestId: req.get('x-request-id') || 'unknown',
+        method: req.body?.method,
+        instanceId: instanceContext?.instanceId,
+        ignoredSessionId: Boolean(req.headers['mcp-session-id']),
+      });
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+      logger.info('Stateless MCP request completed', {
+        duration: Date.now() - startTime,
+        method: req.body?.method,
+      });
+    } finally {
+      // Test doubles and non-streaming responses may not emit lifecycle events.
+      // Cleanup is idempotent, so it is safe to call here as well.
+      await cleanup();
+    }
+  }
   
 
   /**
@@ -1055,6 +1135,15 @@ export class SingleSessionHTTPServer {
     app.get('/mcp', authLimiter, async (req, res) => {
       if (!this.authenticateRequest(req, res)) return;
 
+      if (this.transportMode === 'stateless') {
+        res.status(405).json({
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Method not allowed in stateless mode' },
+          id: null
+        });
+        return;
+      }
+
       // Handle StreamableHTTP transport requests with new pattern
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
       const existingTransport = sessionId ? this.transports[sessionId] : undefined;
@@ -1228,6 +1317,15 @@ export class SingleSessionHTTPServer {
     // unauthenticated client can terminate arbitrary MCP sessions (GHSA-75hx-xj24-mqrw).
     app.delete('/mcp', authLimiter, async (req: express.Request, res: express.Response): Promise<void> => {
       if (!this.authenticateRequest(req, res)) return;
+
+      if (this.transportMode === 'stateless') {
+        res.status(405).json({
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Method not allowed in stateless mode' },
+          id: null
+        });
+        return;
+      }
 
       const mcpSessionId = req.headers['mcp-session-id'] as string;
       
@@ -1454,6 +1552,7 @@ export class SingleSessionHTTPServer {
       logger.info(`n8n MCP Single-Session HTTP Server started`, { 
         port, 
         host, 
+        transportMode: this.transportMode,
         environment: process.env.NODE_ENV || 'development',
         maxSessions: MAX_SESSIONS,
         sessionTimeout: this.sessionTimeout / 1000 / 60,
@@ -1467,7 +1566,10 @@ export class SingleSessionHTTPServer {
       
       console.log(`n8n MCP Single-Session HTTP Server running on ${host}:${port}`);
       console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
-      console.log(`Session Limits: ${MAX_SESSIONS} max sessions, ${this.sessionTimeout / 1000 / 60}min timeout`);
+      console.log(`Transport lifecycle: ${this.transportMode}`);
+      if (this.transportMode === 'stateful') {
+        console.log(`Session Limits: ${MAX_SESSIONS} max sessions, ${this.sessionTimeout / 1000 / 60}min timeout`);
+      }
       console.log(`Health check: ${endpoints.health}`);
       console.log(`MCP endpoint: ${endpoints.mcp}`);
       console.log(`SSE endpoint: ${baseUrl}/sse (legacy clients)`);

--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -6,8 +6,9 @@
  */
 import express from 'express';
 import rateLimit from 'express-rate-limit';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { createMcpHandler, isInitializeRequest } from '@modelcontextprotocol/server';
+import { SSEServerTransport } from '@modelcontextprotocol/server-legacy/sse';
+import { NodeStreamableHTTPServerTransport, toNodeHandler } from '@modelcontextprotocol/node';
 import { N8NDocumentationMCPServer } from './mcp/server';
 import { ConsoleManager } from './utils/console-manager';
 import { logger } from './utils/logger';
@@ -19,7 +20,6 @@ import { getStartupBaseUrl, formatEndpointUrls, detectBaseUrl } from './utils/ur
 import { PROJECT_VERSION } from './utils/version';
 import { v4 as uuidv4 } from 'uuid';
 import { createHash } from 'crypto';
-import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import {
   negotiateProtocolVersion,
   logProtocolNegotiation,
@@ -57,6 +57,39 @@ export function getHttpTransportMode(value = process.env.MCP_HTTP_TRANSPORT_MODE
     );
   }
   return normalized;
+}
+
+/**
+ * Build the SDK v2 per-request HTTP entry used by stateless deployments.
+ * The returned handler negotiates both initialize-era MCP and MCP 2026-07-28
+ * while constructing an isolated server with the caller's tenant context for
+ * every request.
+ */
+export function createDualEraStatelessMcpHandler(
+  instanceContext?: InstanceContext,
+  additionalTools: AdditionalTool[] = []
+) {
+  const requestServers = new Set<N8NDocumentationMCPServer>();
+  const handler = createMcpHandler(() => {
+    const server = new N8NDocumentationMCPServer(instanceContext, undefined, {
+      additionalTools,
+    });
+    requestServers.add(server);
+    return server.getProtocolServer();
+  }, {
+    legacy: 'stateless',
+    onerror: (error) => logger.error('Stateless MCP handler error', { error }),
+  });
+
+  return {
+    handler,
+    close: async (): Promise<void> => {
+      await handler.close();
+      await Promise.allSettled(
+        [...requestServers].map(async (server) => server.close())
+      );
+    },
+  };
 }
 
 interface SessionMetrics {
@@ -115,7 +148,7 @@ export class SingleSessionHTTPServer {
   // or `constructor` would both pass truthiness checks and write to
   // Object.prototype when we assign properties to the looked-up value.
   // Addresses CodeQL js/prototype-polluting-assignment at lines 309 and 399.
-  private transports: { [sessionId: string]: StreamableHTTPServerTransport | SSEServerTransport } = Object.create(null);
+  private transports: { [sessionId: string]: NodeStreamableHTTPServerTransport | SSEServerTransport } = Object.create(null);
   private servers: { [sessionId: string]: N8NDocumentationMCPServer } = Object.create(null);
   private sessionMetadata: { [sessionId: string]: { lastAccess: Date; createdAt: Date } } = Object.create(null);
   private sessionContexts: { [sessionId: string]: InstanceContext | undefined } = Object.create(null);
@@ -592,7 +625,7 @@ export class SingleSessionHTTPServer {
           isInitializeRequest: isInitialize
         });
         
-        let transport: StreamableHTTPServerTransport;
+        let transport: NodeStreamableHTTPServerTransport;
         
         if (isInitialize) {
           // Check session limits before creating new session
@@ -683,7 +716,7 @@ export class SingleSessionHTTPServer {
             additionalTools: this.additionalTools,
           });
 
-          transport = new StreamableHTTPServerTransport({
+          transport = new NodeStreamableHTTPServerTransport({
             sessionIdGenerator: () => sessionIdToUse,
             onsessioninitialized: (initializedSessionId: string) => {
               // Store both transport and server by session ID when session is initialized
@@ -758,7 +791,7 @@ export class SingleSessionHTTPServer {
             return;
           }
 
-          transport = this.transports[sessionId] as StreamableHTTPServerTransport;
+          transport = this.transports[sessionId] as NodeStreamableHTTPServerTransport;
 
           // TOCTOU guard: session may have been removed between the check above and here
           if (!transport) {
@@ -886,51 +919,28 @@ export class SingleSessionHTTPServer {
     instanceContext: InstanceContext | undefined,
     startTime: number
   ): Promise<void> {
-    const server = new N8NDocumentationMCPServer(instanceContext, undefined, {
-      additionalTools: this.additionalTools,
+    const dualEraHandler = createDualEraStatelessMcpHandler(
+      instanceContext,
+      this.additionalTools
+    );
+    const nodeHandler = toNodeHandler(dualEraHandler.handler, {
+      onerror: (error) => logger.error('Stateless MCP Node adapter error', { error }),
     });
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined,
-    });
-    let cleanedUp = false;
-
-    const cleanup = async (): Promise<void> => {
-      if (cleanedUp) return;
-      cleanedUp = true;
-      try {
-        await transport.close();
-      } catch (error) {
-        logger.warn('Stateless transport cleanup failed', { error });
-      }
-      try {
-        await server.close();
-      } catch (error) {
-        logger.warn('Stateless server cleanup failed', { error });
-      }
-    };
-
-    if (typeof res.once === 'function') {
-      res.once('finish', () => { void cleanup(); });
-      res.once('close', () => { void cleanup(); });
-    }
 
     try {
-      logger.info('handleRequest: Creating request-scoped stateless transport', {
+      logger.info('handleRequest: Creating dual-era request-scoped MCP handler', {
         requestId: req.get('x-request-id') || 'unknown',
         method: req.body?.method,
         instanceId: instanceContext?.instanceId,
         ignoredSessionId: Boolean(req.headers['mcp-session-id']),
       });
-      await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
+      await nodeHandler(req, res, req.body);
       logger.info('Stateless MCP request completed', {
         duration: Date.now() - startTime,
         method: req.body?.method,
       });
     } finally {
-      // Test doubles and non-streaming responses may not emit lifecycle events.
-      // Cleanup is idempotent, so it is safe to call here as well.
-      await cleanup();
+      await dualEraHandler.close();
     }
   }
   
@@ -1025,8 +1035,14 @@ export class SingleSessionHTTPServer {
       const allowedOrigin = process.env.CORS_ORIGIN || '*';
       res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
       res.setHeader('Access-Control-Allow-Methods', 'POST, GET, DELETE, OPTIONS');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, Accept, Mcp-Session-Id');
-      res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+      res.setHeader(
+        'Access-Control-Allow-Headers',
+        'Content-Type, Authorization, Accept, Mcp-Session-Id, MCP-Protocol-Version, Mcp-Method, Mcp-Name'
+      );
+      res.setHeader(
+        'Access-Control-Expose-Headers',
+        'Mcp-Session-Id, MCP-Protocol-Version, Mcp-Method, Mcp-Name'
+      );
       res.setHeader('Access-Control-Max-Age', '86400');
       
       if (req.method === 'OPTIONS') {
@@ -1147,7 +1163,7 @@ export class SingleSessionHTTPServer {
       // Handle StreamableHTTP transport requests with new pattern
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
       const existingTransport = sessionId ? this.transports[sessionId] : undefined;
-      if (existingTransport && existingTransport instanceof StreamableHTTPServerTransport) {
+      if (existingTransport && existingTransport instanceof NodeStreamableHTTPServerTransport) {
         // Let the StreamableHTTPServerTransport handle the GET request
         try {
           await existingTransport.handleRequest(req, res, undefined);

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -11,7 +11,7 @@
  * This implementation ensures the transport is properly initialized before handling requests.
  */
 import express from 'express';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { Server } from '@modelcontextprotocol/server';
 import { n8nDocumentationToolsFinal } from './mcp/tools';
 import { n8nManagementTools } from './mcp/tools-n8n-manager';
 import { N8NDocumentationMCPServer } from './mcp/server';
@@ -171,7 +171,10 @@ export async function startFixedHTTPServer() {
     const allowedOrigin = process.env.CORS_ORIGIN || '*';
     res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
     res.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, Accept');
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization, Accept, MCP-Protocol-Version, Mcp-Method, Mcp-Name'
+    );
     res.setHeader('Access-Control-Max-Age', '86400');
     
     if (req.method === 'OPTIONS') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export type {
   Tool,
   CallToolResult,
   ListToolsResult
-} from '@modelcontextprotocol/sdk/types.js';
+} from '@modelcontextprotocol/server';
 
 // Default export for convenience
 import N8NMCPEngine from './mcp-engine';

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -862,8 +862,9 @@ export class N8NDocumentationMCPServer {
       
       // Check if client is n8n (from initialization)
       const clientInfo = this.clientInfo;
-      const isN8nClient = clientInfo?.name?.includes('n8n') || 
-                         clientInfo?.name?.includes('langchain');
+      const isN8nClient = process.env.N8N_MODE === 'true' ||
+                          clientInfo?.name?.includes('n8n') ||
+                          clientInfo?.name?.includes('langchain');
       
       if (isN8nClient) {
         logger.info('Detected n8n client, using n8n-friendly tool descriptions');

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,14 +1,6 @@
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-  InitializeRequestSchema,
-  ListResourcesRequestSchema,
-  ListResourceTemplatesRequestSchema,
-  ReadResourceRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+import { Server } from '@modelcontextprotocol/server';
+import type { Tool } from '@modelcontextprotocol/server';
 import type { ToolDefinition } from '../types';
 import { existsSync, readFileSync, promises as fs } from 'fs';
 import path from 'path';
@@ -755,7 +747,7 @@ export class N8NDocumentationMCPServer {
 
   private setupHandlers(): void {
     // Handle initialization
-    this.server.setRequestHandler(InitializeRequestSchema, async (request) => {
+    this.server.setRequestHandler('initialize', async (request) => {
       const clientVersion = request.params.protocolVersion;
       const clientCapabilities = request.params.capabilities;
       const clientInfo = request.params.clientInfo;
@@ -806,7 +798,7 @@ export class N8NDocumentationMCPServer {
     });
 
     // Handle tool listing
-    this.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
+    this.server.setRequestHandler('tools/list', async (request) => {
       // Get disabled tools from environment variable
       const disabledTools = this.getDisabledTools();
 
@@ -893,7 +885,7 @@ export class N8NDocumentationMCPServer {
     });
 
     // Handle tool execution
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    this.server.setRequestHandler('tools/call', async (request) => {
       const { name, arguments: args } = request.params;
       
       // SECURITY (GHSA-wg4g-395p-mqv3): log metadata only, not raw arg values.
@@ -1158,7 +1150,7 @@ export class N8NDocumentationMCPServer {
     });
 
     // Handle ListResources: UI apps + skill markdown
-    this.server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    this.server.setRequestHandler('resources/list', async () => {
       const apps = UIAppRegistry.getAllApps();
       const skills = SkillResourceRegistry.getAll();
       return {
@@ -1182,12 +1174,12 @@ export class N8NDocumentationMCPServer {
     });
 
     // Advertise URI templates so capable clients can construct skill URIs
-    this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
+    this.server.setRequestHandler('resources/templates/list', async () => ({
       resourceTemplates: SkillResourceRegistry.getTemplates(),
     }));
 
     // Handle ReadResource for UI apps and skill markdown
-    this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    this.server.setRequestHandler('resources/read', async (request) => {
       const uri = request.params.uri;
 
       const uiMatch = uri.match(/^ui:\/\/n8n-mcp\/(.+)$/);
@@ -4190,6 +4182,15 @@ Full documentation is being prepared. For now, use get_node_essentials for confi
   }
 
   // Add connect method to accept any transport
+  /**
+   * Return the low-level SDK server to an official SDK serving entry.
+   * Tool registration remains owned by this wrapper; transports must not
+   * mutate handlers on the returned instance.
+   */
+  getProtocolServer(): Server {
+    return this.server;
+  }
+
   async connect(transport: any): Promise<void> {
     await this.ensureInitialized();
     await this.server.connect(transport);

--- a/src/types/additional-tools.ts
+++ b/src/types/additional-tools.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, Tool } from '@modelcontextprotocol/server';
 import type { InstanceContext } from './instance-context';
 
 export interface AdditionalToolContext {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,13 +32,13 @@ export interface ToolDefinition {
   name: string;
   description: string;
   inputSchema: {
-    type: string;
+    type: 'object';
     properties: Record<string, any>;
     required?: string[];
     additionalProperties?: boolean | Record<string, any>;
   };
   outputSchema?: {
-    type: string;
+    type: 'object';
     properties: Record<string, any>;
     required?: string[];
     additionalProperties?: boolean | Record<string, any>;

--- a/src/utils/mcp-client.ts
+++ b/src/utils/mcp-client.ts
@@ -1,19 +1,22 @@
+// The embedded n8n community node still offers the SDK v1 WebSocket transport,
+// which was intentionally removed from SDK v2. Keep this outgoing client on
+// the isolated v1 wire boundary while the MCP server itself uses SDK v2.
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/websocket.js';
 import {
   CallToolRequest,
-  ListToolsRequest,
-  ListResourcesRequest,
-  ReadResourceRequest,
-  ListPromptsRequest,
-  GetPromptRequest,
   CallToolResultSchema,
-  ListToolsResultSchema,
-  ListResourcesResultSchema,
-  ReadResourceResultSchema,
-  ListPromptsResultSchema,
+  GetPromptRequest,
   GetPromptResultSchema,
+  ListPromptsRequest,
+  ListPromptsResultSchema,
+  ListResourcesRequest,
+  ListResourcesResultSchema,
+  ListToolsRequest,
+  ListToolsResultSchema,
+  ReadResourceRequest,
+  ReadResourceResultSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 
 export interface MCPClientConfig {

--- a/tests/integration/mcp-protocol/dual-era-stateless.test.ts
+++ b/tests/integration/mcp-protocol/dual-era-stateless.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { createDualEraStatelessMcpHandler } from '../../../src/http-server-single-session';
+
+describe('dual-era stateless MCP handler', () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.allSettled(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  async function connect(mode: 'legacy' | 'modern') {
+    const dualEraHandler = createDualEraStatelessMcpHandler();
+    const client = new Client(
+      { name: `n8n-mcp-${mode}-test`, version: '1.0.0' },
+      mode === 'modern'
+        ? { versionNegotiation: { mode: { pin: '2026-07-28' } } }
+        : {}
+    );
+    const transport = new StreamableHTTPClientTransport(
+      new URL('http://n8n-mcp.test/mcp'),
+      {
+        fetch: (url, init) => dualEraHandler.handler.fetch(new Request(url, init)),
+      }
+    );
+
+    cleanups.push(async () => {
+      await client.close();
+      await dualEraHandler.close();
+    });
+    await client.connect(transport);
+    return client;
+  }
+
+  it('serves initialize-era clients without a session', async () => {
+    const client = await connect('legacy');
+    const result = await client.listTools();
+    const callResult = await client.callTool({
+      name: 'tools_documentation',
+      arguments: { topic: 'overview', depth: 'essentials' },
+    });
+
+    expect(client.getProtocolEra()).toBe('legacy');
+    expect(result.tools.some((tool) => tool.name === 'search_nodes')).toBe(true);
+    expect(callResult.content[0]?.type).toBe('text');
+  });
+
+  it('serves MCP 2026-07-28 clients on the same handler', async () => {
+    const client = await connect('modern');
+    const result = await client.listTools();
+    const callResult = await client.callTool({
+      name: 'tools_documentation',
+      arguments: { topic: 'overview', depth: 'essentials' },
+    });
+
+    expect(client.getProtocolEra()).toBe('modern');
+    expect(result.tools.some((tool) => tool.name === 'search_nodes')).toBe(true);
+    expect(callResult.content[0]?.type).toBe('text');
+  });
+});

--- a/tests/integration/mcp-protocol/error-handling.test.ts
+++ b/tests/integration/mcp-protocol/error-handling.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport, Client } from '@modelcontextprotocol/client';
+import { EmptyResultSchema } from '@modelcontextprotocol/core';
 import { TestableN8NMCPServer } from './test-helpers';
 
 describe('MCP Error Handling', () => {
@@ -48,7 +48,7 @@ describe('MCP Error Handling', () => {
         await (client as any).request({
           method: 'nonexistent/method',
           params: {}
-        });
+        }, EmptyResultSchema);
         expect.fail('Should have thrown an error');
       } catch (error: any) {
         expect(error).toBeDefined();

--- a/tests/integration/mcp-protocol/performance.test.ts
+++ b/tests/integration/mcp-protocol/performance.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport, Client } from '@modelcontextprotocol/client';
 import { TestableN8NMCPServer } from './test-helpers';
 
 describe('MCP Performance Tests', () => {
@@ -209,15 +208,19 @@ describe('MCP Performance Tests', () => {
       if (response.content && Array.isArray(response.content) && response.content[0]) {
         // MCP standard response format
         expect(response.content[0].type).toBe('text');
-        expect(response.content[0].text).toBeDefined();
+        const firstContent = response.content[0];
+        if (firstContent.type !== 'text') {
+          throw new Error(`Expected text content, received ${firstContent.type}`);
+        }
+        expect(firstContent.text).toBeDefined();
 
         try {
-          const parsed = JSON.parse(response.content[0].text);
+          const parsed = JSON.parse(firstContent.text);
           // search_nodes returns an object with results property
           results = parsed.results || parsed;
         } catch (e) {
           console.error('Failed to parse JSON:', e);
-          console.error('Response text was:', response.content[0].text);
+          console.error('Response text was:', firstContent.text);
           throw e;
         }
       } else if (Array.isArray(response)) {

--- a/tests/integration/mcp-protocol/protocol-compliance.test.ts
+++ b/tests/integration/mcp-protocol/protocol-compliance.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport, Client } from '@modelcontextprotocol/client';
 import { TestableN8NMCPServer } from './test-helpers';
 
 describe('MCP Protocol Compliance', () => {

--- a/tests/integration/mcp-protocol/session-management.test.ts
+++ b/tests/integration/mcp-protocol/session-management.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport, Client } from '@modelcontextprotocol/client';
 import { TestableN8NMCPServer } from './test-helpers';
 
 describe('MCP Session Management', { timeout: 15000 }, () => {

--- a/tests/integration/mcp-protocol/test-helpers.ts
+++ b/tests/integration/mcp-protocol/test-helpers.ts
@@ -1,11 +1,4 @@
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-  InitializeRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
+import { Server, Transport, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
 import { N8NDocumentationMCPServer } from '../../../src/mcp/server';
 
 let sharedMcpServer: N8NDocumentationMCPServer | null = null;
@@ -49,7 +42,7 @@ export class TestableN8NMCPServer {
 
   private setupHandlers(server: Server) {
     // Initialize handler
-    server.setRequestHandler(InitializeRequestSchema, async () => {
+    server.setRequestHandler('initialize', async () => {
       return {
         protocolVersion: '2024-11-05',
         capabilities: {
@@ -63,7 +56,7 @@ export class TestableN8NMCPServer {
     });
 
     // List tools handler
-    server.setRequestHandler(ListToolsRequestSchema, async () => {
+    server.setRequestHandler('tools/list', async () => {
       // Import the tools directly from the tools module
       const { n8nDocumentationToolsFinal } = await import('../../../src/mcp/tools');
       const { n8nManagementTools } = await import('../../../src/mcp/tools-n8n-manager');
@@ -79,7 +72,7 @@ export class TestableN8NMCPServer {
     });
 
     // Call tool handler
-    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.setRequestHandler('tools/call', async (request) => {
       try {
         // The mcpServer.executeTool returns raw data, we need to wrap it in the MCP response format
         const result = await this.mcpServer.executeTool(request.params.name, request.params.arguments || {});
@@ -98,8 +91,8 @@ export class TestableN8NMCPServer {
           throw error;
         }
         // Otherwise, wrap it in an MCP error
-        throw new McpError(
-          ErrorCode.InternalError,
+        throw new ProtocolError(
+          ProtocolErrorCode.InternalError,
           error.message || 'Unknown error'
         );
       }

--- a/tests/integration/mcp-protocol/tool-invocation.test.ts
+++ b/tests/integration/mcp-protocol/tool-invocation.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport, Client } from '@modelcontextprotocol/client';
 import { TestableN8NMCPServer } from './test-helpers';
 
 describe('MCP Tool Invocation', () => {

--- a/tests/integration/mcp-protocol/workflow-error-validation.test.ts
+++ b/tests/integration/mcp-protocol/workflow-error-validation.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport, Client } from '@modelcontextprotocol/client';
 import { TestableN8NMCPServer } from './test-helpers';
 
 describe('MCP Workflow Error Output Validation Integration', () => {

--- a/tests/test-mcp-tools-integration.js
+++ b/tests/test-mcp-tools-integration.js
@@ -5,8 +5,8 @@
  * Tests both get_node_source_code and list_available_nodes tools
  */
 
-const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
-const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
+const { Server } = require('@modelcontextprotocol/server');
+const { StdioServerTransport } = require('@modelcontextprotocol/server/stdio');
 const { N8NMCPServer } = require('../dist/mcp/server');
 
 // Test configuration

--- a/tests/unit/http-server-n8n-mode.test.ts
+++ b/tests/unit/http-server-n8n-mode.test.ts
@@ -20,8 +20,8 @@ vi.mock('../../src/mcp/server', () => ({
   }))
 }));
 
-vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
-  StreamableHTTPServerTransport: vi.fn().mockImplementation(() => ({
+vi.mock('@modelcontextprotocol/node', () => ({
+  NodeStreamableHTTPServerTransport: vi.fn().mockImplementation(() => ({
     handleRequest: vi.fn().mockImplementation(async (req: any, res: any) => {
       // Simulate successful MCP response
       if (process.env.N8N_MODE === 'true') {

--- a/tests/unit/http-server-session-management.test.ts
+++ b/tests/unit/http-server-session-management.test.ts
@@ -27,8 +27,8 @@ vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
     const mockTransport = {
       handleRequest: vi.fn().mockImplementation(async (req: any, res: any, body?: any) => {
         // For initialize requests, set the session ID header
-        if (body && body.method === 'initialize') {
-          res.setHeader('Mcp-Session-Id', mockTransport.sessionId || 'test-session-id');
+        if (body && body.method === 'initialize' && mockTransport.sessionId) {
+          res.setHeader('Mcp-Session-Id', mockTransport.sessionId);
         }
         res.status(200).json({
           jsonrpc: '2.0',
@@ -262,6 +262,66 @@ describe('HTTP Server Session Management', () => {
   }
 
   describe('Session Creation and Limits', () => {
+    it('should process independent stateless requests without retaining sessions', async () => {
+      process.env.MCP_HTTP_TRANSPORT_MODE = 'stateless';
+      server = new SingleSessionHTTPServer();
+      expect((server as any).cleanupTimer).toBeNull();
+
+      const initialize = createMockReqRes();
+      initialize.req.method = 'POST';
+      initialize.req.body = {
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {},
+        id: 1
+      };
+
+      await server.handleRequest(initialize.req as any, initialize.res as any);
+
+      expect(initialize.res.status).toHaveBeenCalledWith(200);
+      expect(initialize.res.getHeader('mcp-session-id')).toBeUndefined();
+      expect(server.getSessionInfo().sessions?.total).toBe(0);
+
+      const ping = createMockReqRes();
+      ping.req.method = 'POST';
+      ping.req.headers['mcp-session-id'] = 'stale-session-from-client';
+      ping.req.body = {
+        jsonrpc: '2.0',
+        method: 'ping',
+        params: {},
+        id: 2
+      };
+
+      await server.handleRequest(ping.req as any, ping.res as any);
+
+      expect(ping.res.status).toHaveBeenCalledWith(200);
+      expect(server.getSessionInfo().sessions?.total).toBe(0);
+    });
+
+    it('should reject an invalid HTTP transport mode', () => {
+      process.env.MCP_HTTP_TRANSPORT_MODE = 'invalid';
+      expect(() => new SingleSessionHTTPServer()).toThrow(
+        'Invalid MCP_HTTP_TRANSPORT_MODE'
+      );
+    });
+
+    it('should reject GET and DELETE on /mcp in stateless mode', async () => {
+      process.env.MCP_HTTP_TRANSPORT_MODE = 'stateless';
+      server = new SingleSessionHTTPServer();
+      await server.start();
+
+      for (const method of ['get', 'delete'] as const) {
+        const handler = findHandler(method, '/mcp');
+        const { req, res } = createMockReqRes();
+        req.headers.authorization = `Bearer ${TEST_AUTH_TOKEN}`;
+        req.method = method.toUpperCase();
+
+        await handler(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(405);
+      }
+    });
+
     it('should allow creation of sessions up to MAX_SESSIONS limit', async () => {
       server = new SingleSessionHTTPServer();
       await server.start();

--- a/tests/unit/http-server-session-management.test.ts
+++ b/tests/unit/http-server-session-management.test.ts
@@ -22,8 +22,15 @@ vi.mock('uuid', () => ({
 // Mock transport with session cleanup
 const mockTransports: { [key: string]: any } = {};
 
-vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
-  StreamableHTTPServerTransport: vi.fn().mockImplementation((options: any) => {
+vi.mock('@modelcontextprotocol/node', () => ({
+  toNodeHandler: vi.fn(() => async (_req: any, res: any, body?: any) => {
+    res.status(200).json({
+      jsonrpc: '2.0',
+      result: { success: true },
+      id: body?.id || 1,
+    });
+  }),
+  NodeStreamableHTTPServerTransport: vi.fn().mockImplementation((options: any) => {
     const mockTransport = {
       handleRequest: vi.fn().mockImplementation(async (req: any, res: any, body?: any) => {
         // For initialize requests, set the session ID header
@@ -59,7 +66,7 @@ vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
   })
 }));
 
-vi.mock('@modelcontextprotocol/sdk/server/sse.js', () => {
+vi.mock('@modelcontextprotocol/server-legacy/sse', () => {
   class MockSSEServerTransport {
     sessionId: string;
     onclose: (() => void) | null = null;
@@ -80,7 +87,9 @@ vi.mock('@modelcontextprotocol/sdk/server/sse.js', () => {
 
 vi.mock('../../src/mcp/server', () => ({
   N8NDocumentationMCPServer: vi.fn().mockImplementation(() => ({
-    connect: vi.fn().mockResolvedValue(undefined)
+    connect: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    getProtocolServer: vi.fn().mockReturnValue({}),
   }))
 }));
 
@@ -109,7 +118,14 @@ vi.mock('../../src/utils/version', () => ({
 }));
 
 // Mock isInitializeRequest
-vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
+vi.mock('@modelcontextprotocol/server', () => ({
+  createMcpHandler: vi.fn((factory: () => unknown) => {
+    factory();
+    return {
+      fetch: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
   isInitializeRequest: vi.fn((request: any) => {
     return request && request.method === 'initialize';
   })

--- a/tests/unit/http-server/pre-auth-log-redaction.test.ts
+++ b/tests/unit/http-server/pre-auth-log-redaction.test.ts
@@ -19,8 +19,8 @@ vi.mock('uuid', () => ({
 
 const mockTransports: { [key: string]: any } = {};
 
-vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
-  StreamableHTTPServerTransport: vi.fn().mockImplementation((options: any) => {
+vi.mock('@modelcontextprotocol/node', () => ({
+  NodeStreamableHTTPServerTransport: vi.fn().mockImplementation((options: any) => {
     const mockTransport = {
       handleRequest: vi.fn().mockImplementation(async (req: any, res: any, body?: any) => {
         if (body && body.method === 'initialize') {
@@ -45,7 +45,7 @@ vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
   }),
 }));
 
-vi.mock('@modelcontextprotocol/sdk/server/sse.js', () => ({
+vi.mock('@modelcontextprotocol/server-legacy/sse', () => ({
   SSEServerTransport: class {
     sessionId = 'sse-test';
     close = vi.fn().mockResolvedValue(undefined);
@@ -74,7 +74,7 @@ vi.mock('../../../src/utils/version', () => ({
   PROJECT_VERSION: '2.47.11',
 }));
 
-vi.mock('@modelcontextprotocol/sdk/types.js', () => ({
+vi.mock('@modelcontextprotocol/server', () => ({
   isInitializeRequest: vi.fn((request: any) => request && request.method === 'initialize'),
 }));
 

--- a/tests/unit/http-server/ssrf-gate.test.ts
+++ b/tests/unit/http-server/ssrf-gate.test.ts
@@ -32,8 +32,8 @@ vi.mock('../../../src/mcp/server', () => ({
 
 // Transport mock: if the gate allows the request through, respond 200.
 // Tests use this as the "gate passed, transport reached" signal.
-vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
-  StreamableHTTPServerTransport: vi.fn().mockImplementation(() => ({
+vi.mock('@modelcontextprotocol/node', () => ({
+  NodeStreamableHTTPServerTransport: vi.fn().mockImplementation(() => ({
     handleRequest: vi.fn().mockImplementation(async (_req: any, res: any) => {
       if (!res.headersSent) {
         res.status(200).json({ jsonrpc: '2.0', result: { success: true }, id: 1 });

--- a/tests/unit/mcp/additional-tools.test.ts
+++ b/tests/unit/mcp/additional-tools.test.ts
@@ -27,7 +27,18 @@ class TestableN8NMCPServer extends N8NDocumentationMCPServer {
     if (!handler) {
       throw new Error('tools/call handler not registered');
     }
-    return handler({ method: 'tools/call', params: { name, arguments: args } }, {});
+    return handler(
+      { method: 'tools/call', params: { name, arguments: args } },
+      {
+        mcpReq: {
+          id: 1,
+          method: 'tools/call',
+          requestState: () => undefined,
+          signal: new AbortController().signal,
+          send: vi.fn(),
+        },
+      }
+    );
   }
 }
 

--- a/tests/unit/mcp/n8n-mode-tool-descriptions.test.ts
+++ b/tests/unit/mcp/n8n-mode-tool-descriptions.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { N8NDocumentationMCPServer } from '../../../src/mcp/server';
+import { n8nFriendlyDescriptions } from '../../../src/mcp/tools-n8n-friendly';
+
+vi.mock('../../../src/database/database-adapter');
+vi.mock('../../../src/database/node-repository');
+vi.mock('../../../src/templates/template-service');
+vi.mock('../../../src/utils/logger');
+
+class TestableN8NMCPServer extends N8NDocumentationMCPServer {
+  public async simulateToolListRequest(clientName: string): Promise<any> {
+    (this as any).clientInfo = { name: clientName, version: '1.0.0' };
+
+    const handler = (this as any).server._requestHandlers?.get('tools/list');
+    if (!handler) {
+      throw new Error('tools/list handler not registered');
+    }
+
+    return handler({ method: 'tools/list', params: {} }, {});
+  }
+}
+
+describe('n8n-friendly tool descriptions', () => {
+  beforeEach(() => {
+    process.env.NODE_DB_PATH = ':memory:';
+  });
+
+  afterEach(() => {
+    delete process.env.NODE_DB_PATH;
+    delete process.env.N8N_MODE;
+  });
+
+  it.each([
+    { mode: 'true', clientName: 'generic-mcp-client', expected: true },
+    { mode: 'false', clientName: 'n8n-mcp-client', expected: true },
+    { mode: 'false', clientName: 'langchain-client', expected: true },
+    { mode: 'false', clientName: 'generic-mcp-client', expected: false },
+  ])('applies descriptions when N8N_MODE=$mode for $clientName', async ({ mode, clientName, expected }) => {
+    process.env.N8N_MODE = mode;
+    const server = new TestableN8NMCPServer();
+
+    const result = await server.simulateToolListRequest(clientName);
+    const searchNodes = result.tools.find((tool: { name: string }) => tool.name === 'search_nodes');
+
+    expect(searchNodes).toBeDefined();
+    expect(searchNodes.description === n8nFriendlyDescriptions.search_nodes.description).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- add request-scoped stateless Streamable HTTP mode for remote MCP clients
- move the server side to the split MCP TypeScript SDK v2 packages
- serve legacy initialize-era clients and MCP 2026-07-28 clients from the same endpoint
- preserve tenant isolation, CORS handling, disabled-tool policy, and n8n-mode tool descriptions
- retain SDK v1 only for the embedded outgoing WebSocket MCP client, because SDK v2 does not provide that transport

## Compatibility

Existing legacy clients continue to initialize without a session ID. SDK v2 clients can negotiate the modern protocol and use the same tool surface. The implementation remains stateless: each HTTP request receives an isolated server/transport pair.

This PR is transport-only. Response bounding and artifact pagination are intentionally split into a separate independent PR.

## Verification

- `npm run build`
- 82 focused transport and compatibility tests:
  - `tests/integration/mcp-protocol/dual-era-stateless.test.ts`
  - `tests/unit/http-server-session-management.test.ts`
  - `tests/unit/http-server-n8n-mode.test.ts`
- production Docker image build
- rebased onto upstream `main` at 2.68.1

The branch also declares the SDK v2 client/core packages used by its integration test as development-only dependencies.
