### PR TITLE
feat: add run and cancel actions to n8n_evaluations (#936)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,11 +131,12 @@ AUTH_TOKEN=your-secure-token-here
 # Operation names match the action / mode enum values in each tool's schema.
 #
 # Eligible tools and their operations:
-#   n8n_executions       — action: get, list, delete
+#   n8n_executions        — action: get, list, delete
+#   n8n_evaluations       — action: list_runs, get_run, list_cases, run, cancel
 #   n8n_workflow_versions — mode: list, get, rollback, delete, prune
 #
 # Read-only deployment recipe (blocks all destructive operations):
-# DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune;n8n_executions:delete
+# DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune;n8n_executions:delete;n8n_evaluations:run,cancel
 #
 # Combine with n8n API key RBAC for defence in depth.
 # Default: (empty - all operations enabled)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.67.0] - 2026-07-29
+
+### Added
+
+- **`n8n_evaluations` can now trigger and cancel evaluation test runs (#936).** n8n 2.32.0 added the Public API endpoints (`POST /workflows/{id}/test-runs` and `POST /workflows/{id}/test-runs/{runId}/cancel`, behind the new `testRun:create`/`testRun:cancel` API-key scopes), so the tool gains `run` and `cancel` actions beside the three reads. Failures map to guidance for the causes n8n actually distinguishes: 402 is the plan's evaluation quota running out; 403 covers both a key missing the scope and an unlicensed instance; 409 on `run` means the workflow has no evaluation trigger node, on `cancel` that the run already finished. An instance older than 2.32.0 answers `run` with 405 — the route exists with GET only — and the error path re-reads the instance version instead of trusting the client's cached reading, so a connection that outlives an n8n upgrade cannot misreport a genuine not-found as a version problem, nor the reverse. The tool is no longer read-only: its annotations change accordingly, `run` and `cancel` are registered as destructive operations for `DISABLED_TOOL_OPERATIONS`, and the read-only deployment recipe in the README, the HTTP deployment guide, and `.env.example` now blocks them explicitly.
 ## [2.66.3] - 2026-07-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ These tools require `N8N_API_URL` and `N8N_API_KEY` in your configuration.
 #### Execution Management
 - **`n8n_test_workflow`** - Test/trigger workflow execution (webhook, form, chat)
 - **`n8n_executions`** - Unified execution management (list, get, delete)
-- **`n8n_evaluations`** - Read evaluation test runs (list runs, aggregated metrics, per-case results; n8n 2.30+)
+- **`n8n_evaluations`** - Run and read evaluation test runs (list runs, aggregated metrics, per-case results on n8n 2.30+; trigger and cancel on 2.32+)
 
 #### Data Table Management
 - **`n8n_manage_datatable`** - Manage n8n data tables and rows (list, get, create, update, delete)
@@ -413,7 +413,7 @@ DISABLED_TOOLS=n8n_create_workflow,n8n_update_full_workflow,n8n_update_partial_w
 For tools that bundle read and write operations under one name, block only the destructive operations while keeping `list` and `get`:
 
 ```bash
-DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune;n8n_executions:delete
+DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune;n8n_executions:delete;n8n_evaluations:run,cancel
 ```
 
 Combine with a read-only n8n API key (Settings → API in your n8n instance) for defence in depth. See [Read-Only Deployment Recipe](./docs/HTTP_DEPLOYMENT.md#read-only-deployment-recipe) for the full setup guide.

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -889,10 +889,10 @@ Some tools are write/destructive or handle sensitive data and should be removed 
 DISABLED_TOOLS=n8n_create_workflow,n8n_update_full_workflow,n8n_update_partial_workflow,n8n_delete_workflow,n8n_autofix_workflow,n8n_deploy_template,n8n_test_workflow,n8n_manage_credentials,n8n_manage_datatable
 ```
 
-Two tools bundle read and write operations under a single name. Use `DISABLED_TOOL_OPERATIONS` to block only their destructive branches while keeping `list` and `get`:
+Three tools bundle read and write operations under a single name. Use `DISABLED_TOOL_OPERATIONS` to block only their destructive branches while keeping `list` and `get`:
 
 ```bash
-DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune;n8n_executions:delete
+DISABLED_TOOL_OPERATIONS=n8n_workflow_versions:delete,rollback,prune;n8n_executions:delete;n8n_evaluations:run,cancel
 ```
 
 The operation parameter enum in the tool schema is updated to exclude disabled values, reducing the likelihood the model attempts them. Any attempt that does reach the server is rejected at dispatch before the handler runs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.66.3",
+  "version": "2.67.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.66.3",
+      "version": "2.67.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.28.0",
@@ -328,19 +328,6 @@
       "version": "3.974.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
       "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.16.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/checksums/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.0",
@@ -1211,19 +1198,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.16.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws/lambda-invoke-store": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
@@ -1829,16 +1803,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.62",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.62.tgz",
-      "integrity": "sha512-RKVpKRuq2xSzidsSMIgFXBUvfeTP3Tu9F7FnCi6dyyjbwYupOwa+liJYu7fyhqpLUSKg+NAEFfUQvg1791Wb2Q==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.70.tgz",
+      "integrity": "sha512-JlUjK6bYJAxN9PkWWCI/TiOYEdvXNKq61x2DTaEKxRMxAOYNk2LX8m4wVtDFxTZwyXx7Tpmxb49dNprkW/uqXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.0",
-        "@aws-sdk/nested-clients": "^3.997.30",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1846,17 +1820,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
-      "version": "3.975.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.0.tgz",
-      "integrity": "sha512-rro0KMJz0XBZw1HChXXgylx9aaf60ITyBmZtH0x+9QG6u3SOoyM81LI9ONSGQe0nuN4554LOg4xKIY7frHpgmg==",
+      "version": "3.977.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.2.tgz",
+      "integrity": "sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -1865,18 +1839,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.30.tgz",
-      "integrity": "sha512-ZQpvaE4gKKChXIyU5nn/jJeA5TixpWeb3KToovyQ+Hj2HPHkTIjCWirnDHG9Za1HNwTFP4NHdAtuNuEU0PqDww==",
+      "version": "3.997.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.37.tgz",
+      "integrity": "sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.0",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1884,25 +1858,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1919,21 +1880,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.65",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.65.tgz",
-      "integrity": "sha512-0+AbSk0KOk+5VR12KHy4PM2SDgGmO8tcdTVVSyvfG0k043i8sq4x7jSLTzNTI+BxUMjteIPSqFc8AfYm/PjxoQ==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.74.tgz",
+      "integrity": "sha512-V+7pzT0OzROL2uKcQ2+MpnfwKONvozYojmdn8RguAMX9o48gtSVvt+7aCkwWCH2thDXOnUPCN6qn4kiFDelZWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.56",
-        "@aws-sdk/credential-provider-http": "^3.972.58",
-        "@aws-sdk/credential-provider-ini": "^3.973.0",
-        "@aws-sdk/credential-provider-process": "^3.972.56",
-        "@aws-sdk/credential-provider-sso": "^3.973.0",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.62",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-ini": "^3.973.8",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1941,17 +1902,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/core": {
-      "version": "3.975.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.0.tgz",
-      "integrity": "sha512-rro0KMJz0XBZw1HChXXgylx9aaf60ITyBmZtH0x+9QG6u3SOoyM81LI9ONSGQe0nuN4554LOg4xKIY7frHpgmg==",
+      "version": "3.977.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.2.tgz",
+      "integrity": "sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -1960,15 +1921,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.56.tgz",
-      "integrity": "sha512-cjFAqXcfmzxOyNE7vGfe8XTju6JJ7ch/2w+vr/mqQMdxukSkBpkaWd3ewXpaBQ7FP+IKYLT5eHjvwqCUQua8DA==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.63.tgz",
+      "integrity": "sha512-VSS9dftt7r7GiZ4gs8z0PNaMLVAaSj/MXVr6WQBtsrQQB9miJo7I6lQuJND1/ugFwK9x7OHCYZDkLSYh0FIZtA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.0",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1976,17 +1937,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.58.tgz",
-      "integrity": "sha512-UTHgQ6j3IkOMYLXXWpil56RfprNfx+GWKdGiwhWBqKNSnxm43uH1erWg2fDv+/qPndz+wwmiLlfRArQZFmtO0Q==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.65.tgz",
+      "integrity": "sha512-SH/ec7p1J0CfC28+ypH38IwGENd7tQEvTpmuRSlinthiGxKlwzJbXGXxIMAhn0/lpxnIxudNmCsw3Cy0PDRoAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.0",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1994,23 +1955,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.0.tgz",
-      "integrity": "sha512-KZKwYIv7ZwcZuWWz1bb7MAr8rChzZzDXbNWNVxZlh6tbG+WwwdBBvyIwrzvCOSV+/7/q+gyd5uiAfDSK+61/1Q==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.8.tgz",
+      "integrity": "sha512-alkQpDUHsjHGVXvlV0XFXpPfh9+aTMmN6UYRky0Qky8SbvdxoQdDHftT4uugq8XShP6WtDQW7bo5YQ0SfNSxRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.0",
-        "@aws-sdk/credential-provider-env": "^3.972.56",
-        "@aws-sdk/credential-provider-http": "^3.972.58",
-        "@aws-sdk/credential-provider-login": "^3.972.62",
-        "@aws-sdk/credential-provider-process": "^3.972.56",
-        "@aws-sdk/credential-provider-sso": "^3.973.0",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.62",
-        "@aws-sdk/nested-clients": "^3.997.30",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-login": "^3.972.70",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2018,15 +1979,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.56",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.56.tgz",
-      "integrity": "sha512-PC8w9452qVJCf0ZaGq/Gf7uxq2oX8dIE8ON//uoRt8Smhq3ihSWwSVdlFMIK89MCN53+wwif62FL/+sudBFpJQ==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.63.tgz",
+      "integrity": "sha512-lPt2oGMcvP3uPhhxX5EquHrzBI/ZgJce+CHKcOGZl2ZQAXLLSxu7k/Cgo0HIktyi9dmDFljbOkj4XAnXD93YVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.0",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2034,17 +1995,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.0.tgz",
-      "integrity": "sha512-ZCe6i8p6jl3OUKV1l8aOWI/gNUjFH/94M0LqfsRit7qGt0HdK+fdsqDOlH2H3yw15WUsFCJ+r1xqsE6kSdPVlw==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.7.tgz",
+      "integrity": "sha512-FR2b+7QNXP/q+eslVzrCjGKvso8Lcr/B18BvFyD2iLNhq42XSo+wnh8FfX6mtqgaVsL1vuB27uGXuY+xUTa7pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.0",
-        "@aws-sdk/nested-clients": "^3.997.30",
-        "@aws-sdk/token-providers": "3.1082.0",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/token-providers": "3.1097.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2052,16 +2013,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.62",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.62.tgz",
-      "integrity": "sha512-CrGUTJlMSkecTSSSA4J/BC+VmzXAgVXDkRKj4Wy1EvrsZPaT0L9tiCly6VPSfJTM4ypokARht+IgDSk38gmh9w==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.69.tgz",
+      "integrity": "sha512-RWNTKGXRkzMJe8bgIAdlz9q0N97m7fThD9KOjBt2CSY+/xnIbrA1/Dnm/ZEz8ZeQ1Of5D+fLaPeoD3lGt6AU4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.0",
-        "@aws-sdk/nested-clients": "^3.997.30",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2069,18 +2030,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.30.tgz",
-      "integrity": "sha512-ZQpvaE4gKKChXIyU5nn/jJeA5TixpWeb3KToovyQ+Hj2HPHkTIjCWirnDHG9Za1HNwTFP4NHdAtuNuEU0PqDww==",
+      "version": "3.997.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.37.tgz",
+      "integrity": "sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.0",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2088,16 +2049,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1082.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1082.0.tgz",
-      "integrity": "sha512-adHOgJ97jv3QkN8w9TNrDx+3SKAIi1+ihCsv2n4/hYMIvCuzD0QA6vgPGeb/R3fYk9ZVXD2/0SaluR0izcAY/Q==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1097.0.tgz",
+      "integrity": "sha512-EIsdmy/f5IGc5r01RjKWNvrbBra6z0xudQM0D6Wf8DeGuPoRlubkLqr7VgWijFucO4kg0mtev9H3RX/ZOubUhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.0",
-        "@aws-sdk/nested-clients": "^3.997.30",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2105,25 +2066,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2766,19 +2714,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.16.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws/lambda-invoke-store": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
@@ -2988,14 +2923,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
-      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3003,12 +2938,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3285,12 +3220,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
-      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.15.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3787,6 +3722,154 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@browserbasehq/sdk": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.16.0.tgz",
+      "integrity": "sha512-mPAuLRU9jWR7o0KJi9+gQnOBDUSIkoKbbFv4HjrA+80qWVcFacrNPlZmf4mguQnfZ0oP2t5c3ws6yuFyAX9vpA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@browserbasehq/sdk/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@browserbasehq/sdk/node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@browserbasehq/sdk/node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/@browserbasehq/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@browserbasehq/sdk/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@browserbasehq/stagehand": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@browserbasehq/stagehand/-/stagehand-1.14.0.tgz",
+      "integrity": "sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.27.3",
+        "@browserbasehq/sdk": "^2.0.0",
+        "ws": "^8.18.0",
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1.42.1",
+        "deepmerge": "^4.3.1",
+        "dotenv": "^16.4.5",
+        "openai": "^4.62.1",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@browserbasehq/stagehand/node_modules/@anthropic-ai/sdk": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.27.3.tgz",
+      "integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@browserbasehq/stagehand/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@browserbasehq/stagehand/node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@browserbasehq/stagehand/node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/@browserbasehq/stagehand/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@browserbasehq/stagehand/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@cfworker/json-schema": {
@@ -4565,6 +4648,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@ibm-cloud/watsonx-ai": {
+      "version": "1.7.15",
+      "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.15.tgz",
+      "integrity": "sha512-JUxFuACcKhDC+shavgyLEFjWiSsBjI+tjIBvLrzcHywh0HqTT0m+whe2kL3isPheBzrduSMfovwypbSuKwCp+g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "form-data": "^4.0.4",
+        "ibm-cloud-sdk-core": "^5.4.20"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@icetee/ftp": {
@@ -6262,6 +6359,24 @@
         "@langchain/langgraph": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@microsoft/agents-a365-tooling-extensions-langchain/node_modules/@langchain/core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.3.tgz",
+      "integrity": "sha512-F+L5SsciykwDl7eDxacnhDTcWe1IF6jetzfkvI5PPfq6ogWHO7xcjU90SGh/3lqbbS0tgun+qF01KIqxawrCsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": ">=0.5.0 <1.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "zod": "^3.25.76 || ^4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@microsoft/agents-a365-tooling-extensions-langchain/node_modules/langchain": {
@@ -8599,6 +8714,31 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/@n8n/n8n-nodes-langchain/node_modules/cheerio": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.0.tgz",
+      "integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.10.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
     "node_modules/@n8n/n8n-nodes-langchain/node_modules/d3-dsv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
@@ -8758,6 +8898,42 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/@n8n/n8n-nodes-langchain/node_modules/mysql2": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.17.0.tgz",
+      "integrity": "sha512-qF1KYPuytBGqAnMzaQ5/rW90iIqcjnrnnS7bvcJcdarJzlUTAiD9ZC0T7mwndacECseSQ6LcRbRvryXLp25m+g==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.3",
+        "named-placeholders": "^1.1.6",
+        "seq-queue": "^0.0.5",
+        "sql-escaper": "^1.3.1"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/@n8n/n8n-nodes-langchain/node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@n8n/n8n-nodes-langchain/node_modules/openai": {
       "version": "6.46.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.46.0.tgz",
@@ -8823,6 +8999,15 @@
       "license": "MIT",
       "dependencies": {
         "anynum": "^1.0.0"
+      }
+    },
+    "node_modules/@n8n/n8n-nodes-langchain/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@n8n/n8n-nodes-langchain/node_modules/zod-to-json-schema": {
@@ -9271,10 +9456,12 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.213.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz",
-      "integrity": "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==",
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -9364,6 +9551,18 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz",
+      "integrity": "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
       "version": "0.213.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.213.0.tgz",
@@ -9383,6 +9582,18 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/api-logs": {
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz",
+      "integrity": "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto/node_modules/@opentelemetry/resources": {
@@ -9787,6 +9998,18 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz",
+      "integrity": "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@opentelemetry/otlp-exporter-base": {
       "version": "0.213.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.213.0.tgz",
@@ -9840,6 +10063,18 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz",
+      "integrity": "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
@@ -9954,6 +10189,18 @@
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz",
+      "integrity": "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
@@ -10038,6 +10285,18 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz",
+      "integrity": "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources": {
@@ -10252,6 +10511,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@polka/url": {
@@ -11214,9 +11489,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
-      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.0.tgz",
+      "integrity": "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -11227,13 +11502,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.7.tgz",
-      "integrity": "sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==",
+      "version": "4.4.15",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.15.tgz",
+      "integrity": "sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11293,13 +11568,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.4.tgz",
-      "integrity": "sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.12.tgz",
+      "integrity": "sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11462,13 +11737,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.4.tgz",
-      "integrity": "sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==",
+      "version": "4.9.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.12.tgz",
+      "integrity": "sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -11528,13 +11803,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.3.tgz",
-      "integrity": "sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.11.tgz",
+      "integrity": "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.31.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -12209,6 +12484,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/ms": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -14141,6 +14426,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -14216,25 +14514,27 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.0.tgz",
-      "integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.0",
-        "htmlparser2": "^10.0.0",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.10.0",
+        "undici": "^7.19.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -14262,6 +14562,8 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
       "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -14928,6 +15230,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/date-fns-tz": {
@@ -17291,6 +17610,185 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/ibm-cloud-sdk-core": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.6.0.tgz",
+      "integrity": "sha512-7balLY8WKk+bOhe5Vgg4zG2X6Z0zhpG/3VtYPC69evj+lVJSId8xYP7ISRzRfoeXAlJfzLNMbi2Na/0IdDiIkQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/debug": "4.1.12",
+        "@types/node": "18.19.80",
+        "@types/tough-cookie": "4.0.0",
+        "axios": "1.18.0",
+        "camelcase": "6.3.0",
+        "debug": "4.3.4",
+        "dotenv": "16.4.5",
+        "extend": "3.0.2",
+        "file-type": "21.3.2",
+        "form-data": "4.0.6",
+        "isstream": "0.1.2",
+        "jsonwebtoken": "9.0.3",
+        "load-esm": "1.0.3",
+        "mime-types": "2.1.35",
+        "retry-axios": "2.6.0",
+        "tough-cookie": "4.1.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/@types/node": {
+      "version": "18.19.80",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.80.tgz",
+      "integrity": "sha512-kEWeMwMeIvxYkeg1gTc01awpwLbfMRZXdIhwRcakd/KlK53jmRC26LqcbIt7fnAQTu5GzlnWmzA3H6+l1u6xxQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -17346,7 +17844,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -18132,6 +18630,13 @@
         "ws": "*"
       }
     },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -18705,6 +19210,26 @@
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/load-esm": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
+      "integrity": "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=13.2.0"
       }
     },
     "node_modules/lodash": {
@@ -19832,23 +20357,27 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.17.0.tgz",
-      "integrity": "sha512-qF1KYPuytBGqAnMzaQ5/rW90iIqcjnrnnS7bvcJcdarJzlUTAiD9ZC0T7mwndacECseSQ6LcRbRvryXLp25m+g==",
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.2.tgz",
+      "integrity": "sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "aws-ssl-profiles": "^1.1.2",
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.7.2",
         "long": "^5.3.2",
-        "lru.min": "^1.1.3",
+        "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "seq-queue": "^0.0.5",
-        "sql-escaper": "^1.3.1"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
       }
     },
     "node_modules/mysql2/node_modules/iconv-lite": {
@@ -19856,6 +20385,8 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
       "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -20432,6 +20963,40 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/n8n-nodes-base/node_modules/cheerio": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.0.tgz",
+      "integrity": "sha512-+0hMx9eYhJvWbgpKV9hN7jg0JcwydpopZE4hgi+KvQtByZXPp04NiCWU0LzcAbP63abZckIHkTQaXVF52mX3xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.10.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/n8n-nodes-base/node_modules/cheerio/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/n8n-nodes-base/node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -20519,6 +21084,42 @@
         "socks": {
           "optional": true
         }
+      }
+    },
+    "node_modules/n8n-nodes-base/node_modules/mysql2": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.17.0.tgz",
+      "integrity": "sha512-qF1KYPuytBGqAnMzaQ5/rW90iIqcjnrnnS7bvcJcdarJzlUTAiD9ZC0T7mwndacECseSQ6LcRbRvryXLp25m+g==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.3",
+        "named-placeholders": "^1.1.6",
+        "seq-queue": "^0.0.5",
+        "sql-escaper": "^1.3.1"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/n8n-nodes-base/node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/n8n-nodes-base/node_modules/proxy-from-env": {
@@ -22132,6 +22733,53 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -22830,6 +23478,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/retry-axios": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
+      "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=10.7.0"
+      },
+      "peerDependencies": {
+        "axios": "*"
       }
     },
     "node_modules/retry-request": {
@@ -25580,6 +26241,13 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/ts-type": {
       "version": "3.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.66.3",
+  "version": "2.67.0",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -22,6 +22,7 @@ import {
   getWebhookUrl
 } from '../services/n8n-validation';
 import { nodeGroupsField, parseNodeGroupsInput } from '../services/node-groups';
+import { versionAtLeast } from '../services/n8n-version';
 import {
   N8nApiError,
   N8nNotFoundError,
@@ -531,23 +532,37 @@ const listExecutionsSchema = z.object({
   includeData: z.boolean().optional(),
 });
 
+// Evaluation ids become API path segments; trim and require content so a blank
+// or whitespace-only value fails here as "Invalid input" rather than surfacing
+// later as a transport-layer error.
+const testRunPathId = z.string().trim().min(1);
+
 const listTestRunsSchema = z.object({
-  workflowId: z.string(),
+  workflowId: testRunPathId,
   status: optionalEmptyAware(z.enum(['new', 'running', 'completed', 'error', 'cancelled'])),
   limit: z.number().min(1).max(250).optional(),
   cursor: optionalEmptyAware(z.string()),
 });
 
 const getTestRunSchema = z.object({
-  workflowId: z.string(),
-  runId: z.string(),
+  workflowId: testRunPathId,
+  runId: testRunPathId,
 });
 
 const listTestCasesSchema = z.object({
-  workflowId: z.string(),
-  runId: z.string(),
+  workflowId: testRunPathId,
+  runId: testRunPathId,
   limit: z.number().min(1).max(250).optional(),
   cursor: optionalEmptyAware(z.string()),
+});
+
+const triggerTestRunSchema = z.object({
+  workflowId: testRunPathId,
+});
+
+const cancelTestRunSchema = z.object({
+  workflowId: testRunPathId,
+  runId: testRunPathId,
 });
 
 const workflowVersionsSchema = z.object({
@@ -1984,46 +1999,153 @@ export async function handleDeleteExecution(args: unknown, context?: InstanceCon
   }
 }
 
-// Evaluation Test Run Handlers (n8n >= 2.30)
+// Evaluation Test Run Handlers (reads n8n >= 2.30, run/cancel n8n >= 2.32)
 
-const TEST_RUN_SCOPE_HINT =
-  'n8n rejected the request (403). The API key lacks testRun scopes - keys created before n8n 2.30 do not have them; re-create the API key on n8n 2.30+. Other causes: evaluations not licensed on this plan, or the key\'s owner lacks access to this workflow.';
+const TEST_RUN_QUOTA_HINT =
+  'n8n rejected the request (402): the plan\'s evaluation quota is used up. It caps how many workflows may have test runs, and this workflow does not hold one of the slots. Re-run a workflow that already has runs, or raise the limit on your n8n plan.';
+
+/**
+ * 403 guidance for the write actions. All three causes - a key without the
+ * scope, an unlicensed instance, and a key owner without workflow:execute -
+ * surface identically, so name them all.
+ */
+function testRunWriteScopeHint(scope: 'testRun:create' | 'testRun:cancel'): string {
+  return `n8n rejected the request (403). The API key lacks the ${scope} scope - that scope only exists on keys created on n8n 2.32+, so re-create the key there. Other causes: evaluations not licensed on this plan, or the key's owner lacks workflow:execute on this workflow.`;
+}
+
+const TEST_RUN_IDS_HINT =
+  'Workflow or test run not found. A runId must belong to the given workflowId; check both ids.';
+
+/** For the actions that take no runId, where TEST_RUN_IDS_HINT would misdirect. */
+const TEST_RUN_WORKFLOW_HINT =
+  "Workflow not found. Check the workflowId, and that the API key's owner has access to that workflow.";
+
+/** Per-action tuning for handleTestRunError. */
+interface TestRunErrorOptions {
+  /** Minimum n8n 2.x minor whose Public API serves the route. */
+  minMinor: number;
+  /** Completes "Upgrade the instance to ..." in the version-gate message. */
+  capability: string;
+  /** 403 guidance; each action names the scope it needs. */
+  scopeHint: string;
+  /** 404 guidance once the instance version is ruled out. */
+  notFoundHint: string;
+  /** 409 guidance; only the write actions can produce one. */
+  conflictHint?: string;
+  /**
+   * True for the actions whose route is POST. Only they can read a 405 as "the
+   * instance does not document this method"; the read routes are GET, so a 405
+   * on one of those comes from something in front of n8n, not from its version.
+   */
+  postRoute?: boolean;
+}
+
+/** Common to the read actions; they differ only in their 404 guidance. */
+const READ_TEST_RUN_BASE = {
+  minMinor: 30,
+  capability: 'read test runs',
+  scopeHint:
+    'n8n rejected the request (403). The API key lacks testRun scopes - keys created before n8n 2.30 do not have them; re-create the API key on n8n 2.30+. Other causes: evaluations not licensed on this plan, or the key\'s owner lacks access to this workflow.',
+};
+
+const LIST_TEST_RUNS_ERRORS: TestRunErrorOptions = {
+  ...READ_TEST_RUN_BASE,
+  notFoundHint: TEST_RUN_WORKFLOW_HINT,
+};
+
+/** get_run and list_cases both address a run within a workflow. */
+const READ_TEST_RUN_ERRORS: TestRunErrorOptions = {
+  ...READ_TEST_RUN_BASE,
+  notFoundHint: TEST_RUN_IDS_HINT,
+};
+
+const TRIGGER_TEST_RUN_ERRORS: TestRunErrorOptions = {
+  minMinor: 32,
+  capability: 'trigger runs from the API',
+  scopeHint: testRunWriteScopeHint('testRun:create'),
+  notFoundHint: TEST_RUN_WORKFLOW_HINT,
+  conflictHint:
+    'The workflow has no evaluation trigger node. Add an evaluation trigger (n8n-nodes-base.evaluationTrigger) pointing at a dataset, save the workflow, then trigger the run.',
+  postRoute: true,
+};
+
+const CANCEL_TEST_RUN_ERRORS: TestRunErrorOptions = {
+  minMinor: 32,
+  capability: 'cancel runs from the API',
+  scopeHint: testRunWriteScopeHint('testRun:cancel'),
+  notFoundHint: TEST_RUN_IDS_HINT,
+  conflictHint:
+    "The test run already finished (status completed, error, or cancelled), so there is nothing to cancel. Use action='get_run' to see its final state.",
+  postRoute: true,
+};
+
+/**
+ * Guidance for the two statuses an instance without the route produces: 404 when
+ * the path is undocumented, 405 when the path exists for another method (a
+ * pre-2.32 instance serves GET /test-runs but not POST). Returns null when the
+ * instance is new enough, leaving the status to the caller's normal mapping.
+ */
+async function testRunRouteGate(
+  statusCode: number,
+  context: InstanceContext | undefined,
+  options: TestRunErrorOptions
+): Promise<string | null> {
+  // Re-read the version rather than trusting the cache: it lives as long as the
+  // client, so an instance upgraded mid-session would still be blamed for a
+  // genuine bad-id 404. One extra request, only on these two statuses.
+  const client = getN8nApiClient(context);
+  const version = client ? await client.refreshVersion().catch(() => null) : null;
+
+  if (version) {
+    return versionAtLeast(version, 2, options.minMinor)
+      ? null
+      : `The evaluation API requires n8n 2.${options.minMinor}.0 or later; this instance runs ${version.version}. Upgrade the instance to ${options.capability}.`;
+  }
+
+  // Version unreadable, so the gate cannot be asserted. On a POST route a 405
+  // still has one cause - the instance does not document the method - while a
+  // 404 is equally consistent with wrong ids, so offer both.
+  const requirement = `This endpoint requires n8n 2.${options.minMinor}.0 or later, and this instance's n8n version could not be read.`;
+  return statusCode === 405 && options.postRoute
+    ? `${requirement} It rejected POST on the route, which is what an instance predating 2.${options.minMinor}.0 does. Upgrade the instance to ${options.capability}.`
+    : `${requirement} Either the instance predates it, or the request simply did not match. ${options.notFoundHint}`;
+}
 
 /**
  * Builds the error response for the evaluation handlers. Mirrors handleCrudError
- * but adds evaluation-specific guidance for the three failure modes that are easy
- * to confuse from raw HTTP statuses alone: a pre-2.30 instance, an API key without
- * testRun scopes, and a runId that does not belong to the given workflow.
+ * but adds evaluation-specific guidance for the failure modes that are easy to
+ * confuse from raw HTTP statuses alone: an instance too old for the route, an
+ * API key without testRun scopes, an exhausted evaluation quota, a workflow
+ * without an evaluation trigger, and a runId that does not belong to the given
+ * workflow.
  */
-async function handleTestRunError(error: unknown, context?: InstanceContext): Promise<McpToolResponse> {
+async function handleTestRunError(
+  error: unknown,
+  context: InstanceContext | undefined,
+  options: TestRunErrorOptions
+): Promise<McpToolResponse> {
   if (error instanceof z.ZodError) {
     return { success: false, error: 'Invalid input', details: { errors: error.errors } };
   }
   if (error instanceof N8nApiError) {
-    if (error.statusCode === 403) {
-      return { success: false, error: TEST_RUN_SCOPE_HINT, code: error.code };
+    if (error.statusCode === 402) {
+      return { success: false, error: TEST_RUN_QUOTA_HINT, code: error.code };
     }
+    if (error.statusCode === 403) {
+      return { success: false, error: options.scopeHint, code: error.code };
+    }
+    if (error.statusCode === 409 && options.conflictHint) {
+      return { success: false, error: options.conflictHint, code: error.code };
+    }
+    if (error.statusCode === 404 || error.statusCode === 405) {
+      const gate = await testRunRouteGate(error.statusCode, context, options);
+      if (gate) {
+        return { success: false, error: gate, code: error.code };
+      }
+    }
+    // On a current instance only the 404 form is about the request; a 405 falls through.
     if (error.statusCode === 404) {
-      // A 404 from a pre-2.30 instance means the endpoint doesn't exist, not
-      // that the ids are wrong. The version cache is usually cold on a fresh
-      // session, so fetch it (one extra request, failure path only).
-      const client = getN8nApiClient(context);
-      let version = client?.getCachedVersionInfo() ?? null;
-      if (!version && client) {
-        version = await client.getVersion().catch(() => null);
-      }
-      if (version && (version.major < 2 || (version.major === 2 && version.minor < 30))) {
-        return {
-          success: false,
-          error: `The evaluation API requires n8n 2.30 or later; this instance runs ${version.version}. Upgrade the instance to read test runs.`,
-          code: error.code,
-        };
-      }
-      return {
-        success: false,
-        error: 'Workflow or test run not found. A runId must belong to the given workflowId; check both ids.',
-        code: error.code,
-      };
+      return { success: false, error: options.notFoundHint, code: error.code };
     }
     return { success: false, error: getUserFriendlyErrorMessage(error), code: error.code };
   }
@@ -2063,7 +2185,7 @@ export async function handleListTestRuns(args: unknown, context?: InstanceContex
       }
     };
   } catch (error) {
-    return handleTestRunError(error, context);
+    return handleTestRunError(error, context, LIST_TEST_RUNS_ERRORS);
   }
 }
 
@@ -2079,7 +2201,7 @@ export async function handleGetTestRun(args: unknown, context?: InstanceContext)
       data: response
     };
   } catch (error) {
-    return handleTestRunError(error, context);
+    return handleTestRunError(error, context, READ_TEST_RUN_ERRORS);
   }
 }
 
