### PR TITLE
fix: prevent telemetry from blocking workflow updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.65.2] - 2026-07-23
+
+### Fixed
+
+- **Telemetry can no longer stall workflow mutation requests (#944).** Supabase telemetry requests now have a hard two-second deadline that aborts the underlying fetch, and best-effort delivery makes only one attempt so a failed request cannot leave retry work behind. Partial and full workflow-update handlers detach mutation telemetry explicitly, while a global flush queue serializes events, workflows, and mutations without silently dropping concurrent batches.
+
 ## [2.65.1] - 2026-07-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.65.1",
+  "version": "2.65.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.65.1",
+      "version": "2.65.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.65.1",
+  "version": "2.65.2",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -1110,7 +1110,7 @@ export async function handleUpdateWorkflow(
 
     // Track successful mutation
     if (workflowBefore) {
-      trackWorkflowMutationForFullUpdate({
+      void trackWorkflowMutationForFullUpdate({
         sessionId,
         toolName: 'n8n_update_full_workflow',
         userIntent,
@@ -1137,7 +1137,7 @@ export async function handleUpdateWorkflow(
   } catch (error) {
     // Track failed mutation
     if (workflowBefore) {
-      trackWorkflowMutationForFullUpdate({
+      void trackWorkflowMutationForFullUpdate({
         sessionId,
         toolName: 'n8n_update_full_workflow',
         userIntent,

--- a/src/mcp/handlers-workflow-diff.ts
+++ b/src/mcp/handlers-workflow-diff.ts
@@ -582,7 +582,7 @@ export async function handleUpdatePartialWorkflow(
 
       // Track successful mutation
       if (workflowBefore && !input.validateOnly) {
-        trackWorkflowMutation({
+        void trackWorkflowMutation({
           sessionId,
           toolName: 'n8n_update_partial_workflow',
           userIntent: input.intent || 'Partial workflow update',
@@ -619,7 +619,7 @@ export async function handleUpdatePartialWorkflow(
     } catch (error) {
       // Track failed mutation
       if (workflowBefore && !input.validateOnly) {
-        trackWorkflowMutation({
+        void trackWorkflowMutation({
           sessionId,
           toolName: 'n8n_update_partial_workflow',
           userIntent: input.intent || 'Partial workflow update',
@@ -774,4 +774,3 @@ async function trackWorkflowMutation(data: any): Promise<void> {
     logger.debug('Telemetry tracking failed:', error);
   }
 }
-

--- a/src/telemetry/batch-processor.ts
+++ b/src/telemetry/batch-processor.ts
@@ -233,8 +233,6 @@ export class TelemetryBatchProcessor {
    * Flush events with batching
    */
   private async flushEvents(events: TelemetryEvent[]): Promise<boolean> {
-    if (events.length === 0) return true;
-
     try {
       // Batch events
       const batches = this.createBatches(events, TELEMETRY_CONFIG.MAX_BATCH_SIZE);
@@ -281,8 +279,6 @@ export class TelemetryBatchProcessor {
    * Flush workflows with deduplication
    */
   private async flushWorkflows(workflows: WorkflowTelemetry[]): Promise<boolean> {
-    if (workflows.length === 0) return true;
-
     try {
       // Deduplicate workflows by hash
       const uniqueWorkflows = this.deduplicateWorkflows(workflows);
@@ -333,8 +329,6 @@ export class TelemetryBatchProcessor {
    * Flush workflow mutations with batching
    */
   private async flushMutations(mutations: WorkflowMutationRecord[]): Promise<boolean> {
-    if (mutations.length === 0) return true;
-
     try {
       // Batch mutations
       const batches = this.createBatches(mutations, TELEMETRY_CONFIG.MAX_BATCH_SIZE);
@@ -399,6 +393,7 @@ export class TelemetryBatchProcessor {
     operationName: string
   ): Promise<T | null> {
     let timeout: ReturnType<typeof setTimeout> | undefined;
+    let result: T | null;
 
     try {
       const timeoutPromise = new Promise<never>((_, reject) => {
@@ -410,15 +405,17 @@ export class TelemetryBatchProcessor {
         }
       });
 
-      return await Promise.race([operation(), timeoutPromise]) as T;
+      result = await Promise.race([operation(), timeoutPromise]) as T;
     } catch (error) {
       logger.debug(`${operationName} failed:`, error);
-      return null;
-    } finally {
-      if (timeout !== undefined) {
-        clearTimeout(timeout);
-      }
+      result = null;
     }
+
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+
+    return result;
   }
 
   /**

--- a/src/telemetry/batch-processor.ts
+++ b/src/telemetry/batch-processor.ts
@@ -239,7 +239,8 @@ export class TelemetryBatchProcessor {
       // Batch events
       const batches = this.createBatches(events, TELEMETRY_CONFIG.MAX_BATCH_SIZE);
 
-      for (const batch of batches) {
+      for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
+        const batch = batches[batchIndex];
         const result = await this.executeWithTimeout(async () => {
           const { error } = await this.supabase!
             .from('telemetry_events')
@@ -257,9 +258,9 @@ export class TelemetryBatchProcessor {
           this.metrics.eventsTracked += batch.length;
           this.metrics.batchesSent++;
         } else {
-          this.metrics.eventsFailed += batch.length;
-          this.metrics.batchesFailed++;
-          this.addToDeadLetterQueue(batch);
+          const unsent = this.addUnsentBatchesToDeadLetterQueue(batches, batchIndex);
+          this.metrics.eventsFailed += unsent.itemCount;
+          this.metrics.batchesFailed += unsent.batchCount;
           return false;
         }
       }
@@ -290,7 +291,8 @@ export class TelemetryBatchProcessor {
       // Batch workflows
       const batches = this.createBatches(uniqueWorkflows, TELEMETRY_CONFIG.MAX_BATCH_SIZE);
 
-      for (const batch of batches) {
+      for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
+        const batch = batches[batchIndex];
         const result = await this.executeWithTimeout(async () => {
           const { error } = await this.supabase!
             .from('telemetry_workflows')
@@ -308,9 +310,9 @@ export class TelemetryBatchProcessor {
           this.metrics.eventsTracked += batch.length;
           this.metrics.batchesSent++;
         } else {
-          this.metrics.eventsFailed += batch.length;
-          this.metrics.batchesFailed++;
-          this.addToDeadLetterQueue(batch);
+          const unsent = this.addUnsentBatchesToDeadLetterQueue(batches, batchIndex);
+          this.metrics.eventsFailed += unsent.itemCount;
+          this.metrics.batchesFailed += unsent.batchCount;
           return false;
         }
       }
@@ -337,7 +339,8 @@ export class TelemetryBatchProcessor {
       // Batch mutations
       const batches = this.createBatches(mutations, TELEMETRY_CONFIG.MAX_BATCH_SIZE);
 
-      for (const batch of batches) {
+      for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
+        const batch = batches[batchIndex];
         const result = await this.executeWithTimeout(async () => {
           // Convert camelCase to snake_case for Supabase
           const snakeCaseBatch = batch.map(mutation => mutationToSupabaseFormat(mutation));
@@ -366,9 +369,9 @@ export class TelemetryBatchProcessor {
           this.metrics.eventsTracked += batch.length;
           this.metrics.batchesSent++;
         } else {
-          this.metrics.eventsFailed += batch.length;
-          this.metrics.batchesFailed++;
-          this.addToDeadLetterQueue(batch);
+          const unsent = this.addUnsentBatchesToDeadLetterQueue(batches, batchIndex);
+          this.metrics.eventsFailed += unsent.itemCount;
+          this.metrics.batchesFailed += unsent.batchCount;
           return false;
         }
       }
@@ -446,6 +449,22 @@ export class TelemetryBatchProcessor {
     }
 
     return unique;
+  }
+
+  /**
+   * Preserve the failed batch and every later batch that was not attempted.
+   */
+  private addUnsentBatchesToDeadLetterQueue<
+    T extends TelemetryEvent | WorkflowTelemetry | WorkflowMutationRecord
+  >(batches: T[][], failedBatchIndex: number): { itemCount: number; batchCount: number } {
+    const unsentBatches = batches.slice(failedBatchIndex);
+    const unsentItems = unsentBatches.flat();
+    this.addToDeadLetterQueue(unsentItems);
+
+    return {
+      itemCount: unsentItems.length,
+      batchCount: unsentBatches.length,
+    };
   }
 
   /**

--- a/src/telemetry/batch-processor.ts
+++ b/src/telemetry/batch-processor.ts
@@ -93,7 +93,7 @@ export class TelemetryBatchProcessor {
 
     // Set up periodic flushing
     this.flushTimer = setInterval(() => {
-      this.requestFlush();
+      void this.requestFlush();
     }, TELEMETRY_CONFIG.BATCH_FLUSH_INTERVAL);
 
     // Prevent timer from keeping process alive
@@ -103,14 +103,14 @@ export class TelemetryBatchProcessor {
     }
 
     // Set up process exit handlers with stored references for cleanup
-    this.eventListeners.beforeExit = () => this.requestFlush();
+    this.eventListeners.beforeExit = () => {
+      void this.requestFlush();
+    };
     this.eventListeners.sigint = () => {
-      this.requestFlush();
-      process.exit(0);
+      void this.flushAndExit();
     };
     this.eventListeners.sigterm = () => {
-      this.requestFlush();
-      process.exit(0);
+      void this.flushAndExit();
     };
 
     process.on('beforeExit', this.eventListeners.beforeExit);
@@ -150,14 +150,19 @@ export class TelemetryBatchProcessor {
    * Ask the queue owner to flush, falling back to an empty processor flush for
    * standalone callers that do not provide a queue-aware callback.
    */
-  private requestFlush(): void {
+  private requestFlush(): Promise<void> {
     const requestedFlush = this.onFlushRequested
       ? this.onFlushRequested()
       : this.flush();
 
-    void Promise.resolve(requestedFlush).catch(error => {
+    return Promise.resolve(requestedFlush).catch(error => {
       logger.debug('Scheduled telemetry flush failed:', error);
     });
+  }
+
+  private async flushAndExit(): Promise<void> {
+    await this.requestFlush();
+    process.exit(0);
   }
 
   /**

--- a/src/telemetry/batch-processor.ts
+++ b/src/telemetry/batch-processor.ts
@@ -460,10 +460,13 @@ export class TelemetryBatchProcessor {
 
     const events: TelemetryEvent[] = [];
     const workflows: WorkflowTelemetry[] = [];
+    const mutations: WorkflowMutationRecord[] = [];
 
-    // Separate events and workflows
+    // Separate events, workflows, and mutations
     for (const item of this.deadLetterQueue) {
-      if ('workflow_hash' in item) {
+      if ('workflowHashBefore' in item) {
+        mutations.push(item as WorkflowMutationRecord);
+      } else if ('workflow_hash' in item) {
         workflows.push(item as WorkflowTelemetry);
       } else {
         events.push(item as TelemetryEvent);
@@ -479,6 +482,9 @@ export class TelemetryBatchProcessor {
     }
     if (workflows.length > 0) {
       await this.flushWorkflows(workflows);
+    }
+    if (mutations.length > 0) {
+      await this.flushMutations(mutations);
     }
   }
 

--- a/src/telemetry/batch-processor.ts
+++ b/src/telemetry/batch-processor.ts
@@ -64,22 +64,16 @@ export class TelemetryBatchProcessor {
   } = {};
   private started: boolean = false;
   private readonly operationTimeout: number;
-  private readonly retryDelay: number;
-  private readonly random: () => number;
 
   constructor(
     private supabase: SupabaseClient | null,
     private isEnabled: () => boolean,
     timing: {
       operationTimeout?: number;
-      retryDelay?: number;
-      random?: () => number;
     } = {}
   ) {
     this.circuitBreaker = new TelemetryCircuitBreaker();
     this.operationTimeout = timing.operationTimeout ?? TELEMETRY_CONFIG.OPERATION_TIMEOUT;
-    this.retryDelay = timing.retryDelay ?? TELEMETRY_CONFIG.RETRY_DELAY;
-    this.random = timing.random ?? Math.random;
   }
 
   /**
@@ -229,7 +223,7 @@ export class TelemetryBatchProcessor {
       const batches = this.createBatches(events, TELEMETRY_CONFIG.MAX_BATCH_SIZE);
 
       for (const batch of batches) {
-        const result = await this.executeWithRetry(async () => {
+        const result = await this.executeWithTimeout(async () => {
           const { error } = await this.supabase!
             .from('telemetry_events')
             .insert(batch);
@@ -280,7 +274,7 @@ export class TelemetryBatchProcessor {
       const batches = this.createBatches(uniqueWorkflows, TELEMETRY_CONFIG.MAX_BATCH_SIZE);
 
       for (const batch of batches) {
-        const result = await this.executeWithRetry(async () => {
+        const result = await this.executeWithTimeout(async () => {
           const { error } = await this.supabase!
             .from('telemetry_workflows')
             .insert(batch);
@@ -327,7 +321,7 @@ export class TelemetryBatchProcessor {
       const batches = this.createBatches(mutations, TELEMETRY_CONFIG.MAX_BATCH_SIZE);
 
       for (const batch of batches) {
-        const result = await this.executeWithRetry(async () => {
+        const result = await this.executeWithTimeout(async () => {
           // Convert camelCase to snake_case for Supabase
           const snakeCaseBatch = batch.map(mutation => mutationToSupabaseFormat(mutation));
 
@@ -378,54 +372,33 @@ export class TelemetryBatchProcessor {
   }
 
   /**
-   * Execute operation with exponential backoff retry
+   * Execute one operation attempt bounded by the configured timeout
    */
-  private async executeWithRetry<T>(
+  private async executeWithTimeout<T>(
     operation: () => Promise<T>,
     operationName: string
   ): Promise<T | null> {
-    let lastError: Error | null = null;
-    let delay = this.retryDelay;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
 
-    for (let attempt = 1; attempt <= TELEMETRY_CONFIG.MAX_RETRIES; attempt++) {
-      let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error('Operation timed out')), this.operationTimeout);
 
-      try {
-        // Create a timeout promise
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          timeout = setTimeout(() => reject(new Error('Operation timed out')), this.operationTimeout);
-
-          // A best-effort telemetry request must not keep the process alive.
-          if (typeof timeout === 'object' && timeout !== null && 'unref' in timeout) {
-            timeout.unref();
-          }
-        });
-
-        // Race between operation and timeout
-        const result = await Promise.race([operation(), timeoutPromise]) as T;
-        return result;
-      } catch (error) {
-        lastError = error as Error;
-        logger.debug(`${operationName} attempt ${attempt} failed:`, error);
-
-        if (attempt < TELEMETRY_CONFIG.MAX_RETRIES) {
-          if (delay > 0) {
-            // Exponential backoff with jitter
-            const jitter = this.random() * 0.3 * delay; // 30% jitter
-            const waitTime = delay + jitter;
-            await new Promise(resolve => setTimeout(resolve, waitTime));
-          }
-          delay *= 2; // Double the delay for next attempt
+        // A best-effort telemetry request must not keep the process alive.
+        if (typeof timeout === 'object' && timeout !== null && 'unref' in timeout) {
+          timeout.unref();
         }
-      } finally {
-        if (timeout !== undefined) {
-          clearTimeout(timeout);
-        }
+      });
+
+      return await Promise.race([operation(), timeoutPromise]) as T;
+    } catch (error) {
+      logger.debug(`${operationName} failed:`, error);
+      return null;
+    } finally {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
       }
     }
-
-    logger.debug(`${operationName} failed after ${TELEMETRY_CONFIG.MAX_RETRIES} attempts:`, lastError);
-    return null;
   }
 
   /**

--- a/src/telemetry/batch-processor.ts
+++ b/src/telemetry/batch-processor.ts
@@ -42,9 +42,7 @@ function mutationToSupabaseFormat(mutation: WorkflowMutationRecord): Record<stri
 
 export class TelemetryBatchProcessor {
   private flushTimer?: NodeJS.Timeout;
-  private isFlushingEvents: boolean = false;
-  private isFlushingWorkflows: boolean = false;
-  private isFlushingMutations: boolean = false;
+  private flushQueue: Promise<void> = Promise.resolve();
   private circuitBreaker: TelemetryCircuitBreaker;
   private metrics: TelemetryMetrics = {
     eventsTracked: 0,
@@ -65,12 +63,23 @@ export class TelemetryBatchProcessor {
     sigterm?: () => void;
   } = {};
   private started: boolean = false;
+  private readonly operationTimeout: number;
+  private readonly retryDelay: number;
+  private readonly random: () => number;
 
   constructor(
     private supabase: SupabaseClient | null,
-    private isEnabled: () => boolean
+    private isEnabled: () => boolean,
+    timing: {
+      operationTimeout?: number;
+      retryDelay?: number;
+      random?: () => number;
+    } = {}
   ) {
     this.circuitBreaker = new TelemetryCircuitBreaker();
+    this.operationTimeout = timing.operationTimeout ?? TELEMETRY_CONFIG.OPERATION_TIMEOUT;
+    this.retryDelay = timing.retryDelay ?? TELEMETRY_CONFIG.RETRY_DELAY;
+    this.random = timing.random ?? Math.random;
   }
 
   /**
@@ -143,7 +152,28 @@ export class TelemetryBatchProcessor {
   /**
    * Flush events, workflows, and mutations to Supabase
    */
-  async flush(events?: TelemetryEvent[], workflows?: WorkflowTelemetry[], mutations?: WorkflowMutationRecord[]): Promise<void> {
+  flush(events?: TelemetryEvent[], workflows?: WorkflowTelemetry[], mutations?: WorkflowMutationRecord[]): Promise<void> {
+    // Capture each caller's batches before queuing so later caller mutations cannot
+    // change or empty data that is waiting behind an in-progress flush.
+    const queuedEvents = events ? [...events] : undefined;
+    const queuedWorkflows = workflows ? [...workflows] : undefined;
+    const queuedMutations = mutations ? [...mutations] : undefined;
+
+    const queuedFlush = this.flushQueue.then(() =>
+      this.flushQueuedBatch(queuedEvents, queuedWorkflows, queuedMutations)
+    );
+
+    // Keep the queue usable after an unexpected rejection while preserving that
+    // rejection for the caller that owns this particular flush.
+    this.flushQueue = queuedFlush.catch(() => undefined);
+    return queuedFlush;
+  }
+
+  private async flushQueuedBatch(
+    events?: TelemetryEvent[],
+    workflows?: WorkflowTelemetry[],
+    mutations?: WorkflowMutationRecord[]
+  ): Promise<void> {
     if (!this.isEnabled() || !this.supabase) return;
 
     // Check circuit breaker
@@ -192,9 +222,7 @@ export class TelemetryBatchProcessor {
    * Flush events with batching
    */
   private async flushEvents(events: TelemetryEvent[]): Promise<boolean> {
-    if (this.isFlushingEvents || events.length === 0) return true;
-
-    this.isFlushingEvents = true;
+    if (events.length === 0) return true;
 
     try {
       // Batch events
@@ -234,8 +262,6 @@ export class TelemetryBatchProcessor {
         { error: error instanceof Error ? error.message : String(error) },
         true
       );
-    } finally {
-      this.isFlushingEvents = false;
     }
   }
 
@@ -243,9 +269,7 @@ export class TelemetryBatchProcessor {
    * Flush workflows with deduplication
    */
   private async flushWorkflows(workflows: WorkflowTelemetry[]): Promise<boolean> {
-    if (this.isFlushingWorkflows || workflows.length === 0) return true;
-
-    this.isFlushingWorkflows = true;
+    if (workflows.length === 0) return true;
 
     try {
       // Deduplicate workflows by hash
@@ -289,8 +313,6 @@ export class TelemetryBatchProcessor {
         { error: error instanceof Error ? error.message : String(error) },
         true
       );
-    } finally {
-      this.isFlushingWorkflows = false;
     }
   }
 
@@ -298,9 +320,7 @@ export class TelemetryBatchProcessor {
    * Flush workflow mutations with batching
    */
   private async flushMutations(mutations: WorkflowMutationRecord[]): Promise<boolean> {
-    if (this.isFlushingMutations || mutations.length === 0) return true;
-
-    this.isFlushingMutations = true;
+    if (mutations.length === 0) return true;
 
     try {
       // Batch mutations
@@ -354,8 +374,6 @@ export class TelemetryBatchProcessor {
         { error: error instanceof Error ? error.message : String(error) },
         true
       );
-    } finally {
-      this.isFlushingMutations = false;
     }
   }
 
@@ -367,19 +385,20 @@ export class TelemetryBatchProcessor {
     operationName: string
   ): Promise<T | null> {
     let lastError: Error | null = null;
-    let delay = TELEMETRY_CONFIG.RETRY_DELAY;
+    let delay = this.retryDelay;
 
     for (let attempt = 1; attempt <= TELEMETRY_CONFIG.MAX_RETRIES; attempt++) {
-      try {
-        // In test environment, execute without timeout but still handle errors
-        if (process.env.NODE_ENV === 'test' && process.env.VITEST) {
-          const result = await operation();
-          return result;
-        }
+      let timeout: ReturnType<typeof setTimeout> | undefined;
 
+      try {
         // Create a timeout promise
         const timeoutPromise = new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error('Operation timed out')), TELEMETRY_CONFIG.OPERATION_TIMEOUT);
+          timeout = setTimeout(() => reject(new Error('Operation timed out')), this.operationTimeout);
+
+          // A best-effort telemetry request must not keep the process alive.
+          if (typeof timeout === 'object' && timeout !== null && 'unref' in timeout) {
+            timeout.unref();
+          }
         });
 
         // Race between operation and timeout
@@ -390,15 +409,17 @@ export class TelemetryBatchProcessor {
         logger.debug(`${operationName} attempt ${attempt} failed:`, error);
 
         if (attempt < TELEMETRY_CONFIG.MAX_RETRIES) {
-          // Skip delay in test environment when using fake timers
-          if (!(process.env.NODE_ENV === 'test' && process.env.VITEST)) {
+          if (delay > 0) {
             // Exponential backoff with jitter
-            const jitter = Math.random() * 0.3 * delay; // 30% jitter
+            const jitter = this.random() * 0.3 * delay; // 30% jitter
             const waitTime = delay + jitter;
             await new Promise(resolve => setTimeout(resolve, waitTime));
-            delay *= 2; // Double the delay for next attempt
           }
-          // In test mode, continue to next retry attempt without delay
+          delay *= 2; // Double the delay for next attempt
+        }
+      } finally {
+        if (timeout !== undefined) {
+          clearTimeout(timeout);
         }
       }
     }

--- a/src/telemetry/batch-processor.ts
+++ b/src/telemetry/batch-processor.ts
@@ -64,16 +64,19 @@ export class TelemetryBatchProcessor {
   } = {};
   private started: boolean = false;
   private readonly operationTimeout: number;
+  private readonly onFlushRequested?: () => void | Promise<void>;
 
   constructor(
     private supabase: SupabaseClient | null,
     private isEnabled: () => boolean,
-    timing: {
+    options: {
       operationTimeout?: number;
+      onFlushRequested?: () => void | Promise<void>;
     } = {}
   ) {
     this.circuitBreaker = new TelemetryCircuitBreaker();
-    this.operationTimeout = timing.operationTimeout ?? TELEMETRY_CONFIG.OPERATION_TIMEOUT;
+    this.operationTimeout = options.operationTimeout ?? TELEMETRY_CONFIG.OPERATION_TIMEOUT;
+    this.onFlushRequested = options.onFlushRequested;
   }
 
   /**
@@ -90,7 +93,7 @@ export class TelemetryBatchProcessor {
 
     // Set up periodic flushing
     this.flushTimer = setInterval(() => {
-      this.flush();
+      this.requestFlush();
     }, TELEMETRY_CONFIG.BATCH_FLUSH_INTERVAL);
 
     // Prevent timer from keeping process alive
@@ -100,13 +103,13 @@ export class TelemetryBatchProcessor {
     }
 
     // Set up process exit handlers with stored references for cleanup
-    this.eventListeners.beforeExit = () => this.flush();
+    this.eventListeners.beforeExit = () => this.requestFlush();
     this.eventListeners.sigint = () => {
-      this.flush();
+      this.requestFlush();
       process.exit(0);
     };
     this.eventListeners.sigterm = () => {
-      this.flush();
+      this.requestFlush();
       process.exit(0);
     };
 
@@ -141,6 +144,20 @@ export class TelemetryBatchProcessor {
     this.started = false;
 
     logger.debug('Telemetry batch processor stopped');
+  }
+
+  /**
+   * Ask the queue owner to flush, falling back to an empty processor flush for
+   * standalone callers that do not provide a queue-aware callback.
+   */
+  private requestFlush(): void {
+    const requestedFlush = this.onFlushRequested
+      ? this.onFlushRequested()
+      : this.flush();
+
+    void Promise.resolve(requestedFlush).catch(error => {
+      logger.debug('Scheduled telemetry flush failed:', error);
+    });
   }
 
   /**

--- a/src/telemetry/early-error-logger.ts
+++ b/src/telemetry/early-error-logger.ts
@@ -15,6 +15,7 @@ import { TelemetryConfigManager } from './config-manager';
 import { TELEMETRY_BACKEND } from './telemetry-types';
 import { StartupCheckpoint, isValidCheckpoint, getCheckpointDescription } from './startup-checkpoints';
 import { sanitizeErrorMessageCore } from './error-sanitization-utils';
+import { telemetryFetch } from './telemetry-fetch';
 import { logger } from '../utils/logger';
 
 /**
@@ -22,15 +23,25 @@ import { logger } from '../utils/logger';
  * Prevents hanging if Supabase is unreachable
  */
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, operation: string): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
   try {
     const timeoutPromise = new Promise<T>((_, reject) => {
-      setTimeout(() => reject(new Error(`${operation} timeout after ${timeoutMs}ms`)), timeoutMs);
+      timer = setTimeout(
+        () => reject(new Error(`${operation} timeout after ${timeoutMs}ms`)),
+        timeoutMs
+      );
+      timer.unref?.();
     });
 
     return await Promise.race([promise, timeoutPromise]);
   } catch (error) {
     logger.debug(`${operation} failed or timed out:`, error);
     return null;
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
   }
 }
 
@@ -98,6 +109,9 @@ export class EarlyErrorLogger {
           auth: {
             persistSession: false,
             autoRefreshToken: false,
+          },
+          global: {
+            fetch: telemetryFetch,
           },
         }
       );

--- a/src/telemetry/telemetry-fetch.ts
+++ b/src/telemetry/telemetry-fetch.ts
@@ -1,0 +1,80 @@
+import { TELEMETRY_CONFIG } from './telemetry-types';
+
+type TelemetryFetch = typeof globalThis.fetch;
+
+export interface TelemetryFetchOptions {
+  baseFetch?: TelemetryFetch;
+  timeoutMs?: number;
+  setTimeoutFn?: typeof globalThis.setTimeout;
+  clearTimeoutFn?: typeof globalThis.clearTimeout;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('The operation was aborted', 'AbortError');
+}
+
+/**
+ * Create a fetch implementation with a hard deadline for best-effort telemetry.
+ *
+ * The explicit race is intentional: aborting the controller alone is not enough
+ * to guarantee settlement when a custom or mocked fetch implementation ignores
+ * its signal.
+ */
+export function createTelemetryFetch({
+  baseFetch = globalThis.fetch,
+  timeoutMs = TELEMETRY_CONFIG.FETCH_TIMEOUT_MS,
+  setTimeoutFn = globalThis.setTimeout,
+  clearTimeoutFn = globalThis.clearTimeout,
+}: TelemetryFetchOptions = {}): TelemetryFetch {
+  return (input, init) => {
+    const controller = new AbortController();
+    const upstreamSignal = init?.signal
+      ?? (typeof Request !== 'undefined' && input instanceof Request
+        ? input.signal
+        : undefined);
+    let rejectAbort!: (reason?: unknown) => void;
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      rejectAbort = reject;
+    });
+
+    const abort = (reason: unknown): void => {
+      if (!controller.signal.aborted) {
+        controller.abort(reason);
+      }
+      rejectAbort(reason);
+    };
+
+    const handleUpstreamAbort = (): void => {
+      if (upstreamSignal) {
+        abort(abortReason(upstreamSignal));
+      }
+    };
+
+    if (upstreamSignal?.aborted) {
+      handleUpstreamAbort();
+    } else {
+      upstreamSignal?.addEventListener('abort', handleUpstreamAbort, { once: true });
+    }
+
+    const timer = setTimeoutFn(() => {
+      abort(new DOMException(
+        `Telemetry fetch timed out after ${timeoutMs}ms`,
+        'TimeoutError'
+      ));
+    }, timeoutMs);
+    timer.unref?.();
+
+    const fetchPromise = Promise.resolve().then(() => baseFetch(input, {
+      ...init,
+      signal: controller.signal,
+    }));
+
+    return Promise.race([fetchPromise, abortPromise]).finally(() => {
+      clearTimeoutFn(timer);
+      upstreamSignal?.removeEventListener('abort', handleUpstreamAbort);
+    });
+  };
+}
+
+export const telemetryFetch = createTelemetryFetch();

--- a/src/telemetry/telemetry-manager.ts
+++ b/src/telemetry/telemetry-manager.ts
@@ -98,11 +98,14 @@ export class TelemetryManager {
       // Update batch processor with Supabase client
       this.batchProcessor = new TelemetryBatchProcessor(
         this.supabase,
-        () => this.isEnabled()
+        () => this.isEnabled(),
+        {
+          onFlushRequested: () => this.flush(),
+        }
       );
 
-      this.batchProcessor.start();
       this.isInitialized = true;
+      this.batchProcessor.start();
 
       logger.debug('Telemetry initialized successfully');
     } catch (error) {

--- a/src/telemetry/telemetry-manager.ts
+++ b/src/telemetry/telemetry-manager.ts
@@ -10,6 +10,7 @@ import { TelemetryBatchProcessor } from './batch-processor';
 import { TelemetryPerformanceMonitor } from './performance-monitor';
 import { TELEMETRY_BACKEND } from './telemetry-types';
 import { TelemetryError, TelemetryErrorType, TelemetryErrorAggregator } from './telemetry-error';
+import { telemetryFetch } from './telemetry-fetch';
 import { logger } from '../utils/logger';
 
 export class TelemetryManager {
@@ -88,6 +89,9 @@ export class TelemetryManager {
           params: {
             eventsPerSecond: 1,
           },
+        },
+        global: {
+          fetch: telemetryFetch,
         },
       });
 

--- a/src/telemetry/telemetry-types.ts
+++ b/src/telemetry/telemetry-types.ts
@@ -87,9 +87,10 @@ export const TELEMETRY_CONFIG = {
   WORKFLOW_QUEUE_THRESHOLD: 5, // Batch workflows
 
   // Retry logic
-  MAX_RETRIES: 3,
+  MAX_RETRIES: 1,
   RETRY_DELAY: 1000, // 1 second base delay
   OPERATION_TIMEOUT: 5000, // 5 seconds
+  FETCH_TIMEOUT_MS: 2000, // Hard deadline for each telemetry request
 
   // Rate limiting
   RATE_LIMIT_WINDOW: 60000, // 1 minute

--- a/src/telemetry/telemetry-types.ts
+++ b/src/telemetry/telemetry-types.ts
@@ -86,9 +86,7 @@ export const TELEMETRY_CONFIG = {
   EVENT_QUEUE_THRESHOLD: 10, // Batch events for efficiency
   WORKFLOW_QUEUE_THRESHOLD: 5, // Batch workflows
 
-  // Retry logic
-  MAX_RETRIES: 1,
-  RETRY_DELAY: 1000, // 1 second base delay
+  // Network timeouts
   OPERATION_TIMEOUT: 5000, // 5 seconds
   FETCH_TIMEOUT_MS: 2000, // Hard deadline for each telemetry request
 

--- a/tests/unit/mcp/handlers-n8n-manager.test.ts
+++ b/tests/unit/mcp/handlers-n8n-manager.test.ts
@@ -12,6 +12,12 @@ import {
 } from '@/utils/n8n-errors';
 import { ExecutionStatus } from '@/types/n8n-api';
 
+const telemetryMocks = vi.hoisted(() => ({
+  trackEvent: vi.fn(),
+  trackWorkflowCreation: vi.fn(),
+  trackWorkflowMutation: vi.fn(),
+}));
+
 // Mock dependencies
 vi.mock('@/services/n8n-api-client');
 vi.mock('@/services/workflow-validator');
@@ -49,6 +55,13 @@ vi.mock('@/utils/logger', () => ({
     INFO: 2,
     DEBUG: 3,
   }
+}));
+vi.mock('@/telemetry/telemetry-manager', () => ({
+  telemetry: {
+    trackEvent: telemetryMocks.trackEvent,
+    trackWorkflowCreation: telemetryMocks.trackWorkflowCreation,
+    trackWorkflowMutation: telemetryMocks.trackWorkflowMutation,
+  },
 }));
 
 describe('handlers-n8n-manager', () => {
@@ -93,6 +106,7 @@ describe('handlers-n8n-manager', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    telemetryMocks.trackWorkflowMutation.mockResolvedValue(undefined);
     
     // Setup mock API client
     mockApiClient = {
@@ -2132,6 +2146,70 @@ describe('handlers-n8n-manager', () => {
       expect(sentWorkflow.name).toBe('Renamed');
       // Current settings are preserved intact, not nulled or reduced to defaults.
       expect(sentWorkflow.settings).toEqual({ executionOrder: 'v1', timezone: 'Europe/Warsaw' });
+    });
+
+    it('resolves without waiting for stalled mutation telemetry (#944)', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const workflow = createTestWorkflow({
+          id: 'wf-1',
+          name: 'Original Name',
+          active: false,
+        });
+        const updatedWorkflow = {
+          ...workflow,
+          name: 'Renamed Workflow',
+          updatedAt: '2024-01-02T00:00:00Z',
+        };
+        mockApiClient.getWorkflow.mockResolvedValue(workflow);
+        mockApiClient.updateWorkflow.mockResolvedValue(updatedWorkflow);
+
+        let signalTelemetryStarted!: () => void;
+        const telemetryStarted = new Promise<void>((resolve) => {
+          signalTelemetryStarted = resolve;
+        });
+        telemetryMocks.trackWorkflowMutation.mockImplementation(() => {
+          signalTelemetryStarted();
+          return new Promise<void>(() => {});
+        });
+
+        const handlerPromise = handlers.handleUpdateWorkflow(
+          {
+            id: 'wf-1',
+            name: 'Renamed Workflow',
+          },
+          mockRepository,
+        );
+        const outcomePromise = Promise.race([
+          handlerPromise.then((result: any) => ({ state: 'resolved' as const, result })),
+          new Promise<{ state: 'timed-out' }>((resolve) => {
+            setTimeout(() => resolve({ state: 'timed-out' }), 1_000);
+          }),
+        ]);
+
+        await telemetryStarted;
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        await expect(outcomePromise).resolves.toMatchObject({
+          state: 'resolved',
+          result: {
+            success: true,
+            data: {
+              id: 'wf-1',
+              name: 'Renamed Workflow',
+            },
+          },
+        });
+        expect(telemetryMocks.trackWorkflowMutation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            toolName: 'n8n_update_full_workflow',
+            mutationSuccess: true,
+          }),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/tests/unit/mcp/handlers-n8n-manager.test.ts
+++ b/tests/unit/mcp/handlers-n8n-manager.test.ts
@@ -2211,6 +2211,66 @@ describe('handlers-n8n-manager', () => {
         vi.useRealTimers();
       }
     });
+
+    it('returns an API failure without waiting for stalled mutation telemetry (#944)', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const workflow = createTestWorkflow({
+          id: 'wf-1',
+          name: 'Original Name',
+          active: false,
+        });
+        const apiError = new N8nServerError('Workflow update unavailable');
+        mockApiClient.getWorkflow.mockResolvedValue(workflow);
+        mockApiClient.updateWorkflow.mockRejectedValue(apiError);
+
+        let signalTelemetryStarted!: () => void;
+        const telemetryStarted = new Promise<void>((resolve) => {
+          signalTelemetryStarted = resolve;
+        });
+        telemetryMocks.trackWorkflowMutation.mockImplementation(() => {
+          signalTelemetryStarted();
+          return new Promise<void>(() => {});
+        });
+
+        const handlerPromise = handlers.handleUpdateWorkflow(
+          {
+            id: 'wf-1',
+            name: 'Renamed Workflow',
+          },
+          mockRepository,
+        );
+        const outcomePromise = Promise.race([
+          handlerPromise.then((result: any) => ({ state: 'resolved' as const, result })),
+          new Promise<{ state: 'timed-out' }>((resolve) => {
+            setTimeout(() => resolve({ state: 'timed-out' }), 1_000);
+          }),
+        ]);
+
+        await telemetryStarted;
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        await expect(outcomePromise).resolves.toEqual({
+          state: 'resolved',
+          result: {
+            success: false,
+            error: 'Workflow update unavailable',
+            code: 'SERVER_ERROR',
+            details: undefined,
+          },
+        });
+        expect(telemetryMocks.trackWorkflowMutation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            toolName: 'n8n_update_full_workflow',
+            mutationSuccess: false,
+            mutationError: 'Workflow update unavailable',
+          }),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('handleAuditInstance — error message surfacing (#736)', () => {

--- a/tests/unit/mcp/handlers-workflow-diff.test.ts
+++ b/tests/unit/mcp/handlers-workflow-diff.test.ts
@@ -12,11 +12,20 @@ import {
 } from '@/utils/n8n-errors';
 import { z } from 'zod';
 
+const telemetryMocks = vi.hoisted(() => ({
+  trackWorkflowMutation: vi.fn(),
+}));
+
 // Mock dependencies
 vi.mock('@/services/workflow-diff-engine');
 vi.mock('@/services/n8n-api-client');
 vi.mock('@/config/n8n-api');
 vi.mock('@/utils/logger');
+vi.mock('@/telemetry/telemetry-manager', () => ({
+  telemetry: {
+    trackWorkflowMutation: telemetryMocks.trackWorkflowMutation,
+  },
+}));
 vi.mock('@/mcp/handlers-n8n-manager', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/mcp/handlers-n8n-manager')>();
   return {
@@ -72,6 +81,7 @@ describe('handlers-workflow-diff', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    telemetryMocks.trackWorkflowMutation.mockResolvedValue(undefined);
 
     // Setup mock API client
     mockApiClient = {
@@ -178,6 +188,172 @@ describe('handlers-workflow-diff', () => {
       expect(mockApiClient.getWorkflow).toHaveBeenCalledWith('test-workflow-id');
       expect(mockDiffEngine.applyDiff).toHaveBeenCalledWith(testWorkflow, diffRequest);
       expect(mockApiClient.updateWorkflow).toHaveBeenCalledWith('test-workflow-id', updatedWorkflow);
+    });
+
+    it('resolves without waiting for stalled telemetry after Set v3.4 addNode + addConnection (#944)', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const testWorkflow = createTestWorkflow();
+        const setNode = {
+          id: 'set-node',
+          name: 'Set',
+          type: 'n8n-nodes-base.set',
+          typeVersion: 3.4,
+          position: [500, 100],
+          parameters: {
+            assignments: {
+              assignments: [
+                {
+                  id: 'assignment-1',
+                  name: 'status',
+                  value: 'ready',
+                  type: 'string',
+                },
+              ],
+            },
+            options: {},
+          },
+        };
+        const diffRequest = {
+          id: 'test-workflow-id',
+          operations: [
+            {
+              type: 'addNode',
+              node: setNode,
+            },
+            {
+              type: 'addConnection',
+              source: 'HTTP Request',
+              target: 'Set',
+            },
+          ],
+        };
+        const updatedWorkflow = {
+          ...testWorkflow,
+          nodes: [...testWorkflow.nodes, setNode],
+          connections: {
+            ...testWorkflow.connections,
+            'HTTP Request': {
+              main: [[{ node: 'Set', type: 'main', index: 0 }]],
+            },
+          },
+        };
+
+        mockApiClient.getWorkflow.mockResolvedValue(testWorkflow);
+        mockDiffEngine.applyDiff.mockResolvedValue({
+          success: true,
+          workflow: updatedWorkflow,
+          operationsApplied: 2,
+          message: 'Successfully applied 2 operations',
+          errors: [],
+          applied: [0, 1],
+          failed: [],
+        });
+        mockApiClient.updateWorkflow.mockResolvedValue(updatedWorkflow);
+
+        let signalTelemetryStarted!: () => void;
+        const telemetryStarted = new Promise<void>((resolve) => {
+          signalTelemetryStarted = resolve;
+        });
+        telemetryMocks.trackWorkflowMutation.mockImplementation(() => {
+          signalTelemetryStarted();
+          return new Promise<void>(() => {});
+        });
+
+        const handlerPromise = handleUpdatePartialWorkflow(diffRequest, mockRepository);
+        const outcomePromise = Promise.race([
+          handlerPromise.then((result) => ({ state: 'resolved' as const, result })),
+          new Promise<{ state: 'timed-out' }>((resolve) => {
+            setTimeout(() => resolve({ state: 'timed-out' }), 1_000);
+          }),
+        ]);
+
+        await telemetryStarted;
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        await expect(outcomePromise).resolves.toMatchObject({
+          state: 'resolved',
+          result: {
+            success: true,
+            saved: true,
+            data: {
+              operationsApplied: 2,
+            },
+          },
+        });
+        expect(telemetryMocks.trackWorkflowMutation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            toolName: 'n8n_update_partial_workflow',
+            operations: diffRequest.operations,
+            mutationSuccess: true,
+          }),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('resolves API failures without waiting for stalled mutation telemetry', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const testWorkflow = createTestWorkflow();
+        const diffRequest = {
+          id: 'test-workflow-id',
+          operations: [{ type: 'updateName', name: 'Renamed Workflow' }],
+        };
+        mockApiClient.getWorkflow.mockResolvedValue(testWorkflow);
+        mockDiffEngine.applyDiff.mockResolvedValue({
+          success: true,
+          workflow: { ...testWorkflow, name: 'Renamed Workflow' },
+          operationsApplied: 1,
+          message: 'Successfully applied 1 operation',
+          errors: [],
+          applied: [0],
+          failed: [],
+        });
+        mockApiClient.updateWorkflow.mockRejectedValue(
+          new N8nValidationError('Update rejected'),
+        );
+
+        let signalTelemetryStarted!: () => void;
+        const telemetryStarted = new Promise<void>((resolve) => {
+          signalTelemetryStarted = resolve;
+        });
+        telemetryMocks.trackWorkflowMutation.mockImplementation(() => {
+          signalTelemetryStarted();
+          return new Promise<void>(() => {});
+        });
+
+        const handlerPromise = handleUpdatePartialWorkflow(diffRequest, mockRepository);
+        const outcomePromise = Promise.race([
+          handlerPromise.then((result) => ({ state: 'resolved' as const, result })),
+          new Promise<{ state: 'timed-out' }>((resolve) => {
+            setTimeout(() => resolve({ state: 'timed-out' }), 1_000);
+          }),
+        ]);
+
+        await telemetryStarted;
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        await expect(outcomePromise).resolves.toMatchObject({
+          state: 'resolved',
+          result: {
+            success: false,
+            code: 'VALIDATION_ERROR',
+          },
+        });
+        expect(telemetryMocks.trackWorkflowMutation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            toolName: 'n8n_update_partial_workflow',
+            mutationSuccess: false,
+            mutationError: 'Update rejected',
+          }),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('normalizes HTTP MCP serialized addNode payloads before applying the diff (#814)', async () => {

--- a/tests/unit/telemetry/telemetry-fetch.test.ts
+++ b/tests/unit/telemetry/telemetry-fetch.test.ts
@@ -70,6 +70,54 @@ describe('createTelemetryFetch', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it('promptly propagates an already-aborted upstream signal', async () => {
+    const upstreamController = new AbortController();
+    const upstreamReason = new DOMException('Caller already cancelled', 'AbortError');
+    upstreamController.abort(upstreamReason);
+
+    const requestState: { signal: AbortSignal | null } = { signal: null };
+    const baseFetch = vi.fn<typeof fetch>((_input, init) => {
+      requestState.signal = init?.signal ?? null;
+      return new Promise<Response>(() => {});
+    });
+    const telemetryFetch = createTelemetryFetch({ baseFetch, timeoutMs: 2000 });
+
+    await expect(telemetryFetch('https://example.test/telemetry', {
+      signal: upstreamController.signal,
+    })).rejects.toBe(upstreamReason);
+
+    expect(baseFetch).toHaveBeenCalledOnce();
+    expect(requestState.signal?.aborted).toBe(true);
+    expect(requestState.signal?.reason).toBe(upstreamReason);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('derives and propagates the upstream signal from a Request input', async () => {
+    const upstreamController = new AbortController();
+    const upstreamReason = new DOMException('Request cancelled', 'AbortError');
+    const input = new Request('https://example.test/telemetry', {
+      signal: upstreamController.signal,
+    });
+    const requestState: { signal: AbortSignal | null } = { signal: null };
+    const baseFetch = vi.fn<typeof fetch>((_input, init) => {
+      requestState.signal = init?.signal ?? null;
+      return new Promise<Response>(() => {});
+    });
+    const telemetryFetch = createTelemetryFetch({ baseFetch, timeoutMs: 2000 });
+    const request = telemetryFetch(input);
+    const rejection = expect(request).rejects.toBe(upstreamReason);
+
+    upstreamController.abort(upstreamReason);
+
+    await rejection;
+    expect(baseFetch).toHaveBeenCalledWith(input, expect.objectContaining({
+      signal: expect.any(AbortSignal),
+    }));
+    expect(requestState.signal?.aborted).toBe(true);
+    expect(requestState.signal?.reason).toBe(upstreamReason);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('rejects on the deadline even when the base fetch ignores abort', async () => {
     const requestState: { signal: AbortSignal | null } = { signal: null };
     const baseFetch = vi.fn<typeof fetch>((_input, init) => {

--- a/tests/unit/telemetry/telemetry-fetch.test.ts
+++ b/tests/unit/telemetry/telemetry-fetch.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTelemetryFetch } from '../../../src/telemetry/telemetry-fetch';
+
+describe('createTelemetryFetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns a successful response and clears the deadline timer', async () => {
+    const response = new Response(null, { status: 204 });
+    const baseFetch = vi.fn<typeof fetch>().mockResolvedValue(response);
+    const telemetryFetch = createTelemetryFetch({ baseFetch, timeoutMs: 2000 });
+
+    await expect(telemetryFetch('https://example.test/telemetry')).resolves.toBe(response);
+
+    expect(baseFetch).toHaveBeenCalledOnce();
+    expect(baseFetch.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('aborts the underlying fetch when the deadline expires', async () => {
+    const requestState: { signal: AbortSignal | null } = { signal: null };
+    const baseFetch = vi.fn<typeof fetch>((_input, init) => {
+      requestState.signal = init?.signal ?? null;
+      return new Promise<Response>((_resolve, reject) => {
+        requestState.signal?.addEventListener('abort', () => reject(requestState.signal?.reason), {
+          once: true,
+        });
+      });
+    });
+    const telemetryFetch = createTelemetryFetch({ baseFetch, timeoutMs: 2000 });
+    const request = telemetryFetch('https://example.test/telemetry');
+    const rejection = expect(request).rejects.toMatchObject({ name: 'TimeoutError' });
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await rejection;
+    expect(requestState.signal?.aborted).toBe(true);
+    expect(requestState.signal?.reason).toMatchObject({ name: 'TimeoutError' });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('propagates an upstream abort to the underlying fetch', async () => {
+    const upstreamController = new AbortController();
+    const upstreamReason = new DOMException('Caller cancelled', 'AbortError');
+    const requestState: { signal: AbortSignal | null } = { signal: null };
+    const baseFetch = vi.fn<typeof fetch>((_input, init) => {
+      requestState.signal = init?.signal ?? null;
+      return new Promise<Response>((_resolve, reject) => {
+        requestState.signal?.addEventListener('abort', () => reject(requestState.signal?.reason), {
+          once: true,
+        });
+      });
+    });
+    const telemetryFetch = createTelemetryFetch({ baseFetch, timeoutMs: 2000 });
+    const request = telemetryFetch('https://example.test/telemetry', {
+      signal: upstreamController.signal,
+    });
+    const rejection = expect(request).rejects.toBe(upstreamReason);
+
+    upstreamController.abort(upstreamReason);
+
+    await rejection;
+    expect(requestState.signal?.aborted).toBe(true);
+    expect(requestState.signal?.reason).toBe(upstreamReason);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('rejects on the deadline even when the base fetch ignores abort', async () => {
+    const requestState: { signal: AbortSignal | null } = { signal: null };
+    const baseFetch = vi.fn<typeof fetch>((_input, init) => {
+      requestState.signal = init?.signal ?? null;
+      return new Promise<Response>(() => {});
+    });
+    const telemetryFetch = createTelemetryFetch({ baseFetch, timeoutMs: 2000 });
+    const request = telemetryFetch('https://example.test/telemetry');
+    const rejection = expect(request).rejects.toMatchObject({ name: 'TimeoutError' });
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await rejection;
+    expect(requestState.signal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/tests/unit/telemetry/telemetry-fetch.test.ts
+++ b/tests/unit/telemetry/telemetry-fetch.test.ts
@@ -92,6 +92,30 @@ describe('createTelemetryFetch', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it('uses an AbortError fallback when an aborted upstream signal has no reason', async () => {
+    const upstreamController = new AbortController();
+    upstreamController.abort();
+    Object.defineProperty(upstreamController.signal, 'reason', { value: undefined });
+
+    const requestState: { signal: AbortSignal | null } = { signal: null };
+    const baseFetch = vi.fn<typeof fetch>((_input, init) => {
+      requestState.signal = init?.signal ?? null;
+      return new Promise<Response>(() => {});
+    });
+    const telemetryFetch = createTelemetryFetch({ baseFetch, timeoutMs: 2000 });
+    const rejectionReason = await telemetryFetch('https://example.test/telemetry', {
+      signal: upstreamController.signal,
+    }).catch((reason: unknown) => reason);
+
+    expect(rejectionReason).toMatchObject({
+      name: 'AbortError',
+      message: 'The operation was aborted',
+    });
+    expect(requestState.signal?.aborted).toBe(true);
+    expect(requestState.signal?.reason).toBe(rejectionReason);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('derives and propagates the upstream signal from a Request input', async () => {
     const upstreamController = new AbortController();
     const upstreamReason = new DOMException('Request cancelled', 'AbortError');

--- a/tests/unit/telemetry/telemetry-manager.test.ts
+++ b/tests/unit/telemetry/telemetry-manager.test.ts
@@ -142,6 +142,13 @@ describe('TelemetryManager', () => {
     });
 
     it('should initialize successfully when enabled', () => {
+      let enabledDuringStart = false;
+      mockBatchProcessor.start.mockImplementation(() => {
+        const calls = vi.mocked(TelemetryBatchProcessor).mock.calls;
+        const [, isEnabledCallback] = calls[calls.length - 1];
+        enabledDuringStart = isEnabledCallback();
+      });
+
       // Trigger initialization by calling a tracking method
       manager.trackEvent('test', {});
 
@@ -157,6 +164,7 @@ describe('TelemetryManager', () => {
         })
       );
       expect(mockBatchProcessor.start).toHaveBeenCalled();
+      expect(enabledDuringStart).toBe(true);
     });
 
     it('should use environment variables if provided', () => {
@@ -587,10 +595,34 @@ describe('TelemetryManager', () => {
       expect(TelemetryBatchProcessorMock).toHaveBeenCalledTimes(2); // Once with null, once with Supabase client
 
       const lastCall = TelemetryBatchProcessorMock.mock.calls[TelemetryBatchProcessorMock.mock.calls.length - 1];
-      const [supabaseClient, isEnabledCallback] = lastCall;
+      const [supabaseClient, isEnabledCallback, options] = lastCall;
 
       expect(supabaseClient).toBe(mockSupabaseClient);
       expect(isEnabledCallback()).toBe(true);
+      expect(options).toEqual(expect.objectContaining({
+        onFlushRequested: expect.any(Function)
+      }));
+    });
+
+    it('should route scheduled flush requests through the manager queues', async () => {
+      const events = [{ user_id: 'user1', event: 'scheduled', properties: {} }];
+      const workflows = [{ user_id: 'user1', workflow_hash: 'hash1' }];
+      const mutations = [{ workflowHashBefore: 'hash1' }];
+      mockEventTracker.getEventQueue.mockReturnValue(events);
+      mockEventTracker.getWorkflowQueue.mockReturnValue(workflows);
+      mockEventTracker.getMutationQueue.mockReturnValue(mutations);
+
+      const manager = TelemetryManager.getInstance();
+      manager.trackEvent('test', {});
+
+      const calls = vi.mocked(TelemetryBatchProcessor).mock.calls;
+      const options = calls[calls.length - 1][2];
+      await options?.onFlushRequested?.();
+
+      expect(mockBatchProcessor.flush).toHaveBeenCalledWith(events, workflows, mutations);
+      expect(mockEventTracker.clearEventQueue).toHaveBeenCalled();
+      expect(mockEventTracker.clearWorkflowQueue).toHaveBeenCalled();
+      expect(mockEventTracker.clearMutationQueue).toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/telemetry/telemetry-manager.test.ts
+++ b/tests/unit/telemetry/telemetry-manager.test.ts
@@ -614,6 +614,9 @@ describe('TelemetryManager', () => {
             params: {
               eventsPerSecond: 1
             }
+          },
+          global: {
+            fetch: expect.any(Function)
           }
         }
       );

--- a/tests/unit/telemetry/telemetry-processing.test.ts
+++ b/tests/unit/telemetry/telemetry-processing.test.ts
@@ -51,8 +51,6 @@ describe('TelemetryBatchProcessor', () => {
 
     batchProcessor = new TelemetryBatchProcessor(mockSupabase, mockIsEnabled, {
       operationTimeout: TEST_OPERATION_TIMEOUT,
-      retryDelay: 0,
-      random: () => 0,
     });
   });
 
@@ -303,18 +301,9 @@ describe('TelemetryBatchProcessor', () => {
     });
   });
 
-  describe('error handling and retries', () => {
-    it('should succeed within the configured retry limit', async () => {
-      const error = new Error('Network timeout');
-      const errorResponse = createMockSupabaseResponse(error);
+  describe('bounded operation execution', () => {
+    it('should succeed on a single attempt', async () => {
       const insert = vi.mocked(mockSupabase.from('telemetry_events').insert);
-
-      // Leave the final configured attempt available for success. This remains
-      // valid when deployments intentionally configure a single attempt.
-      for (let attempt = 1; attempt < TELEMETRY_CONFIG.MAX_RETRIES; attempt++) {
-        insert.mockResolvedValueOnce(errorResponse);
-      }
-      insert.mockResolvedValueOnce(createMockSupabaseResponse());
 
       const events: TelemetryEvent[] = [{
         user_id: 'user1',
@@ -324,17 +313,18 @@ describe('TelemetryBatchProcessor', () => {
 
       await batchProcessor.flush(events);
 
-      expect(insert).toHaveBeenCalledTimes(TELEMETRY_CONFIG.MAX_RETRIES);
+      expect(insert).toHaveBeenCalledTimes(1);
 
       const metrics = batchProcessor.getMetrics();
       expect(metrics.eventsTracked).toBe(1);
     });
 
-    it('should fail after max retries', async () => {
+    it('should fail after a single attempt', async () => {
       const error = new Error('Persistent network error');
       const errorResponse = createMockSupabaseResponse(error);
 
-      vi.mocked(mockSupabase.from('telemetry_events').insert).mockResolvedValue(errorResponse);
+      const insert = vi.mocked(mockSupabase.from('telemetry_events').insert);
+      insert.mockResolvedValue(errorResponse);
 
       const events: TelemetryEvent[] = [{
         user_id: 'user1',
@@ -344,9 +334,7 @@ describe('TelemetryBatchProcessor', () => {
 
       await batchProcessor.flush(events);
 
-      // Should have been called MAX_RETRIES times
-      expect(mockSupabase.from('telemetry_events').insert)
-        .toHaveBeenCalledTimes(TELEMETRY_CONFIG.MAX_RETRIES);
+      expect(insert).toHaveBeenCalledTimes(1);
 
       const metrics = batchProcessor.getMetrics();
       expect(metrics.eventsFailed).toBe(1);
@@ -377,7 +365,7 @@ describe('TelemetryBatchProcessor', () => {
 
       const metrics = batchProcessor.getMetrics();
       expect(settled).toBe(true);
-      expect(insert).toHaveBeenCalledTimes(TELEMETRY_CONFIG.MAX_RETRIES);
+      expect(insert).toHaveBeenCalledTimes(1);
       expect(metrics.eventsFailed).toBe(1);
       expect(metrics.batchesFailed).toBe(1);
       expect(metrics.deadLetterQueueSize).toBe(1);
@@ -416,18 +404,15 @@ describe('TelemetryBatchProcessor', () => {
       const error = new Error('Temporary error');
       const errorResponse = createMockSupabaseResponse(error);
 
-      // Exhaust the configured attempts, then succeed when the queue is retried.
       const insert = vi.mocked(mockSupabase.from('telemetry_events').insert);
-      for (let attempt = 0; attempt < TELEMETRY_CONFIG.MAX_RETRIES; attempt++) {
-        insert.mockResolvedValueOnce(errorResponse);
-      }
+      insert.mockResolvedValueOnce(errorResponse);
       insert.mockResolvedValueOnce(createMockSupabaseResponse());
 
       const events: TelemetryEvent[] = [
         { user_id: 'user1', event: 'event1', properties: {} }
       ];
 
-      // First flush - should fail after all retries and add to dead letter queue
+      // First flush - should fail and add to dead letter queue
       await batchProcessor.flush(events);
       expect(batchProcessor.getMetrics().deadLetterQueueSize).toBe(1);
 
@@ -439,7 +424,7 @@ describe('TelemetryBatchProcessor', () => {
     it('should maintain dead letter queue size limit', async () => {
       const error = new Error('Persistent error');
       const errorResponse = createMockSupabaseResponse(error);
-      // Always fail - each flush will retry 3 times then add to dead letter queue
+      // Always fail - each flush adds its batch to the dead letter queue
       vi.mocked(mockSupabase.from('telemetry_events').insert).mockResolvedValue(errorResponse);
 
       // Circuit breaker opens after 5 failures, so only first 5 flushes will be processed
@@ -775,9 +760,7 @@ describe('TelemetryBatchProcessor', () => {
       const attemptedUsers = insert.mock.calls.map(([batch]) =>
         (batch as TelemetryEvent[])[0].user_id
       );
-      expect(attemptedUsers).toEqual(events.flatMap(
-        ([event]) => Array(TELEMETRY_CONFIG.MAX_RETRIES).fill(event.user_id)
-      ));
+      expect(attemptedUsers).toEqual(events.map(([event]) => event.user_id));
       expect(batchProcessor.getMetrics()).toMatchObject({
         eventsFailed: 3,
         batchesFailed: 3,

--- a/tests/unit/telemetry/telemetry-processing.test.ts
+++ b/tests/unit/telemetry/telemetry-processing.test.ts
@@ -993,6 +993,7 @@ describe('TelemetryBatchProcessor', () => {
 
       // Trigger SIGINT event
       process.emit('SIGINT', 'SIGINT');
+      for (let index = 0; index < 10; index++) await Promise.resolve();
 
       expect(flushSpy).toHaveBeenCalled();
       expect(mockProcessExit).toHaveBeenCalledWith(0);
@@ -1005,10 +1006,39 @@ describe('TelemetryBatchProcessor', () => {
 
       // Trigger SIGTERM event
       process.emit('SIGTERM', 'SIGTERM');
+      for (let index = 0; index < 10; index++) await Promise.resolve();
 
       expect(flushSpy).toHaveBeenCalled();
       expect(mockProcessExit).toHaveBeenCalledWith(0);
     });
+
+    it.each(['SIGINT', 'SIGTERM'] as const)(
+      'should wait for the scheduled flush before exiting on %s',
+      async signal => {
+        let resolveFlush!: () => void;
+        const onFlushRequested = vi.fn(() => new Promise<void>(resolve => {
+          resolveFlush = resolve;
+        }));
+        const processor = new TelemetryBatchProcessor(mockSupabase, mockIsEnabled, {
+          operationTimeout: TEST_OPERATION_TIMEOUT,
+          onFlushRequested,
+        });
+
+        processor.start();
+        process.emit(signal, signal);
+        await Promise.resolve();
+
+        expect(onFlushRequested).toHaveBeenCalledOnce();
+        expect(mockProcessExit).not.toHaveBeenCalled();
+
+        resolveFlush();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(mockProcessExit).toHaveBeenCalledWith(0);
+        processor.stop();
+      }
+    );
   });
 
   describe('Issue #517: workflow data preservation', () => {

--- a/tests/unit/telemetry/telemetry-processing.test.ts
+++ b/tests/unit/telemetry/telemetry-processing.test.ts
@@ -63,15 +63,18 @@ describe('TelemetryBatchProcessor', () => {
   });
 
   describe('start()', () => {
-    it('should start periodic flushing when enabled', () => {
+    it('should start periodic flushing when enabled', async () => {
       const setIntervalSpy = vi.spyOn(global, 'setInterval');
+      const flushSpy = vi.spyOn(batchProcessor, 'flush');
 
       batchProcessor.start();
+      await vi.advanceTimersByTimeAsync(TELEMETRY_CONFIG.BATCH_FLUSH_INTERVAL);
 
       expect(setIntervalSpy).toHaveBeenCalledWith(
         expect.any(Function),
         TELEMETRY_CONFIG.BATCH_FLUSH_INTERVAL
       );
+      expect(flushSpy).toHaveBeenCalled();
     });
 
     it('should not start when disabled', () => {
@@ -831,6 +834,22 @@ describe('TelemetryBatchProcessor', () => {
   });
 
   describe('process lifecycle integration', () => {
+    it('should route lifecycle flushes through the queue-aware callback', async () => {
+      const onFlushRequested = vi.fn().mockRejectedValue(new Error('Scheduled flush failed'));
+      const processor = new TelemetryBatchProcessor(mockSupabase, mockIsEnabled, {
+        operationTimeout: TEST_OPERATION_TIMEOUT,
+        onFlushRequested,
+      });
+
+      processor.start();
+      process.emit('beforeExit', 0);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(onFlushRequested).toHaveBeenCalledOnce();
+      processor.stop();
+    });
+
     it('should flush on process beforeExit', async () => {
       const flushSpy = vi.spyOn(batchProcessor, 'flush');
 

--- a/tests/unit/telemetry/telemetry-processing.test.ts
+++ b/tests/unit/telemetry/telemetry-processing.test.ts
@@ -427,10 +427,8 @@ describe('TelemetryBatchProcessor', () => {
       // Always fail - each flush adds its batch to the dead letter queue
       vi.mocked(mockSupabase.from('telemetry_events').insert).mockResolvedValue(errorResponse);
 
-      // Circuit breaker opens after 5 failures, so only first 5 flushes will be processed
-      // 5 batches of 5 items = 25 total items in dead letter queue
-      for (let i = 0; i < 10; i++) {
-        const events: TelemetryEvent[] = Array.from({ length: 5 }, (_, j) => ({
+      for (let i = 0; i < 3; i++) {
+        const events: TelemetryEvent[] = Array.from({ length: 50 }, (_, j) => ({
           user_id: `user${i}_${j}`,
           event: 'test_event',
           properties: { batch: i, index: j }
@@ -440,9 +438,70 @@ describe('TelemetryBatchProcessor', () => {
       }
 
       const metrics = batchProcessor.getMetrics();
-      // Circuit breaker opens after 5 failures, so only 25 items are added
-      expect(metrics.deadLetterQueueSize).toBe(25); // 5 flushes * 5 items each
-      expect(metrics.eventsDropped).toBe(25); // 5 additional flushes dropped due to circuit breaker
+      expect(metrics.deadLetterQueueSize).toBe(100);
+      expect(metrics.eventsDropped).toBe(50);
+    });
+
+    it('should retry failed workflow mutations through the mutation table', async () => {
+      const errorResponse = createMockSupabaseResponse(new Error('Temporary mutation error'));
+      const mutationInsert = vi.fn()
+        .mockResolvedValueOnce(errorResponse)
+        .mockResolvedValueOnce(createMockSupabaseResponse());
+      const eventInsert = vi.fn().mockResolvedValue(createMockSupabaseResponse());
+
+      vi.mocked(mockSupabase.from).mockImplementation((table) => ({
+        insert: table === 'workflow_mutations' ? mutationInsert : eventInsert,
+        url: { href: '' },
+        headers: {},
+        select: vi.fn(),
+        upsert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn()
+      } as any));
+
+      const mutation: WorkflowMutationRecord = {
+        userId: 'user1',
+        sessionId: 'session1',
+        workflowBefore: { nodes: [], connections: {} },
+        workflowAfter: { nodes: [], connections: {} },
+        workflowHashBefore: 'hash1',
+        workflowHashAfter: 'hash2',
+        userIntent: 'Test mutation DLQ retry',
+        intentClassification: IntentClassification.ADD_FUNCTIONALITY,
+        toolName: MutationToolName.UPDATE_PARTIAL,
+        operations: [],
+        operationCount: 0,
+        operationTypes: [],
+        validationImproved: null,
+        errorsResolved: 0,
+        errorsIntroduced: 0,
+        nodesAdded: 0,
+        nodesRemoved: 0,
+        nodesModified: 0,
+        connectionsAdded: 0,
+        connectionsRemoved: 0,
+        propertiesChanged: 0,
+        mutationSuccess: false,
+        durationMs: 10
+      };
+
+      await batchProcessor.flush(undefined, undefined, [mutation]);
+      expect(batchProcessor.getMetrics().deadLetterQueueSize).toBe(1);
+
+      await batchProcessor.flush([]);
+
+      expect(mutationInsert).toHaveBeenCalledTimes(2);
+      expect(eventInsert).not.toHaveBeenCalled();
+      expect(mockSupabase.from).toHaveBeenNthCalledWith(1, 'workflow_mutations');
+      expect(mockSupabase.from).toHaveBeenNthCalledWith(2, 'workflow_mutations');
+      expect(mutationInsert).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          user_id: 'user1',
+          workflow_hash_before: 'hash1',
+          workflow_hash_after: 'hash2'
+        })
+      ]);
+      expect(batchProcessor.getMetrics().deadLetterQueueSize).toBe(0);
     });
 
     it('should handle mixed events and workflows in dead letter queue', async () => {

--- a/tests/unit/telemetry/telemetry-processing.test.ts
+++ b/tests/unit/telemetry/telemetry-processing.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../../src/utils/logger', () => ({
 }));
 
 describe('TelemetryBatchProcessor', () => {
+  const TEST_OPERATION_TIMEOUT = 100;
   let batchProcessor: TelemetryBatchProcessor;
   let mockSupabase: SupabaseClient;
   let mockIsEnabled: ReturnType<typeof vi.fn>;
@@ -48,7 +49,11 @@ describe('TelemetryBatchProcessor', () => {
 
     vi.clearAllMocks();
 
-    batchProcessor = new TelemetryBatchProcessor(mockSupabase, mockIsEnabled);
+    batchProcessor = new TelemetryBatchProcessor(mockSupabase, mockIsEnabled, {
+      operationTimeout: TEST_OPERATION_TIMEOUT,
+      retryDelay: 0,
+      random: () => 0,
+    });
   });
 
   afterEach(() => {
@@ -299,15 +304,17 @@ describe('TelemetryBatchProcessor', () => {
   });
 
   describe('error handling and retries', () => {
-    it('should retry on failure with exponential backoff', async () => {
+    it('should succeed within the configured retry limit', async () => {
       const error = new Error('Network timeout');
       const errorResponse = createMockSupabaseResponse(error);
+      const insert = vi.mocked(mockSupabase.from('telemetry_events').insert);
 
-      // Mock to fail first 2 times, then succeed
-      vi.mocked(mockSupabase.from('telemetry_events').insert)
-        .mockResolvedValueOnce(errorResponse)
-        .mockResolvedValueOnce(errorResponse)
-        .mockResolvedValueOnce(createMockSupabaseResponse());
+      // Leave the final configured attempt available for success. This remains
+      // valid when deployments intentionally configure a single attempt.
+      for (let attempt = 1; attempt < TELEMETRY_CONFIG.MAX_RETRIES; attempt++) {
+        insert.mockResolvedValueOnce(errorResponse);
+      }
+      insert.mockResolvedValueOnce(createMockSupabaseResponse());
 
       const events: TelemetryEvent[] = [{
         user_id: 'user1',
@@ -317,11 +324,10 @@ describe('TelemetryBatchProcessor', () => {
 
       await batchProcessor.flush(events);
 
-      // Should have been called 3 times (2 failures + 1 success)
-      expect(mockSupabase.from('telemetry_events').insert).toHaveBeenCalledTimes(3);
+      expect(insert).toHaveBeenCalledTimes(TELEMETRY_CONFIG.MAX_RETRIES);
 
       const metrics = batchProcessor.getMetrics();
-      expect(metrics.eventsTracked).toBe(1); // Should succeed on third try
+      expect(metrics.eventsTracked).toBe(1);
     });
 
     it('should fail after max retries', async () => {
@@ -348,11 +354,9 @@ describe('TelemetryBatchProcessor', () => {
       expect(metrics.deadLetterQueueSize).toBe(1);
     });
 
-    it('should handle operation timeout', async () => {
-      // Mock the operation to always fail with timeout error
-      vi.mocked(mockSupabase.from('telemetry_events').insert).mockRejectedValue(
-        new Error('Operation timed out')
-      );
+    it('should bound a truly never-settling operation with production timeout behavior', async () => {
+      const insert = vi.mocked(mockSupabase.from('telemetry_events').insert);
+      insert.mockImplementation(() => new Promise(() => {}) as any);
 
       const events: TelemetryEvent[] = [{
         user_id: 'user1',
@@ -360,11 +364,34 @@ describe('TelemetryBatchProcessor', () => {
         properties: {}
       }];
 
-      // The flush should fail after retries
-      await batchProcessor.flush(events);
+      let settled = false;
+      const flushPromise = batchProcessor.flush(events).then(() => {
+        settled = true;
+      });
+
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      await vi.runAllTimersAsync();
+      await flushPromise;
 
       const metrics = batchProcessor.getMetrics();
+      expect(settled).toBe(true);
+      expect(insert).toHaveBeenCalledTimes(TELEMETRY_CONFIG.MAX_RETRIES);
       expect(metrics.eventsFailed).toBe(1);
+      expect(metrics.batchesFailed).toBe(1);
+      expect(metrics.deadLetterQueueSize).toBe(1);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('should clear the operation timeout after a successful attempt', async () => {
+      await batchProcessor.flush([{
+        user_id: 'user1',
+        event: 'test_event',
+        properties: {}
+      }]);
+
+      expect(vi.getTimerCount()).toBe(0);
     });
   });
 
@@ -389,12 +416,12 @@ describe('TelemetryBatchProcessor', () => {
       const error = new Error('Temporary error');
       const errorResponse = createMockSupabaseResponse(error);
 
-      // First 3 calls fail (for all retries), then succeed
-      vi.mocked(mockSupabase.from('telemetry_events').insert)
-        .mockResolvedValueOnce(errorResponse)  // Retry 1
-        .mockResolvedValueOnce(errorResponse)  // Retry 2
-        .mockResolvedValueOnce(errorResponse)  // Retry 3
-        .mockResolvedValueOnce(createMockSupabaseResponse());  // Success on next flush
+      // Exhaust the configured attempts, then succeed when the queue is retried.
+      const insert = vi.mocked(mockSupabase.from('telemetry_events').insert);
+      for (let attempt = 0; attempt < TELEMETRY_CONFIG.MAX_RETRIES; attempt++) {
+        insert.mockResolvedValueOnce(errorResponse);
+      }
+      insert.mockResolvedValueOnce(createMockSupabaseResponse());
 
       const events: TelemetryEvent[] = [
         { user_id: 'user1', event: 'event1', properties: {} }
@@ -626,23 +653,138 @@ describe('TelemetryBatchProcessor', () => {
       await expect(processor.flush(events)).resolves.not.toThrow();
     });
 
-    it('should handle concurrent flush operations', async () => {
-      const events: TelemetryEvent[] = [
-        { user_id: 'user1', event: 'test_event', properties: {} }
-      ];
+    it('should serialize concurrent event, workflow, and mutation flushes globally', async () => {
+      const operationOrder: string[] = [];
+      const pendingOperations: Array<() => void> = [];
+      let activeOperations = 0;
+      let maxActiveOperations = 0;
 
-      // Start multiple flush operations concurrently
+      vi.mocked(mockSupabase.from).mockImplementation((table) => ({
+        insert: vi.fn().mockImplementation(() => {
+          operationOrder.push(table);
+          activeOperations++;
+          maxActiveOperations = Math.max(maxActiveOperations, activeOperations);
+
+          return new Promise(resolve => {
+            pendingOperations.push(() => {
+              activeOperations--;
+              resolve(createMockSupabaseResponse());
+            });
+          });
+        }),
+        url: { href: '' },
+        headers: {},
+        select: vi.fn(),
+        upsert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn()
+      } as any));
+
+      const event: TelemetryEvent = {
+        user_id: 'event-user',
+        event: 'test_event',
+        properties: {}
+      };
+      const workflow: WorkflowTelemetry = {
+        user_id: 'workflow-user',
+        workflow_hash: 'concurrent-hash',
+        node_count: 1,
+        node_types: ['n8n-nodes-base.set'],
+        has_trigger: false,
+        has_webhook: false,
+        complexity: 'simple',
+        sanitized_workflow: { nodes: [], connections: {} }
+      };
+      const mutation = {
+        userId: 'mutation-user',
+        sessionId: 'concurrent-session',
+        workflowBefore: { nodes: [], connections: {} },
+        workflowAfter: { nodes: [], connections: {} },
+        workflowHashBefore: 'before',
+        workflowHashAfter: 'after',
+        userIntent: 'Test concurrent serialization',
+        intentClassification: IntentClassification.ADD_FUNCTIONALITY,
+        toolName: MutationToolName.UPDATE_PARTIAL,
+        operations: [],
+        operationCount: 0,
+        operationTypes: [],
+        validationImproved: null,
+        errorsResolved: 0,
+        errorsIntroduced: 0,
+        nodesAdded: 0,
+        nodesRemoved: 0,
+        nodesModified: 0,
+        connectionsAdded: 0,
+        connectionsRemoved: 0,
+        propertiesChanged: 0,
+        mutationSuccess: true,
+        durationMs: 1
+      } as WorkflowMutationRecord;
+
       const flushPromises = [
-        batchProcessor.flush(events),
-        batchProcessor.flush(events),
-        batchProcessor.flush(events)
+        batchProcessor.flush([event]),
+        batchProcessor.flush(undefined, [workflow]),
+        batchProcessor.flush(undefined, undefined, [mutation])
       ];
 
+      for (let index = 0; index < 10; index++) await Promise.resolve();
+      expect(operationOrder).toEqual(['telemetry_events']);
+      expect(activeOperations).toBe(1);
+
+      pendingOperations.shift()!();
+      for (let index = 0; index < 10; index++) await Promise.resolve();
+      expect(operationOrder).toEqual(['telemetry_events', 'telemetry_workflows']);
+      expect(activeOperations).toBe(1);
+
+      pendingOperations.shift()!();
+      for (let index = 0; index < 10; index++) await Promise.resolve();
+      expect(operationOrder).toEqual([
+        'telemetry_events',
+        'telemetry_workflows',
+        'workflow_mutations'
+      ]);
+      expect(activeOperations).toBe(1);
+
+      pendingOperations.shift()!();
       await Promise.all(flushPromises);
 
-      // Should handle concurrent operations gracefully
-      const metrics = batchProcessor.getMetrics();
-      expect(metrics.eventsTracked).toBeGreaterThan(0);
+      expect(maxActiveOperations).toBe(1);
+      expect(batchProcessor.getMetrics()).toMatchObject({
+        eventsTracked: 3,
+        batchesSent: 3,
+        eventsFailed: 0,
+        batchesFailed: 0
+      });
+    });
+
+    it('should settle queued never-ending flushes without silently losing any batch', async () => {
+      const insert = vi.mocked(mockSupabase.from('telemetry_events').insert);
+      insert.mockImplementation(() => new Promise(() => {}) as any);
+
+      const events = ['queued-1', 'queued-2', 'queued-3'].map(user_id => [{
+        user_id,
+        event: 'never_settles',
+        properties: {}
+      }] as TelemetryEvent[]);
+
+      const flushPromises = events.map(batch => batchProcessor.flush(batch));
+
+      await vi.runAllTimersAsync();
+      await Promise.all(flushPromises);
+
+      const attemptedUsers = insert.mock.calls.map(([batch]) =>
+        (batch as TelemetryEvent[])[0].user_id
+      );
+      expect(attemptedUsers).toEqual(events.flatMap(
+        ([event]) => Array(TELEMETRY_CONFIG.MAX_RETRIES).fill(event.user_id)
+      ));
+      expect(batchProcessor.getMetrics()).toMatchObject({
+        eventsFailed: 3,
+        batchesFailed: 3,
+        eventsDropped: 0,
+        deadLetterQueueSize: 3
+      });
+      expect(vi.getTimerCount()).toBe(0);
     });
   });
 

--- a/tests/unit/telemetry/telemetry-processing.test.ts
+++ b/tests/unit/telemetry/telemetry-processing.test.ts
@@ -32,6 +32,43 @@ describe('TelemetryBatchProcessor', () => {
     success: !error,
   });
 
+  const createWorkflowTelemetry = (index: number): WorkflowTelemetry => ({
+    user_id: `workflow-user-${index}`,
+    workflow_hash: `workflow-hash-${index}`,
+    node_count: 1,
+    node_types: ['n8n-nodes-base.set'],
+    has_trigger: false,
+    has_webhook: false,
+    complexity: 'simple',
+    sanitized_workflow: { nodes: [], connections: {} },
+  });
+
+  const createMutationRecord = (index: number): WorkflowMutationRecord => ({
+    userId: `mutation-user-${index}`,
+    sessionId: `mutation-session-${index}`,
+    workflowBefore: { nodes: [], connections: {} },
+    workflowAfter: { nodes: [], connections: {} },
+    workflowHashBefore: `before-${index}`,
+    workflowHashAfter: `after-${index}`,
+    userIntent: 'Test multi-batch retention',
+    intentClassification: IntentClassification.ADD_FUNCTIONALITY,
+    toolName: MutationToolName.UPDATE_PARTIAL,
+    operations: [],
+    operationCount: 0,
+    operationTypes: [],
+    validationImproved: null,
+    errorsResolved: 0,
+    errorsIntroduced: 0,
+    nodesAdded: 0,
+    nodesRemoved: 0,
+    nodesModified: 0,
+    connectionsAdded: 0,
+    connectionsRemoved: 0,
+    propertiesChanged: 0,
+    mutationSuccess: true,
+    durationMs: 1,
+  });
+
   beforeEach(() => {
     vi.useFakeTimers();
     mockIsEnabled = vi.fn().mockReturnValue(true);
@@ -94,6 +131,17 @@ describe('TelemetryBatchProcessor', () => {
 
       expect(setIntervalSpy).not.toHaveBeenCalled();
       processor.stop();
+    });
+
+    it('should not register timers or listeners more than once', () => {
+      const setIntervalSpy = vi.spyOn(global, 'setInterval');
+      const onSpy = vi.spyOn(process, 'on');
+
+      batchProcessor.start();
+      batchProcessor.start();
+
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(onSpy).toHaveBeenCalledTimes(3);
     });
 
     it('should set up process exit handlers', () => {
@@ -226,6 +274,45 @@ describe('TelemetryBatchProcessor', () => {
   });
 
   describe('batch creation', () => {
+    async function expectAllUnsentBatchesRetried(
+      table: string,
+      itemCount: number,
+      flush: () => Promise<void>
+    ): Promise<void> {
+      const insert = vi.fn()
+        .mockResolvedValueOnce(createMockSupabaseResponse(new Error('First batch failed')))
+        .mockResolvedValue(createMockSupabaseResponse());
+      vi.mocked(mockSupabase.from).mockImplementation((requestedTable) => ({
+        insert: requestedTable === table
+          ? insert
+          : vi.fn().mockResolvedValue(createMockSupabaseResponse()),
+        url: { href: '' },
+        headers: {},
+        select: vi.fn(),
+        upsert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn()
+      } as any));
+
+      await flush();
+
+      expect(insert).toHaveBeenCalledTimes(1);
+      expect(batchProcessor.getMetrics()).toMatchObject({
+        eventsFailed: itemCount,
+        batchesFailed: 2,
+        deadLetterQueueSize: itemCount,
+      });
+
+      await batchProcessor.flush([]);
+
+      const retriedItems = insert.mock.calls
+        .slice(1)
+        .flatMap(([batch]) => batch);
+      expect(insert).toHaveBeenCalledTimes(3);
+      expect(retriedItems).toHaveLength(itemCount);
+      expect(batchProcessor.getMetrics().deadLetterQueueSize).toBe(0);
+    }
+
     it('should create single batch for small datasets', async () => {
       const events: TelemetryEvent[] = Array.from({ length: 10 }, (_, i) => ({
         user_id: `user${i}`,
@@ -256,6 +343,44 @@ describe('TelemetryBatchProcessor', () => {
 
       expect(firstCall).toHaveLength(TELEMETRY_CONFIG.MAX_BATCH_SIZE);
       expect(secondCall).toHaveLength(25);
+    });
+
+    it('should retain every unattempted event batch after a failure', async () => {
+      const events: TelemetryEvent[] = Array.from({ length: 60 }, (_, index) => ({
+        user_id: `event-user-${index}`,
+        event: 'multi_batch_event',
+        properties: { index },
+      }));
+
+      await expectAllUnsentBatchesRetried(
+        'telemetry_events',
+        events.length,
+        () => batchProcessor.flush(events)
+      );
+    });
+
+    it('should retain every unattempted workflow batch after a failure', async () => {
+      const workflows = Array.from({ length: 60 }, (_, index) =>
+        createWorkflowTelemetry(index)
+      );
+
+      await expectAllUnsentBatchesRetried(
+        'telemetry_workflows',
+        workflows.length,
+        () => batchProcessor.flush(undefined, workflows)
+      );
+    });
+
+    it('should retain every unattempted mutation batch after a failure', async () => {
+      const mutations = Array.from({ length: 60 }, (_, index) =>
+        createMutationRecord(index)
+      );
+
+      await expectAllUnsentBatchesRetried(
+        'workflow_mutations',
+        mutations.length,
+        () => batchProcessor.flush(undefined, undefined, mutations)
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- bound every Supabase telemetry request with a 2-second aborting fetch deadline
- use one timeout-bounded telemetry delivery attempt so a failed best-effort request cannot leave retry work behind
- serialize batch flushes globally so concurrent events, workflows, and mutations are not silently skipped
- make workflow-mutation telemetry explicitly fire-and-forget at partial and full update handler boundaries
- route failed workflow mutations back through the mutation table when processing the dead-letter queue
- retain the failed batch and all later unattempted batches for events, workflows, and mutations
- route periodic and process-lifecycle flush requests through `TelemetryManager`, which owns and drains the telemetry queues
- await the bounded queue-aware flush before exiting on SIGINT or SIGTERM
- add regression coverage for cancellation, never-settling transports, flush concurrency, handler liveness, dead-letter retries, scheduled queue draining, multi-batch failures, and shutdown ordering
- bump the package release version to `2.65.2` and document the fix in `CHANGELOG.md`

## Root cause

Telemetry's operation timeout raced the Supabase promise but did not abort the underlying fetch. A stalled transport could therefore survive the timeout, and retries could create additional orphaned requests. Concurrent flush guards could also return success without sending the queued batch.

Workflow update handlers intended mutation telemetry to be best-effort, but that contract was implicit. This change makes the detachment explicit and bounds the transport itself, including implementations that ignore `AbortSignal`.

The shared dead-letter queue previously distinguished only workflow snapshots from events, so failed mutation records could be retried against `telemetry_events`. Mutation records are now classified separately and retried through `workflow_mutations`.

When a multi-batch flush failed early, only the current batch entered the dead-letter queue and later unattempted batches were lost. All affected batches are now retained and accounted for before retry.

Periodic and exit-triggered flushes were also initiated inside `TelemetryBatchProcessor`, which cannot access the queues owned by `TelemetryEventTracker`. Scheduled flush requests now call back into `TelemetryManager`, and initialization is completed before the processor starts, so queued events, workflows, and mutations are actually drained.

SIGINT and SIGTERM previously started that flush but immediately called `process.exit(0)`, which could terminate the process before the Promise settled. Signal handlers now exit only after the bounded flush completes.

## Impact

Workflow mutation responses no longer depend on telemetry transport liveness. Telemetry remains enabled and best-effort, while concurrent batches are processed one at a time without silent loss. Failed mutation telemetry retains its correct destination during dead-letter retries, scheduled flushes drain the manager-owned queues, a failed batch no longer discards later batches, and shutdown signals give the bounded flush a chance to finish.

Fixes #944

## Verification

- `npm run typecheck`
- `npm run build`
- release metadata consistency: `package.json`, root `package-lock.json`, and `CHANGELOG.md` all report `2.65.2`
- focused regression suite: 277 passed, 2 skipped
- Codecov patch coverage: 100% (161/161 coverable changed lines)
- full unit suite: 5,302 passed, 35 skipped
- independent testing-agent review: no blocking findings
- live `n8n-mcp-testing` verification with telemetry enabled:
  - Set node typeVersion 3.4 plus `addConnection` completed and persisted successfully
  - saved workflow validation returned zero errors and warnings
  - invalid source connection returned a normal failure response without modifying the workflow
  - no mutation call hung or timed out

Conceived by Romuald Członkowski - www.aiadvisors.pl/en