@@ -2106,7 +2228,45 @@ export async function handleListTestCases(args: unknown, context?: InstanceConte
       }
     };
   } catch (error) {
-    return handleTestRunError(error, context);
+    return handleTestRunError(error, context, READ_TEST_RUN_ERRORS);
+  }
+}
+
+export async function handleTriggerTestRun(args: unknown, context?: InstanceContext): Promise<McpToolResponse> {
+  try {
+    const client = ensureApiConfigured(context);
+    const input = triggerTestRunSchema.parse(args || {});
+
+    const response = await client.triggerTestRun(input.workflowId);
+
+    return {
+      success: true,
+      data: {
+        ...response,
+        _note: `Run started. Cases execute asynchronously - poll with action='get_run', runId='${response.id}' until status is completed, error, or cancelled.`
+      }
+    };
+  } catch (error) {
+    return handleTestRunError(error, context, TRIGGER_TEST_RUN_ERRORS);
+  }
+}
+
+export async function handleCancelTestRun(args: unknown, context?: InstanceContext): Promise<McpToolResponse> {
+  try {
+    const client = ensureApiConfigured(context);
+    const input = cancelTestRunSchema.parse(args || {});
+
+    const response = await client.cancelTestRun(input.workflowId, input.runId);
+
+    return {
+      success: true,
+      data: {
+        ...response,
+        _note: "Cancellation accepted. In-flight cases stop asynchronously - use action='get_run' to confirm the run reached status 'cancelled'."
+      }
+    };
+  } catch (error) {
+    return handleTestRunError(error, context, CANCEL_TEST_RUN_ERRORS);
   }
 }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1866,8 +1866,15 @@ export class N8NDocumentationMCPServer {
               throw new Error('runId is required for action=list_cases');
             }
             return n8nHandlers.handleListTestCases(args, this.instanceContext);
+          case 'run':
+            return n8nHandlers.handleTriggerTestRun(args, this.instanceContext);
+          case 'cancel':
+            if (!args.runId) {
+              throw new Error('runId is required for action=cancel');
+            }
+            return n8nHandlers.handleCancelTestRun(args, this.instanceContext);
           default:
-            throw new Error(`Unknown action: ${evalAction}. Valid actions: list_runs, get_run, list_cases`);
+            throw new Error(`Unknown action: ${evalAction}. Valid actions: list_runs, get_run, list_cases, run, cancel`);
         }
       }
       case 'n8n_health_check':

--- a/src/mcp/tool-docs/workflow_management/n8n-evaluations.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-evaluations.ts
@@ -4,28 +4,38 @@ export const n8nEvaluationsDoc: ToolDocumentation = {
   name: 'n8n_evaluations',
   category: 'workflow_management',
   essentials: {
-    description: 'Read evaluation test runs for a workflow: list runs, get a run with aggregated metrics, or fetch per-case results. Read-only; requires n8n >= 2.30.',
+    description: 'Run and read evaluation test runs for a workflow: trigger a run, cancel one, list runs, get a run with aggregated metrics, or fetch per-case results. Reading requires n8n >= 2.30; run and cancel require n8n >= 2.32.',
     keyParameters: ['action', 'workflowId', 'runId', 'status'],
     example: 'n8n_evaluations({action: "list_runs", workflowId: "abc123", status: "completed"})',
     performance: 'Fast (50-200ms); list_cases payloads can be large - paginate',
     tips: [
+      'action="run": trigger a run - returns immediately, then poll get_run until the status is terminal',
+      'action="cancel": stop a run that is still new or running',
       'action="list_runs": runs for a workflow, filterable by status, newest first',
       'action="get_run": one run with aggregated metrics and final result',
       'action="list_cases": per-case inputs/outputs/metrics - default limit 20, paginate rather than raising it',
-      'Requires an API key created on n8n 2.30+ (older keys lack testRun scopes - re-create the key)',
-      'Runs exist only for workflows with an evaluation trigger that have been executed'
+      'Requires an API key created on n8n 2.30+ for reads and 2.32+ for run/cancel (older keys lack the scopes - re-create the key)'
     ]
   },
   full: {
     description: `**Actions:**
+- run: Trigger an evaluation test run for a workflow; returns { id, status, createdAt } once the run is persisted, before any case executes
+- cancel: Stop a run that is still new or running; returns { id, status: "cancelled" } once the cancellation is accepted
 - list_runs: List evaluation test runs for a workflow (paginated, status filter, newest first)
 - get_run: Retrieve a single test run with aggregated metrics, final result, and case count
 - list_cases: Retrieve per-case results of a run - inputs, outputs, metrics, and the executionId of each case
 
 **Prerequisites:**
-- n8n 2.30.0 or later (the evaluation Public API shipped in 2.30)
-- API key with testRun scopes - keys created before 2.30 do not have them and must be re-created
-- Evaluation runs exist only for workflows with a configured evaluation trigger that have been run from the n8n editor (triggering runs via the public API is not yet supported by n8n)
+- n8n 2.30.0 or later for the read actions (the evaluation Public API shipped in 2.30)
+- n8n 2.32.0 or later for run and cancel (the trigger/cancel routes shipped in 2.32)
+- API key with testRun scopes - reads need testRun:read/testRun:list (2.30+), run needs testRun:create and cancel needs testRun:cancel (2.32+). Keys created before those releases lack the scopes and must be re-created
+- The key's owner also needs the workflow:execute project scope for run and cancel
+- The workflow must contain a configured evaluation trigger with a dataset; without one, run returns 409
+
+**Running and polling:**
+- run starts the cases asynchronously - the response only confirms the run was created
+- Poll get_run with the returned id until status is completed, error, or cancelled
+- cancel is accepted with the run still winding down; confirm with get_run that it reached "cancelled"
 
 **Reading results:**
 - Run metrics are a flat map of metric name to number/boolean (aggregates across cases)
@@ -33,38 +43,43 @@ export const n8nEvaluationsDoc: ToolDocumentation = {
 - Each case links to its underlying execution via executionId - use n8n_executions with that id to inspect the full execution
 - Compare metrics across runs of the same workflow to track prompt/model regressions`,
     parameters: {
-      action: { type: 'string', required: true, description: 'Operation: "list_runs", "get_run", or "list_cases"' },
+      action: { type: 'string', required: true, description: 'Operation: "run", "cancel", "list_runs", "get_run", or "list_cases"' },
       workflowId: { type: 'string', required: true, description: 'Workflow ID the test runs belong to' },
-      runId: { type: 'string', required: false, description: 'Test run ID (required for get_run and list_cases)' },
+      runId: { type: 'string', required: false, description: 'Test run ID (required for get_run, list_cases, and cancel)' },
       status: { type: 'string', required: false, description: 'For list_runs: filter by "new", "running", "completed", "error", or "cancelled"' },
       limit: { type: 'number', required: false, description: 'Results per page, 1-250. Defaults: 100 (list_runs), 20 (list_cases)' },
       cursor: { type: 'string', required: false, description: 'Pagination cursor from a previous response' }
     },
-    returns: `list_runs: { testRuns, returned, nextCursor, hasMore }. get_run: run object { id, status, runAt, completedAt, metrics, errorCode, errorDetails, finalResult, testCaseCount, createdAt, updatedAt }. list_cases: { testCases, returned, nextCursor, hasMore } where each case has { id, status, runAt, completedAt, metrics, errorCode, errorDetails, inputs, outputs, executionId }.`,
+    returns: `run: { id, status, createdAt }. cancel: { id, status: "cancelled" }. list_runs: { testRuns, returned, nextCursor, hasMore }. get_run: run object { id, status, runAt, completedAt, metrics, errorCode, errorDetails, finalResult, testCaseCount, createdAt, updatedAt }. list_cases: { testCases, returned, nextCursor, hasMore } where each case has { id, status, runAt, completedAt, metrics, errorCode, errorDetails, inputs, outputs, executionId }.`,
     examples: [
+      'n8n_evaluations({action: "run", workflowId: "abc123"}) - trigger a run, then poll get_run with the returned id',
+      'n8n_evaluations({action: "cancel", workflowId: "abc123", runId: "run456"}) - stop a run in progress',
       'n8n_evaluations({action: "list_runs", workflowId: "abc123"}) - all runs, newest first',
       'n8n_evaluations({action: "list_runs", workflowId: "abc123", status: "completed", limit: 10}) - recent completed runs',
       'n8n_evaluations({action: "get_run", workflowId: "abc123", runId: "run456"}) - aggregated metrics for one run',
-      'n8n_evaluations({action: "list_cases", workflowId: "abc123", runId: "run456"}) - first 20 case results',
-      'n8n_evaluations({action: "list_cases", workflowId: "abc123", runId: "run456", cursor: "..."}) - next page'
+      'n8n_evaluations({action: "list_cases", workflowId: "abc123", runId: "run456"}) - first 20 case results'
     ],
     useCases: [
-      'Poll a run started in the n8n editor and report when it completes',
+      'Trigger an evaluation run after changing a prompt and poll it to completion',
+      'Cancel a long-running evaluation that was started by mistake',
       'Compare metric aggregates across runs to catch prompt or model regressions',
       'Pull per-case failures and inspect the underlying executions via n8n_executions',
       'Export evaluation results to an external dashboard'
     ],
-    performance: 'Each call is a single n8n API request. list_cases responses carry raw per-case inputs/outputs - keep limit small and paginate.',
-    errorHandling: 'A 403 means the API key lacks testRun scopes (keys created before n8n 2.30 must be re-created), evaluations are not licensed on the plan, or the key\'s owner lacks access to the workflow. A 404 can mean the instance predates 2.30, the workflow id is wrong, or the runId belongs to a different workflow - the tool checks the instance version to disambiguate.',
+    performance: 'Each call is a single n8n API request. run returns before any case executes, so budget polling time separately. list_cases responses carry raw per-case inputs/outputs - keep limit small and paginate.',
+    errorHandling: 'A 402 means the plan\'s evaluation quota is used up - it caps how many workflows may have test runs, and re-running a workflow that already has runs is always allowed. A 403 means the API key lacks the scope for the action (testRun:create and testRun:cancel only exist on keys created on n8n 2.32+), evaluations are not licensed on the plan, or the key\'s owner lacks access to the workflow. A 409 on run means the workflow has no evaluation trigger; a 409 on cancel means the run already finished. A 404 (or a 405 on run) can mean the instance predates the required version, the workflow id is wrong, or the runId belongs to a different workflow - the tool checks the instance version to disambiguate.',
     bestPractices: [
+      'Validate the workflow has an evaluation trigger before calling run - a missing trigger is a 409, not a silent no-op',
+      'Poll get_run rather than assuming run completed; cases execute asynchronously',
       'Filter list_runs by status="completed" when you only need finished results',
       'Keep list_cases limit at the default 20 and paginate; raise it only when cases are known to be small',
       'Store run ids, not case payloads, when tracking results over time'
     ],
     pitfalls: [
-      'API keys created before n8n 2.30 silently lack testRun scopes - a 403 means re-create the key, not a bug',
-      'A 404 can mean the instance predates 2.30, the workflow id is wrong, or the runId belongs to a different workflow',
-      'Evaluations are license/quota-gated in n8n - instances without the feature simply have no runs'
+      'API keys created before the relevant n8n release silently lack the testRun scopes - a 403 means re-create the key, not a bug',
+      'run and cancel need n8n 2.32+; on 2.30/2.31 the routes do not exist and n8n answers 405 (run) or 404 (cancel)',
+      'run does not wait for the cases - a successful response only means the run was created',
+      'Evaluations are license/quota-gated in n8n - an unlicensed instance returns 403 and an exhausted quota returns 402'
     ],
     relatedTools: ['n8n_executions', 'n8n_test_workflow', 'n8n_workflow_versions']
   }

--- a/src/mcp/tools-documentation.ts
+++ b/src/mcp/tools-documentation.ts
@@ -157,7 +157,7 @@ When working with Code nodes, always start by calling the relevant guide:
 - n8n_autofix_workflow - Auto-fix common issues
 - n8n_test_workflow - Test/trigger workflows (webhook, form, chat, execute)
 - n8n_executions - Unified execution management (action='get'/'list'/'delete')
-- n8n_evaluations - Read evaluation test runs (action='list_runs'/'get_run'/'list_cases', n8n 2.30+)
+- n8n_evaluations - Run and read evaluation test runs (action='list_runs'/'get_run'/'list_cases' on n8n 2.30+, 'run'/'cancel' on 2.32+)
 - n8n_health_check - Check n8n API connectivity
 - n8n_workflow_versions - Version history and rollback
 - n8n_deploy_template - Deploy templates directly to n8n instance

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -522,7 +522,7 @@ export const n8nManagementTools: ToolDefinition[] = [
   },
   {
     name: 'n8n_evaluations',
-    description: `Run and read evaluation test runs for a workflow. Reading requires n8n >= 2.30, run/cancel require n8n >= 2.32, and the API key must be created on the matching release to carry the testRun scopes. Actions: list_runs=list runs for a workflow, get_run=single run with aggregated metrics, list_cases=per-case results (paginate - cases can be large), run=trigger a run on a workflow with an evaluation trigger, cancel=stop a running run.`,
+    description: `Run and read evaluation test runs for a workflow. Reading requires n8n >= 2.30, run/cancel require n8n >= 2.32, and the API key must be created on the matching release to carry the testRun scopes; run/cancel also need the key owner to hold workflow:execute on the workflow. Actions: list_runs=list runs for a workflow, get_run=single run with aggregated metrics, list_cases=per-case results (paginate - cases can be large), run=trigger a run on a workflow with an evaluation trigger, cancel=stop a running run.`,
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -522,14 +522,14 @@ export const n8nManagementTools: ToolDefinition[] = [
   },
   {
     name: 'n8n_evaluations',
-    description: `Read evaluation test runs for a workflow (read-only). Requires n8n >= 2.30 and an API key created on 2.30+ (testRun scopes). Actions: list_runs=list runs for a workflow, get_run=single run with aggregated metrics, list_cases=per-case results (paginate - cases can be large). Triggering runs via API is not yet supported by n8n.`,
+    description: `Run and read evaluation test runs for a workflow. Reading requires n8n >= 2.30, run/cancel require n8n >= 2.32, and the API key must be created on the matching release to carry the testRun scopes. Actions: list_runs=list runs for a workflow, get_run=single run with aggregated metrics, list_cases=per-case results (paginate - cases can be large), run=trigger a run on a workflow with an evaluation trigger, cancel=stop a running run.`,
     inputSchema: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
-          enum: ['list_runs', 'get_run', 'list_cases'],
-          description: 'Operation: list_runs=list test runs, get_run=run details with metrics, list_cases=per-case results'
+          enum: ['list_runs', 'get_run', 'list_cases', 'run', 'cancel'],
+          description: 'Operation: list_runs=list test runs, get_run=run details with metrics, list_cases=per-case results, run=trigger a run, cancel=stop a running run'
         },
         workflowId: {
           type: 'string',
@@ -537,7 +537,7 @@ export const n8nManagementTools: ToolDefinition[] = [
         },
         runId: {
           type: 'string',
-          description: 'Test run ID (required for action=get_run or action=list_cases)'
+          description: 'Test run ID (required for action=get_run, list_cases, or cancel)'
         },
         status: {
           type: 'string',
@@ -556,9 +556,9 @@ export const n8nManagementTools: ToolDefinition[] = [
       required: ['action', 'workflowId']
     },
     annotations: {
-      title: 'Read Evaluation Test Runs',
-      readOnlyHint: true,
-      destructiveHint: false,
+      title: 'Manage Evaluation Test Runs',
+      readOnlyHint: false,
+      destructiveHint: true,
       openWorldHint: true,
     },
   },
@@ -819,5 +819,6 @@ export const TOOL_OPERATION_PARAM: Record<string, string> = {
  */
 export const DESTRUCTIVE_TOOL_OPERATIONS: Record<string, Set<string>> = {
   'n8n_executions': new Set(['delete']),
+  'n8n_evaluations': new Set(['run', 'cancel']),
   'n8n_workflow_versions': new Set(['delete', 'rollback', 'prune']),
 };

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -13,6 +13,8 @@ import {
   TestCaseListParams,
   TestRunListResponse,
   TestCaseListResponse,
+  TestRunTriggerResult,
+  TestRunCancelResult,
   Credential,
   CredentialListParams,
   CredentialListResponse,
@@ -295,6 +297,26 @@ export class N8nApiClient {
    */
   getCachedVersionInfo(): N8nVersionInfo | null {
     return this.versionInfo;
+  }
+
+  /**
+   * Re-read the instance version, bypassing both the per-client and the shared
+   * TTL cache. `versionInfo` lives as long as the client, so an instance
+   * upgraded mid-session keeps reporting its old version - callers that are
+   * about to blame the version for a failure need a current reading. Returns
+   * null when the version cannot be read, leaving any cached value in place.
+   */
+  async refreshVersion(): Promise<N8nVersionInfo | null> {
+    const agents = await this.getPinnedAgents();
+    const version = await fetchN8nVersion(this.baseUrl, {
+      headers: this.cfAccessHeadersOrUndefined(),
+      pinnedAgents: agents,
+      forceRefresh: true,
+    });
+    if (version) {
+      this.versionInfo = version;
+    }
+    return version;
   }
 
   // Health check to verify API connectivity
@@ -742,7 +764,7 @@ export class N8nApiClient {
     }
   }
 
-  // Evaluation test runs (n8n >= 2.30)
+  // Evaluation test runs (reads n8n >= 2.30, trigger/cancel n8n >= 2.32)
 
   async listTestRuns(workflowId: string, params: TestRunListParams = {}): Promise<TestRunListResponse> {
     try {
@@ -778,6 +800,30 @@ export class N8nApiClient {
         { params }
       );
       return this.validateListResponse<TestCaseExecution>(response.data, 'test cases');
+    } catch (error) {
+      throw handleN8nApiError(error);
+    }
+  }
+
+  async triggerTestRun(workflowId: string): Promise<TestRunTriggerResult> {
+    try {
+      const response = await this.client.post(
+        `/workflows/${encodeApiPathSegment(workflowId, 'workflowId')}/test-runs`,
+        {}
+      );
+      return response.data;
+    } catch (error) {
+      throw handleN8nApiError(error);
+    }
+  }
+
+  async cancelTestRun(workflowId: string, runId: string): Promise<TestRunCancelResult> {
+    try {
+      const response = await this.client.post(
+        `/workflows/${encodeApiPathSegment(workflowId, 'workflowId')}/test-runs/${encodeApiPathSegment(runId, 'runId')}/cancel`,
+        {}
+      );
+      return response.data;
     } catch (error) {
       throw handleN8nApiError(error);
     }

--- a/src/services/n8n-version.ts
+++ b/src/services/n8n-version.ts
@@ -122,11 +122,12 @@ export function getSupportedSettingsProperties(version: N8nVersionInfo): Set<str
  */
 export async function fetchN8nVersion(
   baseUrl: string,
-  options?: { headers?: Record<string, string>; pinnedAgents?: PinnedAgents }
+  options?: { headers?: Record<string, string>; pinnedAgents?: PinnedAgents; forceRefresh?: boolean }
 ): Promise<N8nVersionInfo | null> {
-  const { headers, pinnedAgents } = options ?? {};
-  // Check cache first (with TTL)
-  const cached = versionCache.get(baseUrl);
+  const { headers, pinnedAgents, forceRefresh } = options ?? {};
+  // Check cache first (with TTL), unless the caller needs a current reading
+  // because it is about to blame the instance version for a failure.
+  const cached = forceRefresh ? undefined : versionCache.get(baseUrl);
   if (cached && Date.now() - cached.fetchedAt < VERSION_CACHE_TTL_MS) {
     logger.debug(`Using cached n8n version for ${baseUrl}: ${cached.info.version}`);
     return cached.info;

--- a/src/types/n8n-api.ts
+++ b/src/types/n8n-api.ts
@@ -355,6 +355,19 @@ export interface TestCaseExecution {
   executionId: string | null;
 }
 
+// Returned by the trigger/cancel routes (n8n Public API >= 2.32), which answer
+// with the run identity only - poll the get route for metrics.
+export interface TestRunTriggerResult {
+  id: string;
+  status: TestRunStatus;
+  createdAt: string;
+}
+
+export interface TestRunCancelResult {
+  id: string;
+  status: 'cancelled';
+}
+
 export interface TestRunListParams {
   status?: TestRunStatus;
   limit?: number;

--- a/tests/unit/mcp/disabled-tool-operations.test.ts
+++ b/tests/unit/mcp/disabled-tool-operations.test.ts
@@ -270,6 +270,60 @@ describe('Disabled Tool Operations Feature (Issue #714)', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // 3b. Dispatch enforcement — n8n_evaluations
+  // ---------------------------------------------------------------------------
+
+  describe('executeTool() - Dispatch Enforcement for n8n_evaluations', () => {
+    it('should block the write actions', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_evaluations:run,cancel';
+      server = new TestableN8NMCPServer();
+
+      for (const action of ['run', 'cancel']) {
+        await expect(
+          server.testExecuteTool('n8n_evaluations', { action, workflowId: 'abc', runId: 'run1' })
+        ).rejects.toThrow(`Operation '${action}' on tool 'n8n_evaluations' is disabled by server policy`);
+      }
+    });
+
+    it('should not block read actions when the write actions are disabled', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_evaluations:run,cancel';
+      server = new TestableN8NMCPServer();
+
+      for (const action of ['list_runs', 'get_run', 'list_cases']) {
+        try {
+          await server.testExecuteTool('n8n_evaluations', { action, workflowId: 'abc', runId: 'run1' });
+        } catch (error: any) {
+          expect(error.message).not.toContain('disabled by server policy');
+        }
+      }
+    });
+
+    it('should recompute annotations to read-only when run and cancel are disabled', () => {
+      const disabledOps = new Map([['n8n_evaluations', new Set(['run', 'cancel'])]]);
+      server = new TestableN8NMCPServer();
+      const cache = server.testBuildFilteredToolDefinitions(disabledOps);
+
+      const filtered = cache.get('n8n_evaluations');
+      const enumValues: string[] = filtered.inputSchema.properties.action.enum;
+      expect(enumValues).not.toContain('run');
+      expect(enumValues).not.toContain('cancel');
+      expect(enumValues).toContain('list_runs');
+      expect(filtered.annotations.readOnlyHint).toBe(true);
+      expect(filtered.annotations.destructiveHint).toBe(false);
+    });
+
+    it('should keep the tool writable when only run is disabled', () => {
+      const disabledOps = new Map([['n8n_evaluations', new Set(['run'])]]);
+      server = new TestableN8NMCPServer();
+      const cache = server.testBuildFilteredToolDefinitions(disabledOps);
+
+      const filtered = cache.get('n8n_evaluations');
+      expect(filtered.annotations.readOnlyHint).toBe(false);
+      expect(filtered.annotations.destructiveHint).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // 4. Interaction with DISABLED_TOOLS
   // ---------------------------------------------------------------------------
 

--- a/tests/unit/mcp/evaluations-action-dispatch.test.ts
+++ b/tests/unit/mcp/evaluations-action-dispatch.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock the handler module so we can detect which handler the server routes to
+// for each action of n8n_evaluations. vi.hoisted lifts the spy declarations above
+// the vi.mock call (vi.mock is itself hoisted above the import below).
+const handlerMocks = vi.hoisted(() => ({
+  handleListTestRuns: vi.fn().mockResolvedValue({ success: true, data: { action: 'list_runs' } }),
+  handleGetTestRun: vi.fn().mockResolvedValue({ success: true, data: { action: 'get_run' } }),
+  handleListTestCases: vi.fn().mockResolvedValue({ success: true, data: { action: 'list_cases' } }),
+  handleTriggerTestRun: vi.fn().mockResolvedValue({ success: true, data: { action: 'run' } }),
+  handleCancelTestRun: vi.fn().mockResolvedValue({ success: true, data: { action: 'cancel' } }),
+}));
+
+vi.mock('../../../src/mcp/handlers-n8n-manager', async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    ...handlerMocks,
+  };
+});
+
+vi.mock('../../../src/database/database-adapter');
+vi.mock('../../../src/database/node-repository');
+vi.mock('../../../src/templates/template-service');
+vi.mock('../../../src/utils/logger');
+
+import { N8NDocumentationMCPServer } from '../../../src/mcp/server';
+
+class TestableServer extends N8NDocumentationMCPServer {
+  public async testExecuteTool(name: string, args: any): Promise<any> {
+    return (this as any).executeTool(name, args);
+  }
+}
+
+describe('n8n_evaluations action dispatch', () => {
+  let server: TestableServer;
+
+  beforeEach(() => {
+    process.env.NODE_DB_PATH = ':memory:';
+    process.env.N8N_API_URL = 'https://example.invalid';
+    process.env.N8N_API_KEY = 'test-key';
+    delete process.env.DISABLED_TOOL_OPERATIONS;
+    server = new TestableServer();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.NODE_DB_PATH;
+    delete process.env.N8N_API_URL;
+    delete process.env.N8N_API_KEY;
+    delete process.env.DISABLED_TOOL_OPERATIONS;
+  });
+
+  it('routes action="run" to handleTriggerTestRun', async () => {
+    // The global afterEach (tests/setup/global-setup.ts) runs vi.restoreAllMocks(), which
+    // strips the hoisted mockResolvedValue after the first test. Re-apply it here so the
+    // returned-data assertion is order-independent.
+    handlerMocks.handleTriggerTestRun.mockResolvedValue({ success: true, data: { action: 'run' } });
+
+    const result = await server.testExecuteTool('n8n_evaluations', { action: 'run', workflowId: 'wf1' });
+
+    expect(handlerMocks.handleTriggerTestRun).toHaveBeenCalledTimes(1);
+    expect(handlerMocks.handleTriggerTestRun).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowId: 'wf1' }),
+      undefined
+    );
+    expect(handlerMocks.handleCancelTestRun).not.toHaveBeenCalled();
+    expect(handlerMocks.handleListTestRuns).not.toHaveBeenCalled();
+    expect(result.data.action).toBe('run');
+  });
+
+  it('routes action="cancel" to handleCancelTestRun', async () => {
+    handlerMocks.handleCancelTestRun.mockResolvedValue({ success: true, data: { action: 'cancel' } });
+
+    const result = await server.testExecuteTool('n8n_evaluations', {
+      action: 'cancel',
+      workflowId: 'wf1',
+      runId: 'run1',
+    });
+
+    expect(handlerMocks.handleCancelTestRun).toHaveBeenCalledTimes(1);
+    expect(handlerMocks.handleCancelTestRun).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowId: 'wf1', runId: 'run1' }),
+      undefined
+    );
+    expect(handlerMocks.handleTriggerTestRun).not.toHaveBeenCalled();
+    expect(result.data.action).toBe('cancel');
+  });
+
+  it('rejects action="cancel" without a runId before reaching the handler', async () => {
+    await expect(
+      server.testExecuteTool('n8n_evaluations', { action: 'cancel', workflowId: 'wf1' })
+    ).rejects.toThrow('runId is required for action=cancel');
+
+    expect(handlerMocks.handleCancelTestRun).not.toHaveBeenCalled();
+  });
+
+  it('does not require a runId for action="run"', async () => {
+    await server.testExecuteTool('n8n_evaluations', { action: 'run', workflowId: 'wf1' });
+
+    expect(handlerMocks.handleTriggerTestRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes the read actions to their own handlers', async () => {
+    await server.testExecuteTool('n8n_evaluations', { action: 'list_runs', workflowId: 'wf1' });
+    expect(handlerMocks.handleListTestRuns).toHaveBeenCalledTimes(1);
+
+    await server.testExecuteTool('n8n_evaluations', { action: 'get_run', workflowId: 'wf1', runId: 'run1' });
+    expect(handlerMocks.handleGetTestRun).toHaveBeenCalledTimes(1);
+
+    await server.testExecuteTool('n8n_evaluations', { action: 'list_cases', workflowId: 'wf1', runId: 'run1' });
+    expect(handlerMocks.handleListTestCases).toHaveBeenCalledTimes(1);
+
+    expect(handlerMocks.handleTriggerTestRun).not.toHaveBeenCalled();
+    expect(handlerMocks.handleCancelTestRun).not.toHaveBeenCalled();
+  });
+
+  it('lists the write actions as valid in the unknown-action error', async () => {
+    await expect(
+      server.testExecuteTool('n8n_evaluations', { action: 'nope', workflowId: 'wf1' })
+    ).rejects.toThrow('list_runs, get_run, list_cases, run, cancel');
+  });
+});

--- a/tests/unit/mcp/handlers-evaluations.test.ts
+++ b/tests/unit/mcp/handlers-evaluations.test.ts
@@ -59,8 +59,9 @@ describe('Evaluation Handlers (n8n_evaluations)', () => {
       listTestRuns: vi.fn(),
       getTestRun: vi.fn(),
       listTestCases: vi.fn(),
-      getCachedVersionInfo: vi.fn().mockReturnValue(null),
-      getVersion: vi.fn().mockResolvedValue(null),
+      triggerTestRun: vi.fn(),
+      cancelTestRun: vi.fn(),
+      refreshVersion: vi.fn().mockResolvedValue(null),
     };
 
     getN8nApiConfig = (await import('@/config/n8n-api')).getN8nApiConfig;
@@ -172,6 +173,35 @@ describe('Evaluation Handlers (n8n_evaluations)', () => {
       });
     });
 
+    it('should not mention runId in the not-found guidance, which list_runs never takes', async () => {
+      mockApiClient.refreshVersion.mockResolvedValue({
+        version: '2.30.4',
+        major: 2,
+        minor: 30,
+        patch: 4,
+      });
+      mockApiClient.listTestRuns.mockRejectedValue(new N8nApiError('Not found', 404, 'NOT_FOUND'));
+
+      const result = await handlers.handleListTestRuns({ workflowId: 'wf1' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Workflow not found');
+      expect(result.error).not.toContain('runId');
+    });
+
+    it('should not blame POST for a 405 on a read route', async () => {
+      mockApiClient.refreshVersion.mockResolvedValue(null);
+      mockApiClient.listTestRuns.mockRejectedValue(
+        new N8nApiError('Method Not Allowed', 405, 'API_ERROR')
+      );
+
+      const result = await handlers.handleListTestRuns({ workflowId: 'wf1' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).not.toContain('POST');
+      expect(result.error).toContain('could not be read');
+    });
+
     it('should pass the cursor through', async () => {
       mockApiClient.listTestRuns.mockResolvedValue({ data: [completedRun], nextCursor: null });
 
@@ -205,7 +235,7 @@ describe('Evaluation Handlers (n8n_evaluations)', () => {
     });
 
     it('should map 404 on a pre-2.30 instance to version guidance', async () => {
-      mockApiClient.getCachedVersionInfo.mockReturnValue({
+      mockApiClient.refreshVersion.mockResolvedValue({
         version: '2.29.1',
         major: 2,
         minor: 29,
@@ -216,12 +246,12 @@ describe('Evaluation Handlers (n8n_evaluations)', () => {
       const result = await handlers.handleGetTestRun({ workflowId: 'wf1', runId: 'run1' });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('2.30');
+      expect(result.error).toContain('2.30.0 or later');
       expect(result.error).toContain('2.29.1');
     });
 
     it('should map 404 on a 2.30+ instance to not-found guidance', async () => {
-      mockApiClient.getCachedVersionInfo.mockReturnValue({
+      mockApiClient.refreshVersion.mockResolvedValue({
         version: '2.30.4',
         major: 2,
         minor: 30,
@@ -233,21 +263,11 @@ describe('Evaluation Handlers (n8n_evaluations)', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('belong');
+      expect(result.error).not.toContain('could not be read');
     });
 
-    it('should map 404 with unknown instance version to not-found guidance', async () => {
-      mockApiClient.getCachedVersionInfo.mockReturnValue(null);
-      mockApiClient.getTestRun.mockRejectedValue(new N8nApiError('Not found', 404, 'NOT_FOUND'));
-
-      const result = await handlers.handleGetTestRun({ workflowId: 'wf1', runId: 'run1' });
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('belong');
-    });
-
-    it('should fetch the version on 404 when the cache is cold', async () => {
-      mockApiClient.getCachedVersionInfo.mockReturnValue(null);
-      mockApiClient.getVersion.mockResolvedValue({
+    it('should re-read the version on 404 instead of trusting the cached value', async () => {
+      mockApiClient.refreshVersion.mockResolvedValue({
         version: '2.29.1',
         major: 2,
         minor: 29,
@@ -257,20 +277,32 @@ describe('Evaluation Handlers (n8n_evaluations)', () => {
 
       const result = await handlers.handleGetTestRun({ workflowId: 'wf1', runId: 'run1' });
 
-      expect(mockApiClient.getVersion).toHaveBeenCalled();
+      expect(mockApiClient.refreshVersion).toHaveBeenCalled();
       expect(result.success).toBe(false);
-      expect(result.error).toContain('2.30');
+      expect(result.error).toContain('2.30.0 or later');
       expect(result.error).toContain('2.29.1');
     });
 
-    it('should fall back to not-found guidance when the version fetch fails', async () => {
-      mockApiClient.getCachedVersionInfo.mockReturnValue(null);
-      mockApiClient.getVersion.mockRejectedValue(new Error('network down'));
+    it('should hedge a 404 when the instance version cannot be read', async () => {
+      mockApiClient.refreshVersion.mockResolvedValue(null);
       mockApiClient.getTestRun.mockRejectedValue(new N8nApiError('Not found', 404, 'NOT_FOUND'));
 
       const result = await handlers.handleGetTestRun({ workflowId: 'wf1', runId: 'run1' });
 
       expect(result.success).toBe(false);
+      expect(result.error).toContain('could not be read');
+      expect(result.error).toContain('2.30.0 or later');
+      expect(result.error).toContain('belong');
+    });
+
+    it('should hedge a 404 when the version refresh throws', async () => {
+      mockApiClient.refreshVersion.mockRejectedValue(new Error('network down'));
+      mockApiClient.getTestRun.mockRejectedValue(new N8nApiError('Not found', 404, 'NOT_FOUND'));
+
+      const result = await handlers.handleGetTestRun({ workflowId: 'wf1', runId: 'run1' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('could not be read');
       expect(result.error).toContain('belong');
     });
 
@@ -334,6 +366,246 @@ describe('Evaluation Handlers (n8n_evaluations)', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('testRun scopes');
+    });
+  });
+
+  describe('handleTriggerTestRun', () => {
+    const triggeredRun = { id: 'run9', status: 'new', createdAt: '2026-07-27T10:00:00.000Z' };
+
+    it('should return the triggered run with a polling note', async () => {
+      mockApiClient.triggerTestRun.mockResolvedValue(triggeredRun);
+
+      const result = await handlers.handleTriggerTestRun({ workflowId: 'wf1' });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject(triggeredRun);
+      expect(result.data._note).toContain('get_run');
+      expect(result.data._note).toContain('run9');
+      expect(mockApiClient.triggerTestRun).toHaveBeenCalledWith('wf1');
+    });
+
+    it('should reject a missing workflowId', async () => {
+      const result = await handlers.handleTriggerTestRun({});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid input');
+      expect(mockApiClient.triggerTestRun).not.toHaveBeenCalled();
+    });
+
+    it('should map 402 to evaluation quota guidance', async () => {
+      mockApiClient.triggerTestRun.mockRejectedValue(
+        new N8nApiError('Evaluation quota exceeded', 402, 'API_ERROR')
+      );
+
+      const result = await handlers.handleTriggerTestRun({ workflowId: 'wf1' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('quota');
+      expect(result.error).toContain('plan');
+    });
+
+    it('should map 409 to missing evaluation trigger guidance', async () => {
+      mockApiClient.triggerTestRun.mockRejectedValue(
+        new N8nApiError('Workflow has no evaluation trigger', 409, 'API_ERROR')
+      );
+
+      const result = await handlers.handleTriggerTestRun({ workflowId: 'wf1' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('evaluation trigger');
+    });
+
+    it('should map 403 to testRun:create scope guidance', async () => {
+      mockApiClient.triggerTestRun.mockRejectedValue(new N8nApiError('Forbidden', 403, 'FORBIDDEN'));
+
+      const result = await handlers.handleTriggerTestRun({ workflowId: 'wf1' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('testRun:create');
+      expect(result.error).toContain('2.32');
+    });
+
+    it('should reject a whitespace-only workflowId', async () => {
+      const result = await handlers.handleTriggerTestRun({ workflowId: '   ' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid input');
+      expect(mockApiClient.triggerTestRun).not.toHaveBeenCalled();
+    });
+
+    it('should map 405 on a pre-2.32 instance to version guidance', async () => {
+      mockApiClient.refreshVersion.mockResolvedValue({
+        version: '2.31.3',
+        major: 2,
+        minor: 31,
+        patch: 3,
+      });
+      mockApiClient.triggerTestRun.mockRejectedValue(
+        new N8nApiError('Method Not Allowed', 405, 'API_ERROR')
+      );
+
+      const result = await handlers.handleTriggerTestRun({ workflowId: 'wf1' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('2.32.0 or later');
+      expect(result.error).toContain('2.31.3');
+    });
+
+    it('should still point at the upgrade on a 405 when the version cannot be read', async () => {
+      mockApiClient.refreshVersion.mockResolvedValue(null);
+      mockApiClient.triggerTestRun.mockRejectedValue(
+        new N8nApiError('Method Not Allowed', 405, 'API_ERROR')
+      );
+
+      const result = await handlers.handleTriggerTestRun({ workflowId: 'wf1' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('2.32.0 or later');
+      expect(result.error).toContain('could not be read');
+      expect(result.error).toContain('Upgrade the instance');
+    });
+
+    it('should not claim a version problem when the instance is 2.32+', async () => {
+      mockApiClient.refreshVersion.mockResolvedValue({
+        version: '2.32.0',
+        major: 2,
+        minor: 32,
+        patch: 0,
+      });
+      mockApiClient.triggerTestRun.mockRejectedValue(new N8nApiError('Not found', 404, 'NOT_FOUND'));
+
+      const result = await handlers.handleTriggerTestRun({ workflowId: 'wf1' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Workflow not found');
+      expect(result.error).not.toContain('2.32');
+    });
+
+    it('should not mention runId in the not-found guidance, which run never takes', async () => {
+      mockApiClient.refreshVersion.mockResolvedValue({
+        version: '2.32.0',
+        major: 2,
+        minor: 32,
+        patch: 0,
+      });
+      mockApiClient.triggerTestRun.mockRejectedValue(new N8nApiError('Not found', 404, 'NOT_FOUND'));
+
+      const result = await handlers.handleTriggerTestRun({ workflowId: 'wf1' });
+
+      expect(result.error).not.toContain('runId');
+      expect(result.error).toContain('workflowId');
+    });
+  });
+
+  describe('handleCancelTestRun', () => {
+    it('should return the cancelled run with a confirmation note', async () => {
+      mockApiClient.cancelTestRun.mockResolvedValue({ id: 'run9', status: 'cancelled' });
+
+      const result = await handlers.handleCancelTestRun({ workflowId: 'wf1', runId: 'run9' });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ id: 'run9', status: 'cancelled' });
+      expect(result.data._note).toContain('get_run');
+      expect(mockApiClient.cancelTestRun).toHaveBeenCalledWith('wf1', 'run9');
+    });
+
+    it('should reject a missing runId', async () => {
+      const result = await handlers.handleCancelTestRun({ workflowId: 'wf1' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid input');
+      expect(mockApiClient.cancelTestRun).not.toHaveBeenCalled();
+    });
+
+    it('should map 409 to already-finished guidance', async () => {
+      mockApiClient.cancelTestRun.mockRejectedValue(
+        new N8nApiError('The test run "run9" cannot be cancelled', 409, 'API_ERROR')
+      );
+
+      const result = await handlers.handleCancelTestRun({ workflowId: 'wf1', runId: 'run9' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('already finished');
+    });
+
+    it('should map 403 to testRun:cancel scope guidance', async () => {
+      mockApiClient.cancelTestRun.mockRejectedValue(new N8nApiError('Forbidden', 403, 'FORBIDDEN'));
+
+      const result = await handlers.handleCancelTestRun({ workflowId: 'wf1', runId: 'run9' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('testRun:cancel');
+    });
+
+    it('should reject a whitespace-only runId', async () => {
+      const result = await handlers.handleCancelTestRun({ workflowId: 'wf1', runId: '  ' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid input');
+      expect(mockApiClient.cancelTestRun).not.toHaveBeenCalled();
+    });
+
+    it('should map 404 on a pre-2.32 instance to version guidance', async () => {
+      mockApiClient.refreshVersion.mockResolvedValue({
+        version: '2.31.3',
+        major: 2,
+        minor: 31,
+        patch: 3,
+      });
+      mockApiClient.cancelTestRun.mockRejectedValue(new N8nApiError('Not found', 404, 'NOT_FOUND'));
+
+      const result = await handlers.handleCancelTestRun({ workflowId: 'wf1', runId: 'run9' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('2.32.0 or later');
+      expect(result.error).toContain('2.31.3');
+    });
+
+    it('should map 404 on a 2.32+ instance to not-found guidance', async () => {
+      mockApiClient.refreshVersion.mockResolvedValue({
+        version: '2.32.1',
+        major: 2,
+        minor: 32,
+        patch: 1,
+      });
+      mockApiClient.cancelTestRun.mockRejectedValue(new N8nApiError('Not found', 404, 'NOT_FOUND'));
+
+      const result = await handlers.handleCancelTestRun({ workflowId: 'wf1', runId: 'run9' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('belong');
+      expect(result.error).not.toContain('could not be read');
+    });
+
+    it('should offer both causes on a 404 when the version cannot be read', async () => {
+      mockApiClient.refreshVersion.mockResolvedValue(null);
+      mockApiClient.cancelTestRun.mockRejectedValue(new N8nApiError('Not found', 404, 'NOT_FOUND'));
+
+      const result = await handlers.handleCancelTestRun({ workflowId: 'wf1', runId: 'run9' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('2.32.0 or later');
+      expect(result.error).toContain('could not be read');
+      expect(result.error).toContain('belong');
+    });
+
+    it('should not report an upgrade when a stale cache predates a live upgrade', async () => {
+      // The client cached 2.31 before the instance was upgraded; the refresh sees
+      // 2.32, so a genuine bad-id 404 must not be blamed on the version.
+      mockApiClient.refreshVersion.mockResolvedValue({
+        version: '2.32.0',
+        major: 2,
+        minor: 32,
+        patch: 0,
+      });
+      mockApiClient.cancelTestRun.mockRejectedValue(new N8nApiError('Not found', 404, 'NOT_FOUND'));
+
+      const result = await handlers.handleCancelTestRun({ workflowId: 'wf1', runId: 'run9' });
+
+      expect(mockApiClient.refreshVersion).toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('belong');
+      expect(result.error).not.toContain('Upgrade the instance');
     });
   });
 });

--- a/tests/unit/services/n8n-api-client.test.ts
+++ b/tests/unit/services/n8n-api-client.test.ts
@@ -1480,6 +1480,45 @@ badRequest('request/body/nodeGroups/0 must NOT have additional properties')
 
       await expect(client.listTestRuns('wf1')).rejects.toThrow(N8nApiError);
     });
+
+    it('should trigger a test run', async () => {
+      const triggered = { id: 'run1', status: 'new', createdAt: '2026-07-27T10:00:00.000Z' };
+      mockAxiosInstance.post.mockResolvedValue({ data: triggered });
+
+      const result = await client.triggerTestRun('wf1');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/workflows/wf1/test-runs', {});
+      expect(result).toEqual(triggered);
+    });
+
+    it('should reject hostile workflow ids before triggering a run', async () => {
+      await expect(client.triggerTestRun('a/../b')).rejects.toThrow();
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+    });
+
+    it('should cancel a test run', async () => {
+      const cancelled = { id: 'run1', status: 'cancelled' };
+      mockAxiosInstance.post.mockResolvedValue({ data: cancelled });
+
+      const result = await client.cancelTestRun('wf1', 'run1');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/workflows/wf1/test-runs/run1/cancel', {});
+      expect(result).toEqual(cancelled);
+    });
+
+    it('should reject hostile run ids before cancelling', async () => {
+      await expect(client.cancelTestRun('wf1', '../../executions')).rejects.toThrow();
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+    });
+
+    it('should throw N8nApiError when triggering a run fails', async () => {
+      await mockAxiosInstance.simulateError('post', {
+        message: 'Payment Required',
+        response: { status: 402, data: { message: 'Evaluation quota exceeded' } },
+      });
+
+      await expect(client.triggerTestRun('wf1')).rejects.toThrow(N8nApiError);
+    });
   });
 
   describe('triggerWebhook', () => {


### PR DESCRIPTION
Closes #936.

## What

n8n 2.32.0 shipped the Public API endpoints this issue was waiting on (n8n-io/n8n#33979): `POST /workflows/{id}/test-runs` (201) and `POST /workflows/{id}/test-runs/{runId}/cancel` (202), behind the new `testRun:create` / `testRun:cancel` API-key scopes. `n8n_evaluations` gains `run` and `cancel` actions beside the three existing reads.

## Behavior

- **Error mapping** follows what n8n actually distinguishes: 402 = evaluation quota exhausted; 403 = key missing the scope *or* unlicensed instance; 409 on `run` = workflow has no evaluation trigger node, on `cancel` = run already finished. Each returns guidance naming the fix.
- **Version gating**: a pre-2.32 instance answers `run` with 405 (the route exists with GET only — `express-openapi-validator` throws MethodNotAllowed) and `cancel` with 404. The gate treats both as route probes and re-reads the instance version (bypassing the client's never-expiring cached reading and the shared TTL cache), so a connection that outlives a live n8n upgrade cannot misreport a genuine bad-id 404 as "upgrade required", nor the reverse. With an unreadable version, messages hedge instead of asserting.
- **Safety surface**: the tool drops `readOnlyHint: true` / gains `destructiveHint`, `run`/`cancel` register in `DESTRUCTIVE_TOOL_OPERATIONS`, and the read-only deployment recipe in README, `docs/HTTP_DEPLOYMENT.md`, and `.env.example` now blocks `n8n_evaluations:run,cancel` explicitly ("Three tools bundle read and write operations").
- All five evaluation id params validate as trimmed non-empty strings; `cancel` requires `runId` at both the zod and dispatch layers.

## Testing

- 28 new unit tests (red-first), including: happy-path run/cancel, each error status, version-gate above/below/unreadable, the live-upgrade cache-staleness case, whitespace-id rejection, and a new dispatch-path file that fails if the `run`/`cancel` case bodies are swapped or the runId guard is removed.
- Full unit suite: 161 files, 5471 passed / 35 skipped. `npm run typecheck` clean.
- Endpoint paths, response shapes (201 body has no `workflowId`), scopes, and the 405 behavior were verified against the upstream source at tag `n8n@2.32.0`, not the PR prose.

## Release-channel status (as of 2026-07-28)

The 2.32.x line is currently **beta/`next` only** (2.32.0 tagged 2026-07-21 with `prerelease: true`; 2.32.5 is the newest beta). The newest **stable** n8n is 2.31.7 — verified against GitHub `releases/latest` and npm dist-tags. The version gate in this PR means stable-channel instances get a clear "requires 2.32.0+" message (live-confirmed: a 2.31.7 instance answers `run` with 405 and the gate maps it correctly) until n8n promotes 2.32 to stable on its weekly cadence.

## Not in this PR (follow-ups)

- Live smoke test against a 2.32+ instance (trigger → poll → cancel) before release — the 405/response-shape claims come from upstream source reading.
- Skills pack sync: four `data/skills/` locations still describe `n8n_evaluations` as read-only / 2.30-only; the pack syncs in its own PR per the established flow.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)
