### PR TITLE
fix: bracket-index path updates and fabricated community node types (#950, #949)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.66.3] - 2026-07-28
+
+### Fixed
+
+- **`updateNode` bracket-index paths update the array element instead of writing a junk key (#950).** Property paths split only on dots, so an update keyed `parameters.assignments.assignments[0].value` wrote a literal `"assignments[0]"` property onto the array, reported success, and left the real element untouched. A shared tokenizer now resolves bracket segments as array indices (digits only) for both `updateNode` and `patchNodeField`, and rejects the forms that used to corrupt silently: malformed or out-of-range brackets, empty segments (`a..b`), and non-index segments on arrays for writes — `parameters.arr.length: 0` previously truncated the array. An `updates` object applies to a draft that is swapped in only on success, so a failing key no longer leaves a half-updated node behind under `continueOnError`; removal by index splices instead of leaving a JSON `null` hole; and batched removals on the same array apply highest index first, so removing `[0]` and `[1]` from `[A,B,C]` removes A and B rather than A and C.
+- **`search_nodes` no longer fabricates node types for npm-sourced community nodes (#949).** The npm fallback derived the type suffix from the package name — `n8n-nodes-globals` became `n8n-nodes-globals.globals`, but the package's only node is `globalConstants` — so a workflow built from the search result failed to import. The suffix now comes from the package's own `n8n.nodes` manifest entry (first parseable file, a leading acronym lowercased as a unit, the old heuristic kept as a logged fallback), and the sync self-heals: a package whose stored type no longer matches is re-keyed in place, dropping the stale row and carrying its README and AI summary over — including under `--update`, which previously skipped such packages outright. The bundled database is repaired in this release: 45 fabricated types re-keyed (`…globals` → `…globalConstants`, `…deepseekchatmodel` → `…lmChatDeepSeek`, `…telegramgrampro` → `…telegramMtproto`), 1,460 community nodes total. The filename-derived name remains a heuristic — ground truth is the node's `description.name`, which only tarball parsing could read — so isolated mismatches stay possible for unverified packages.
+
 ## [2.66.2] - 2026-07-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.66.2",
+  "version": "2.66.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.66.2",
+      "version": "2.66.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.66.2",
+  "version": "2.66.3",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/community/community-node-fetcher.ts
+++ b/src/community/community-node-fetcher.ts
@@ -365,8 +365,15 @@ export class CommunityNodeFetcher {
   /**
    * Fetch package.json for a specific npm package to get the n8n node configuration.
    * Validates package name to prevent path traversal attacks.
+   *
+   * Callers that can proceed without the manifest may pass a smaller retry
+   * budget or timeout so one slow package does not hold up a bulk sync.
    */
-  async fetchPackageJson(packageName: string, version?: string): Promise<any | null> {
+  async fetchPackageJson(
+    packageName: string,
+    version?: string,
+    options?: { maxRetries?: number; timeout?: number }
+  ): Promise<any | null> {
     // Validate package name to prevent path traversal
     if (!this.validatePackageName(packageName)) {
       logger.warn(`Invalid package name rejected: ${packageName}`);
@@ -379,10 +386,13 @@ export class CommunityNodeFetcher {
 
     return this.retryWithBackoff(
       async () => {
-        const response = await axios.get(url, { timeout: FETCH_CONFIG.NPM_REGISTRY_TIMEOUT });
+        const response = await axios.get(url, {
+          timeout: options?.timeout ?? FETCH_CONFIG.NPM_REGISTRY_TIMEOUT
+        });
         return response.data;
       },
-      `Fetching package.json for ${packageName}${version ? `@${version}` : ''}`
+      `Fetching package.json for ${packageName}${version ? `@${version}` : ''}`,
+      options?.maxRetries ?? this.maxRetries
     );
   }
 

--- a/src/community/community-node-service.ts
+++ b/src/community/community-node-service.ts
@@ -42,6 +42,37 @@ export interface SyncOptions {
 }
 
 /**
+ * package.json lookups during the npm sync are best-effort: one attempt with a
+ * short timeout. A miss falls back to the package-name heuristic, so a slow
+ * registry must not stretch a sync of hundreds of packages by hours.
+ */
+const NPM_MANIFEST_FETCH = { maxRetries: 1, timeout: 5000 } as const;
+
+/**
+ * Derive a node name from an n8n node entry point declared in package.json.
+ * e.g., "dist/nodes/GlobalConstants/GlobalConstants.node.js" -> "globalConstants"
+ * Returns undefined when the entry is not a node file.
+ */
+function extractNodeNameFromEntryPath(entryPath: string): string | undefined {
+  const match = /([^\\/]+)\.node\.(?:js|ts)$/.exec(entryPath);
+  if (!match) {
+    return undefined;
+  }
+
+  const className = match[1];
+
+  // A leading acronym is lowercased as a unit: PDFGeneration publishes as
+  // pdfGeneration, while plain PascalCase keeps the single-letter form
+  // (GlobalConstants -> globalConstants).
+  const acronym = /^[A-Z]+(?=[A-Z][a-z])/.exec(className);
+  if (acronym) {
+    return acronym[0].toLowerCase() + className.slice(acronym[0].length);
+  }
+
+  return className.charAt(0).toLowerCase() + className.slice(1);
+}
+
+/**
  * Service for syncing community nodes from n8n Strapi API and npm registry.
  *
  * Key insight: Verified nodes from Strapi include full `nodeDescription` schemas,
@@ -201,18 +232,28 @@ export class CommunityNodeService {
           continue;
         }
 
-        // Skip if already exists and skipExisting is true
-        if (skipExisting && this.repository.hasNodeByNpmPackage(packageName)) {
+        const existing = this.repository.getNodeByNpmPackage(packageName);
+
+        // For npm packages, we create a basic node entry with metadata
+        // Full schema extraction would require downloading and parsing the tarball
+        const parsedNode = await this.npmPackageToParsedNode(pkg);
+        const staleRow = this.staleCommunityRow(existing, parsedNode.nodeType);
+
+        // Skip if already exists and skipExisting is true. A row keyed by an
+        // outdated node type is the one case that must not be skipped — only a
+        // re-key corrects it.
+        if (skipExisting && existing && !staleRow) {
           result.skipped++;
           continue;
         }
 
-        // For npm packages, we create a basic node entry with metadata
-        // Full schema extraction would require downloading and parsing the tarball
-        const parsedNode = this.npmPackageToParsedNode(pkg);
-
         // Save to database
         this.repository.saveNode(parsedNode);
+
+        if (staleRow) {
+          this.replaceStaleCommunityRow(packageName, staleRow, parsedNode.nodeType);
+        }
+
         result.saved++;
 
         if (progressCallback) {
@@ -308,11 +349,12 @@ export class CommunityNodeService {
    * Convert npm package info to basic ParsedNode.
    * Note: This is a minimal entry - full schema requires tarball parsing.
    */
-  private npmPackageToParsedNode(pkg: NpmSearchResult): ParsedNode & CommunityNodeFields {
+  private async npmPackageToParsedNode(
+    pkg: NpmSearchResult
+  ): Promise<ParsedNode & CommunityNodeFields> {
     const { package: pkgInfo, score } = pkg;
 
-    // Extract node name from package name (e.g., n8n-nodes-globals -> GlobalConstants)
-    const nodeName = this.extractNodeNameFromPackage(pkgInfo.name);
+    const nodeName = await this.resolveNpmNodeName(pkgInfo.name, pkgInfo.version);
     const nodeType = `${pkgInfo.name}.${nodeName}`;
 
     return {
@@ -373,6 +415,78 @@ export class CommunityNodeService {
   }
 
   /**
+   * A stored row is stale when this sync resolves a different node type for the
+   * same npm package, which happens for packages saved under the fabricated
+   * package-name type (#949). Verified rows carry the real node name from
+   * Strapi and are never re-keyed.
+   */
+  private staleCommunityRow(existing: any, nodeType: string): any | undefined {
+    if (!existing || !existing.isCommunity || existing.isVerified) {
+      return undefined;
+    }
+    return existing.nodeType && existing.nodeType !== nodeType ? existing : undefined;
+  }
+
+  /**
+   * Drop the rows this package no longer resolves to and carry the generated
+   * documentation over to the new row, which saveNode could not preserve
+   * because preservation is keyed by node type.
+   */
+  private replaceStaleCommunityRow(packageName: string, staleRow: any, nodeType: string): void {
+    const removed = this.repository.deleteStaleCommunityNodes(packageName, nodeType);
+    logger.info(
+      `Re-keyed ${packageName}: "${staleRow.nodeType}" -> "${nodeType}" (${removed} outdated row(s) removed)`
+    );
+
+    if (staleRow.npmReadme) {
+      this.repository.updateNodeReadme(nodeType, staleRow.npmReadme);
+    }
+    if (staleRow.aiDocumentationSummary) {
+      this.repository.updateNodeAISummary(nodeType, staleRow.aiDocumentationSummary);
+    }
+  }
+
+  /**
+   * Resolve the node name for an npm-only package.
+   *
+   * The package.json `n8n.nodes` array lists the package's node entry points
+   * (e.g. "dist/nodes/GlobalConstants/GlobalConstants.node.js"), which carry the
+   * real node name. Deriving it from the package name instead fabricated node
+   * types that do not exist in n8n (#949).
+   *
+   * Only the first entry is used: the npm path stores one row per package.
+   */
+  private async resolveNpmNodeName(packageName: string, version?: string): Promise<string> {
+    let entries: unknown[] = [];
+
+    try {
+      const packageJson = await this.fetcher.fetchPackageJson(
+        packageName,
+        version,
+        NPM_MANIFEST_FETCH
+      );
+      if (Array.isArray(packageJson?.n8n?.nodes)) {
+        entries = packageJson.n8n.nodes;
+      }
+    } catch (error: any) {
+      logger.warn(`Could not fetch package.json for ${packageName}: ${error.message}`);
+    }
+
+    for (const entry of entries) {
+      const nodeName = typeof entry === 'string' ? extractNodeNameFromEntryPath(entry) : undefined;
+      if (nodeName) {
+        return nodeName;
+      }
+    }
+
+    const fallback = this.extractNodeNameFromPackage(packageName);
+    logger.warn(
+      `No usable n8n.nodes entry for ${packageName}, falling back to the package-name heuristic: "${fallback}"`
+    );
+    return fallback;
+  }
+
+  /**
    * Extract node name from npm package name.
    * n8n community nodes typically use lowercase node class names.
    * e.g., "n8n-nodes-chatwoot" -> "chatwoot"
@@ -380,6 +494,7 @@ export class CommunityNodeService {
    *
    * Note: We use lowercase because most community nodes follow this convention.
    * Verified nodes from Strapi have the correct casing in nodeDesc.name.
+   * Only a fallback — see resolveNpmNodeName.
    */
   private extractNodeNameFromPackage(packageName: string): string {
     // Remove scope if present

--- a/src/database/node-repository.ts
+++ b/src/database/node-repository.ts
@@ -702,6 +702,20 @@ export class NodeRepository {
   }
 
   /**
+   * Delete unverified community rows for an npm package that are keyed by a
+   * node type other than the given one. Rows are keyed by node_type, so a sync
+   * that resolves a corrected node type for a package would otherwise insert a
+   * second row and leave the outdated one in search results (#949).
+   */
+  deleteStaleCommunityNodes(npmPackageName: string, keepNodeType: string): number {
+    const result = this.db.prepare(`
+      DELETE FROM nodes
+      WHERE npm_package_name = ? AND node_type != ? AND is_community = 1 AND is_verified = 0
+    `).run(npmPackageName, keepNodeType);
+    return result.changes;
+  }
+
+  /**
    * Delete all community nodes (for rebuild)
    */
   deleteCommunityNodes(): number {

--- a/src/mcp/tool-docs/workflow_management/n8n-update-partial-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-update-partial-workflow.ts
@@ -260,6 +260,21 @@ n8n_update_partial_workflow({
     updates: { "parameters.headers": null }
   }]
 });
+
+// Remove single array elements: the array is spliced, so later elements shift
+// down. Several removals on the same array in one updates object are applied
+// from the highest index down, so the indices you pass are the ones you see.
+n8n_update_partial_workflow({
+  id: "wf_345",
+  operations: [{
+    type: "updateNode",
+    nodeName: "Edit Fields",
+    updates: {
+      "parameters.assignments.assignments[0]": null,
+      "parameters.assignments.assignments[1]": null
+    }
+  }]
+});
 \`\`\`
 
 ### Migrating from Deprecated Properties
@@ -445,7 +460,7 @@ n8n_update_partial_workflow({
       'When properties are mutually exclusive (e.g., continueOnFail and onError), setting only the new property will fail - you must remove the old one with null',
       'Removing a required property may cause validation errors - check node documentation first',
       'Nested property removal with dot notation only removes the specific nested field, not the entire parent object',
-      'Array index notation (e.g., "parameters.headers[0]") is not supported - remove the entire array property instead'
+      'Array elements are addressed by index in bracket or dot form (e.g., "parameters.assignments.assignments[0].value" or "parameters.assignments.assignments.0.value") - out-of-range indices are rejected, so new elements cannot be appended this way'
     ],
     relatedTools: ['n8n_update_full_workflow', 'n8n_get_workflow', 'validate_workflow', 'tools_documentation']
   }

--- a/src/services/workflow-diff-engine.ts
+++ b/src/services/workflow-diff-engine.ts
@@ -81,6 +81,97 @@ function isUnsafeRegex(pattern: string): boolean {
   return false;
 }
 
+interface PathSegment {
+  key: string;
+  /** Segment came from bracket syntax (`items[0]`), which only an array can satisfy. */
+  bracket: boolean;
+}
+
+/**
+ * Split a property path into segments, understanding dot notation and bracket
+ * indices: "assignments[0].value" → ["assignments", "0", "value"].
+ *
+ * Bracket indices must be non-negative integers. Anything else is malformed and
+ * throws — treating "assignments[0]" as a literal key silently wrote a junk
+ * sibling property instead of updating the array element (#950).
+ */
+function parsePropertyPath(path: string): PathSegment[] {
+  const segments: PathSegment[] = [];
+
+  for (const part of path.split('.')) {
+    if (!part.includes('[') && !part.includes(']')) {
+      if (part === '') {
+        throw new Error(
+          `Invalid property path "${path}": empty path segment. ` +
+          `Write "parameters.url" without leading, trailing or repeated dots.`
+        );
+      }
+      segments.push({ key: part, bracket: false });
+      continue;
+    }
+
+    const match = /^([^[\]]*)((?:\[\d+\])+)$/.exec(part);
+    if (!match) {
+      throw new Error(
+        `Invalid property path "${path}": malformed bracket index in "${part}". ` +
+        `Use "items[0].name" with a non-negative integer, or the equivalent "items.0.name".`
+      );
+    }
+
+    const [, base, indices] = match;
+    if (base) segments.push({ key: base, bracket: false });
+    for (const [, index] of indices.matchAll(/\[(\d+)\]/g)) {
+      segments.push({ key: index, bracket: true });
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Resolve a path segment against its container, returning the key to read or
+ * write. Numeric segments address array elements by index; a bracket segment
+ * that does not land on an array is a caller mistake, not a new property.
+ *
+ * Writes additionally refuse non-index segments on arrays: keys like "-1" or
+ * "length" would either be dropped on serialization or truncate the array,
+ * which is the same silent corruption bracket parsing fixes (#950). Reads stay
+ * permissive so an unresolvable path simply reads as undefined.
+ */
+function resolveSegment(
+  container: any,
+  segment: PathSegment,
+  path: string,
+  forWrite: boolean
+): string | number {
+  if (Array.isArray(container)) {
+    if (/^\d+$/.test(segment.key)) {
+      const index = Number(segment.key);
+      if (index >= container.length) {
+        throw new Error(
+          `Invalid property path "${path}": index ${index} is out of range for an array of ${container.length} item(s).`
+        );
+      }
+      return index;
+    }
+
+    if (forWrite) {
+      throw new Error(
+        `Invalid property path "${path}": "${segment.key}" is not an array index. ` +
+        `Address array elements by position, e.g. "items[0].name".`
+      );
+    }
+  }
+
+  if (segment.bracket) {
+    throw new Error(
+      `Invalid property path "${path}": "[${segment.key}]" expects an array but found ${container === null ? 'null' : typeof container}.`
+    );
+  }
+
+  return segment.key;
+}
+
 function countOccurrences(str: string, search: string): number {
   let count = 0;
   let pos = 0;
@@ -565,8 +656,14 @@ export class WorkflowDiffEngine {
       }
     }
 
-    // Validate __patch_find_replace syntax (#642)
     for (const [path, value] of Object.entries(operation.updates)) {
+      try {
+        parsePropertyPath(path);
+      } catch (error) {
+        return error instanceof Error ? error.message : `Invalid property path "${path}"`;
+      }
+
+      // Validate __patch_find_replace syntax (#642)
       if (value !== null && typeof value === 'object' && !Array.isArray(value)
           && '__patch_find_replace' in value) {
         const patches = value.__patch_find_replace;
@@ -602,16 +699,25 @@ export class WorkflowDiffEngine {
       return `patchNodeField requires a "fieldPath" string (e.g., "parameters.jsCode")`;
     }
 
+    let pathSegments: PathSegment[];
+    try {
+      pathSegments = parsePropertyPath(operation.fieldPath);
+    } catch (error) {
+      const reason = error instanceof Error
+        ? error.message
+        : `invalid fieldPath "${operation.fieldPath}"`;
+      return `patchNodeField: ${reason}`;
+    }
+
     // Prototype pollution protection
-    const pathSegments = operation.fieldPath.split('.');
-    if (pathSegments.some(k => DANGEROUS_PATH_KEYS.has(k))) {
+    if (pathSegments.some(s => DANGEROUS_PATH_KEYS.has(s.key))) {
       return `patchNodeField: fieldPath "${operation.fieldPath}" contains a forbidden key (__proto__, constructor, or prototype)`;
     }
 
     // Same reason updateNode refuses it: canvas groups and pinned data reference the node id, so
     // rewriting it here would orphan them. Only the node's OWN id is protected — a nested id such
     // as `parameters.assignments.assignments[0].id` is ordinary node data.
-    if (pathSegments[0] === 'id') {
+    if (pathSegments[0].key === 'id') {
       return `Cannot patch the id of a node: node IDs are immutable because canvas groups and pinned data reference them. Remove and re-add the node instead.`;
     }
 
@@ -950,14 +1056,20 @@ export class WorkflowDiffEngine {
       ? { oldName: node.name, newName: operation.updates.name }
       : undefined;
 
+    // Apply updates to a draft: a path that throws halfway through the object
+    // (e.g. after auto-creating an intermediate) would otherwise leave the node
+    // half-updated, and in continueOnError mode a later operation would persist
+    // that state. The draft is swapped in only once every update succeeded.
+    const draft: WorkflowNode = JSON.parse(JSON.stringify(node));
+
     // Apply updates using dot notation
-    Object.entries(operation.updates).forEach(([path, value]) => {
+    this.orderUpdateEntries(operation.updates).forEach(([path, value]) => {
       // Handle __patch_find_replace for surgical string edits (#642)
       // Format and type validation already passed in validateUpdateNode()
       if (value !== null && typeof value === 'object' && !Array.isArray(value)
           && '__patch_find_replace' in value) {
         const patches = value.__patch_find_replace as Array<{ find: string; replace: string }>;
-        let current = this.getNestedProperty(node, path) as string;
+        let current = this.getNestedProperty(draft, path) as string;
         for (const patch of patches) {
           if (!current.includes(patch.find)) {
             this.warnings.push({
@@ -968,16 +1080,21 @@ export class WorkflowDiffEngine {
           }
           current = current.replace(patch.find, patch.replace);
         }
-        this.setNestedProperty(node, path, current);
+        this.setNestedProperty(draft, path, current);
       } else {
-        this.setNestedProperty(node, path, value);
+        this.setNestedProperty(draft, path, value);
       }
     });
 
-    // Sanitize node after updates to ensure metadata is complete
-    const sanitized = sanitizeNode(node);
-
-    // Update the node in-place
+    // Sanitize the draft after updates to ensure metadata is complete, then swap
+    // it in without replacing the node object itself — the workflow arrays and
+    // the rename bookkeeping hold this reference.
+    const sanitized = sanitizeNode(draft);
+    for (const key of Object.keys(node)) {
+      if (!Object.prototype.hasOwnProperty.call(sanitized, key)) {
+        delete (node as any)[key];
+      }
+    }
     Object.assign(node, sanitized);
 
     // Commit the rename only after updates+sanitization succeeded and the
@@ -987,6 +1104,41 @@ export class WorkflowDiffEngine {
       this.renameMap.set(pendingRename.oldName, pendingRename.newName);
       logger.debug(`Tracking rename: "${pendingRename.oldName}" → "${pendingRename.newName}"`);
     }
+  }
+
+  /**
+   * Order the updates of one operation so that removals of elements of the same
+   * array run from the highest index down. Splicing "items[0]" before "items[1]"
+   * would shift the array under the second removal and drop the wrong element.
+   * Every other entry keeps its position.
+   */
+  private orderUpdateEntries(updates: Record<string, any>): Array<[string, any]> {
+    const entries = Object.entries(updates);
+    const removalsByParent = new Map<string, Array<{ position: number; index: number }>>();
+
+    entries.forEach(([path, value], position) => {
+      if (value !== null && value !== undefined) return;
+
+      const segments = parsePropertyPath(path);
+      const lastSegment = segments[segments.length - 1];
+      if (!/^\d+$/.test(lastSegment.key)) return;
+
+      const parent = segments.slice(0, -1).map(s => s.key).join('.');
+      const removals = removalsByParent.get(parent) ?? [];
+      removals.push({ position, index: Number(lastSegment.key) });
+      removalsByParent.set(parent, removals);
+    });
+
+    const ordered = [...entries];
+    for (const removals of removalsByParent.values()) {
+      if (removals.length < 2) continue;
+      const descending = [...removals].sort((a, b) => b.index - a.index);
+      removals.forEach(({ position }, i) => {
+        ordered[position] = entries[descending[i].position];
+      });
+    }
+
+    return ordered;
   }
 
   private applyPatchNodeField(workflow: Workflow, operation: PatchNodeFieldOperation): void {
@@ -1839,31 +1991,36 @@ export class WorkflowDiffEngine {
   }
 
   private getNestedProperty(obj: any, path: string): any {
-    const keys = path.split('.');
     let current = obj;
-    for (const key of keys) {
-      if (DANGEROUS_PATH_KEYS.has(key)) return undefined;
-      if (current == null || typeof current !== 'object') return undefined;
-      current = current[key];
+    try {
+      for (const segment of parsePropertyPath(path)) {
+        if (DANGEROUS_PATH_KEYS.has(segment.key)) return undefined;
+        if (current == null || typeof current !== 'object') return undefined;
+        const key = resolveSegment(current, segment, path, false);
+        current = current[key];
+      }
+    } catch {
+      // Malformed or unsatisfiable path — the property does not exist.
+      return undefined;
     }
     return current;
   }
 
   private setNestedProperty(obj: any, path: string, value: any): void {
-    const keys = path.split('.');
+    const segments = parsePropertyPath(path);
     let current = obj;
 
     // Prototype pollution protection (eager: throw before any write).
-    if (keys.some(k => DANGEROUS_PATH_KEYS.has(k))) {
+    if (segments.some(s => DANGEROUS_PATH_KEYS.has(s.key))) {
       throw new Error(`Invalid property path: "${path}" contains a forbidden key`);
     }
 
-    for (let i = 0; i < keys.length - 1; i++) {
-      const key = keys[i];
+    for (let i = 0; i < segments.length - 1; i++) {
+      const key = resolveSegment(current, segments[i], path, true);
       // Per-iteration guard. Redundant with the eager check above (which
       // already throws), but kept so CodeQL's `js/prototype-pollution-utility`
       // dataflow sees the write site is guarded at the point of assignment.
-      if (DANGEROUS_PATH_KEYS.has(key)) {
+      if (typeof key === 'string' && DANGEROUS_PATH_KEYS.has(key)) {
         throw new Error(`Invalid property path: "${path}" contains a forbidden key`);
       }
       if (!Object.prototype.hasOwnProperty.call(current, key)
@@ -1876,9 +2033,9 @@ export class WorkflowDiffEngine {
       current = current[key];
     }
 
-    const finalKey = keys[keys.length - 1];
+    const finalKey = resolveSegment(current, segments[segments.length - 1], path, true);
     // Same CodeQL-visible guard at the final write site.
-    if (DANGEROUS_PATH_KEYS.has(finalKey)) {
+    if (typeof finalKey === 'string' && DANGEROUS_PATH_KEYS.has(finalKey)) {
       throw new Error(`Invalid property path: "${path}" contains a forbidden key`);
     }
     // Both null and undefined remove the property. undefined is accepted because
@@ -1886,7 +2043,13 @@ export class WorkflowDiffEngine {
     // (see processErrorOutputFixes), so treating only null as the deletion marker
     // left those fixes silently inert at the diff-engine layer.
     if (value === null || value === undefined) {
-      delete current[finalKey];
+      // A numeric key only resolves against an array, where deleting in place
+      // would leave a hole that serializes back to n8n as a null element.
+      if (typeof finalKey === 'number') {
+        current.splice(finalKey, 1);
+      } else {
+        delete current[finalKey];
+      }
     } else {
       current[finalKey] = value;
     }

--- a/tests/unit/community/community-node-service.test.ts
+++ b/tests/unit/community/community-node-service.test.ts
@@ -7,12 +7,14 @@ import {
   NpmSearchResult,
 } from '@/community/community-node-fetcher';
 import { ParsedNode } from '@/parsers/node-parser';
+import { logger } from '@/utils/logger';
 
 // Mock the fetcher
 vi.mock('@/community/community-node-fetcher', () => ({
   CommunityNodeFetcher: vi.fn().mockImplementation(() => ({
     fetchVerifiedNodes: vi.fn(),
     fetchNpmPackages: vi.fn(),
+    fetchPackageJson: vi.fn(),
   })),
 }));
 
@@ -32,6 +34,7 @@ describe('CommunityNodeService', () => {
   let mockFetcher: {
     fetchVerifiedNodes: ReturnType<typeof vi.fn>;
     fetchNpmPackages: ReturnType<typeof vi.fn>;
+    fetchPackageJson: ReturnType<typeof vi.fn>;
   };
 
   // Sample test data
@@ -97,6 +100,10 @@ describe('CommunityNodeService', () => {
     mockRepository = {
       saveNode: vi.fn(),
       hasNodeByNpmPackage: vi.fn().mockReturnValue(false),
+      getNodeByNpmPackage: vi.fn().mockReturnValue(null),
+      deleteStaleCommunityNodes: vi.fn().mockReturnValue(0),
+      updateNodeReadme: vi.fn(),
+      updateNodeAISummary: vi.fn(),
       getCommunityNodes: vi.fn().mockReturnValue([]),
       getCommunityStats: vi.fn().mockReturnValue({ total: 0, verified: 0, unverified: 0 }),
       deleteCommunityNodes: vi.fn().mockReturnValue(0),
@@ -106,6 +113,7 @@ describe('CommunityNodeService', () => {
     mockFetcher = {
       fetchVerifiedNodes: vi.fn().mockResolvedValue([]),
       fetchNpmPackages: vi.fn().mockResolvedValue([]),
+      fetchPackageJson: vi.fn().mockResolvedValue(null),
     };
 
     // Override CommunityNodeFetcher to return our mock
@@ -308,7 +316,12 @@ describe('CommunityNodeService', () => {
 
     it('should skip existing packages when skipExisting is true', async () => {
       mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
-      (mockRepository.hasNodeByNpmPackage as any).mockReturnValue(true);
+      (mockRepository.getNodeByNpmPackage as any).mockReturnValue({
+        nodeType: 'n8n-nodes-npm-test.npmtest',
+        npmPackageName: 'n8n-nodes-npm-test',
+        isCommunity: true,
+        isVerified: false,
+      });
 
       const result = await service.syncNpmNodes(100, undefined, true);
 
@@ -655,6 +668,155 @@ describe('CommunityNodeService', () => {
       );
     });
 
+    it('should derive the node name from the package.json n8n.nodes entry (#949)', async () => {
+      const globalsPackage = {
+        ...mockNpmPackage,
+        package: { ...mockNpmPackage.package, name: 'n8n-nodes-globals' },
+      };
+      mockFetcher.fetchNpmPackages.mockResolvedValue([globalsPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: { nodes: ['dist/nodes/GlobalConstants/GlobalConstants.node.js'] },
+      });
+
+      await service.syncNpmNodes();
+
+      expect(mockFetcher.fetchPackageJson).toHaveBeenCalledWith(
+        'n8n-nodes-globals',
+        '1.0.0',
+        expect.objectContaining({ maxRetries: 1 })
+      );
+      expect(mockRepository.saveNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodeType: 'n8n-nodes-globals.globalConstants',
+          displayName: 'globalConstants',
+        })
+      );
+    });
+
+    it('should lowercase a leading acronym in the node name (#949)', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: { nodes: ['dist/nodes/PDFGeneration/PDFGeneration.node.js'] },
+      });
+
+      await service.syncNpmNodes();
+
+      expect(mockRepository.saveNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodeType: 'n8n-nodes-npm-test.pdfGeneration',
+        })
+      );
+    });
+
+    it('should use the first n8n.nodes entry that names a node file (#949)', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: { nodes: ['dist/README.js', 'dist/nodes/Foo/Foo.node.js'] },
+      });
+
+      await service.syncNpmNodes();
+
+      expect(mockRepository.saveNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodeType: 'n8n-nodes-npm-test.foo',
+        })
+      );
+    });
+
+    it('should fall back and warn when no n8n.nodes entry names a node file (#949)', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: { nodes: ['dist/index.js'] },
+      });
+
+      await service.syncNpmNodes();
+
+      expect(mockRepository.saveNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodeType: 'n8n-nodes-npm-test.npmtest',
+        })
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('n8n-nodes-npm-test')
+      );
+    });
+
+    it('should look up the manifest with a single attempt and a short timeout (#949)', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+
+      await service.syncNpmNodes();
+
+      const options = mockFetcher.fetchPackageJson.mock.calls[0][2];
+      expect(options.maxRetries).toBe(1);
+      expect(options.timeout).toBeLessThan(15000);
+    });
+
+    it('should derive the node name from package.json for scoped packages (#949)', async () => {
+      const scopedPackage = {
+        ...mockNpmPackage,
+        package: { ...mockNpmPackage.package, name: '@myorg/n8n-nodes-custom' },
+      };
+      mockFetcher.fetchNpmPackages.mockResolvedValue([scopedPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: { nodes: ['dist/nodes/CustomThing/CustomThing.node.js'] },
+      });
+
+      await service.syncNpmNodes();
+
+      expect(mockRepository.saveNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodeType: '@myorg/n8n-nodes-custom.customThing',
+        })
+      );
+    });
+
+    it('should use the first entry of a multi-node n8n.nodes array (#949)', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: {
+          nodes: [
+            'dist/nodes/FirstNode/FirstNode.node.js',
+            'dist/nodes/SecondNode/SecondNode.node.js',
+          ],
+        },
+      });
+
+      await service.syncNpmNodes();
+
+      expect(mockRepository.saveNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodeType: 'n8n-nodes-npm-test.firstNode',
+        })
+      );
+    });
+
+    it('should fall back to the package-name heuristic when n8n.nodes is missing (#949)', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({ name: 'n8n-nodes-npm-test' });
+
+      await service.syncNpmNodes();
+
+      expect(mockRepository.saveNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodeType: 'n8n-nodes-npm-test.npmtest',
+        })
+      );
+    });
+
+    it('should fall back to the package-name heuristic when package.json cannot be fetched (#949)', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockRejectedValue(new Error('npm registry down'));
+
+      const result = await service.syncNpmNodes();
+
+      expect(result.saved).toBe(1);
+      expect(mockRepository.saveNode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodeType: 'n8n-nodes-npm-test.npmtest',
+        })
+      );
+    });
+
     it('should calculate approximate downloads from popularity score', async () => {
       const popularPackage = {
         ...mockNpmPackage,
@@ -675,6 +837,85 @@ describe('CommunityNodeService', () => {
           npmDownloads: 5000, // 0.5 * 10000
         })
       );
+    });
+  });
+
+  describe('stale node type re-keying (#949)', () => {
+    const globalsPackage: NpmSearchResult = {
+      ...mockNpmPackage,
+      package: { ...mockNpmPackage.package, name: 'n8n-nodes-globals' },
+    };
+
+    const staleRow = {
+      nodeType: 'n8n-nodes-globals.globals',
+      npmPackageName: 'n8n-nodes-globals',
+      isCommunity: true,
+      isVerified: false,
+      npmReadme: '# Globals',
+      aiDocumentationSummary: { summary: 'existing summary' },
+    };
+
+    beforeEach(() => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([globalsPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: { nodes: ['dist/nodes/GlobalConstants/GlobalConstants.node.js'] },
+      });
+    });
+
+    it('should replace a row keyed by the old node type and carry over its docs', async () => {
+      (mockRepository.getNodeByNpmPackage as any).mockReturnValue(staleRow);
+
+      const result = await service.syncNpmNodes();
+
+      expect(result.saved).toBe(1);
+      expect(mockRepository.saveNode).toHaveBeenCalledWith(
+        expect.objectContaining({ nodeType: 'n8n-nodes-globals.globalConstants' })
+      );
+      expect(mockRepository.deleteStaleCommunityNodes).toHaveBeenCalledWith(
+        'n8n-nodes-globals',
+        'n8n-nodes-globals.globalConstants'
+      );
+      expect(mockRepository.updateNodeReadme).toHaveBeenCalledWith(
+        'n8n-nodes-globals.globalConstants',
+        '# Globals'
+      );
+      expect(mockRepository.updateNodeAISummary).toHaveBeenCalledWith(
+        'n8n-nodes-globals.globalConstants',
+        { summary: 'existing summary' }
+      );
+    });
+
+    it('should re-key even when skipExisting is set', async () => {
+      (mockRepository.getNodeByNpmPackage as any).mockReturnValue(staleRow);
+
+      const result = await service.syncNpmNodes(100, undefined, true);
+
+      expect(result.saved).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(mockRepository.deleteStaleCommunityNodes).toHaveBeenCalled();
+    });
+
+    it('should leave a row with the same node type alone', async () => {
+      (mockRepository.getNodeByNpmPackage as any).mockReturnValue({
+        ...staleRow,
+        nodeType: 'n8n-nodes-globals.globalConstants',
+      });
+
+      await service.syncNpmNodes();
+
+      expect(mockRepository.deleteStaleCommunityNodes).not.toHaveBeenCalled();
+      expect(mockRepository.updateNodeReadme).not.toHaveBeenCalled();
+    });
+
+    it('should never re-key a verified row', async () => {
+      (mockRepository.getNodeByNpmPackage as any).mockReturnValue({
+        ...staleRow,
+        isVerified: true,
+      });
+
+      await service.syncNpmNodes();
+
+      expect(mockRepository.deleteStaleCommunityNodes).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/database/node-repository-community.test.ts
+++ b/tests/unit/database/node-repository-community.test.ts
@@ -109,6 +109,21 @@ class MockPreparedStatement implements PreparedStatement {
       });
     }
 
+    // deleteStaleCommunityNodes
+    if (this.sql.includes('DELETE FROM nodes') && this.sql.includes('node_type != ?')) {
+      this.run = vi.fn((npmPackageName: string, keepNodeType: string): RunResult => {
+        const nodes = this.mockData.get('community_nodes') || [];
+        const remaining = nodes.filter((n: any) => !(
+          n.npm_package_name === npmPackageName &&
+          n.node_type !== keepNodeType &&
+          n.is_community === 1 &&
+          n.is_verified === 0
+        ));
+        this.mockData.set('community_nodes', remaining);
+        return { changes: nodes.length - remaining.length, lastInsertRowid: 0 };
+      });
+    }
+
     // deleteCommunityNodes
     if (this.sql.includes('DELETE FROM nodes WHERE is_community = 1')) {
       this.run = vi.fn(() => {
@@ -429,6 +444,42 @@ describe('NodeRepository - Community Node Methods', () => {
       const deletedCount = repository.deleteCommunityNodes();
 
       expect(deletedCount).toBe(0);
+    });
+  });
+
+  describe('deleteStaleCommunityNodes', () => {
+    const staleRow = {
+      ...sampleCommunityNodes[1],
+      node_type: 'n8n-nodes-unverified.unverified',
+    };
+
+    beforeEach(() => {
+      mockAdapter._setMockData('community_nodes', [...sampleCommunityNodes, staleRow]);
+    });
+
+    it('should remove rows of the package that are keyed by another node type', () => {
+      const deletedCount = repository.deleteStaleCommunityNodes(
+        'n8n-nodes-unverified',
+        'n8n-nodes-unverified.testNode'
+      );
+
+      expect(deletedCount).toBe(1);
+      const remaining = mockAdapter._getMockData('community_nodes');
+      expect(remaining.map((n: any) => n.node_type)).toEqual([
+        'n8n-nodes-verified.testNode',
+        'n8n-nodes-unverified.testNode',
+        'n8n-nodes-popular.testNode',
+      ]);
+    });
+
+    it('should never remove verified rows', () => {
+      const deletedCount = repository.deleteStaleCommunityNodes(
+        'n8n-nodes-verified',
+        'n8n-nodes-verified.renamed'
+      );
+
+      expect(deletedCount).toBe(0);
+      expect(mockAdapter._getMockData('community_nodes')).toHaveLength(4);
     });
   });
 

--- a/tests/unit/services/workflow-diff-engine.test.ts
+++ b/tests/unit/services/workflow-diff-engine.test.ts
@@ -6869,4 +6869,419 @@ describe('WorkflowDiffEngine', () => {
       expect(result.workflow).toBeUndefined();
     });
   });
+
+  describe('Bracket index paths (Issue #950)', () => {
+    const buildSetWorkflow = (): Workflow => {
+      const workflow = JSON.parse(JSON.stringify(baseWorkflow));
+      workflow.nodes.push({
+        id: 'set-1',
+        name: 'Set',
+        type: 'n8n-nodes-base.set',
+        typeVersion: 3.4,
+        position: [900, 300],
+        parameters: {
+          assignments: {
+            assignments: [
+              { id: 'a1', name: 'first', value: 'old value', type: 'string' },
+              { id: 'a2', name: 'second', value: 'untouched', type: 'string' }
+            ]
+          }
+        }
+      });
+      return workflow;
+    };
+
+    const findSetNode = (result: any) =>
+      result.workflow!.nodes.find((n: any) => n.name === 'Set');
+
+    it('should update an array element addressed with a bracket index', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'updateNode' as const,
+          nodeId: 'set-1',
+          updates: {
+            'parameters.assignments.assignments[0].value': 'new value'
+          }
+        }]
+      });
+
+      expect(result.success).toBe(true);
+      const assignments = findSetNode(result).parameters.assignments.assignments;
+      expect(assignments[0].value).toBe('new value');
+      expect(assignments[1].value).toBe('untouched');
+    });
+
+    it('should not create a literal bracket key on the array', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'updateNode' as const,
+          nodeId: 'set-1',
+          updates: {
+            'parameters.assignments.assignments[0].value': 'new value'
+          }
+        }]
+      });
+
+      expect(result.success).toBe(true);
+      const container = findSetNode(result).parameters.assignments;
+      expect(Object.prototype.hasOwnProperty.call(container, 'assignments[0]')).toBe(false);
+      expect(container.assignments.length).toBe(2);
+    });
+
+    it('should update through multiple bracket indices', async () => {
+      const workflow = JSON.parse(JSON.stringify(baseWorkflow));
+      workflow.nodes.push({
+        id: 'matrix-1',
+        name: 'Matrix',
+        type: 'n8n-nodes-base.code',
+        typeVersion: 2,
+        position: [900, 300],
+        parameters: { rows: [[{ label: 'a' }, { label: 'b' }]] }
+      });
+
+      const result = await diffEngine.applyDiff(workflow, {
+        id: 'test',
+        operations: [{
+          type: 'updateNode' as const,
+          nodeId: 'matrix-1',
+          updates: { 'parameters.rows[0][1].label': 'c' }
+        }]
+      });
+
+      expect(result.success).toBe(true);
+      const rows = result.workflow!.nodes.find((n: any) => n.id === 'matrix-1')!.parameters.rows as any;
+      expect(rows[0][1].label).toBe('c');
+      expect(rows[0][0].label).toBe('a');
+    });
+
+    it('should still support the numeric dot notation form', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'updateNode' as const,
+          nodeId: 'set-1',
+          updates: {
+            'parameters.assignments.assignments.0.value': 'dotted value'
+          }
+        }]
+      });
+
+      expect(result.success).toBe(true);
+      expect(findSetNode(result).parameters.assignments.assignments[0].value).toBe('dotted value');
+    });
+
+    it('should remove an array element without leaving a hole', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'updateNode' as const,
+          nodeId: 'set-1',
+          updates: { 'parameters.assignments.assignments[0]': null }
+        }]
+      });
+
+      expect(result.success).toBe(true);
+      const assignments = findSetNode(result).parameters.assignments.assignments;
+      expect(assignments).toHaveLength(1);
+      expect(assignments[0].name).toBe('second');
+    });
+
+    it('should reject a malformed bracket index', async () => {
+      for (const path of [
+        'parameters.assignments.assignments[x].value',
+        'parameters.assignments.assignments[].value',
+        'parameters.assignments.assignments[0.value',
+        'parameters.assignments.assignments[-1].value'
+      ]) {
+        const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+          id: 'test',
+          operations: [{
+            type: 'updateNode' as const,
+            nodeId: 'set-1',
+            updates: { [path]: 'new value' }
+          }]
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.errors![0].message).toContain('malformed bracket index');
+      }
+    });
+
+    it('should reject an out-of-range bracket index instead of writing a junk key', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'updateNode' as const,
+          nodeId: 'set-1',
+          updates: { 'parameters.assignments.assignments[5].value': 'new value' }
+        }]
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors![0].message).toContain('out of range');
+    });
+
+    it('should reject a bracket index applied to a non-array value', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'updateNode' as const,
+          nodeId: 'set-1',
+          updates: { 'parameters.assignments[0].value': 'new value' }
+        }]
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors![0].message).toContain('expects an array');
+    });
+
+    it('should reject a forbidden key that follows a bracket index', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'updateNode' as const,
+          nodeId: 'set-1',
+          updates: { 'parameters.assignments.assignments[0].__proto__.polluted': 'malicious' }
+        }]
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors![0].message).toContain('forbidden key');
+      expect(({} as any).polluted).toBeUndefined();
+    });
+
+    it('should patch a string field addressed with a bracket index', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'patchNodeField' as const,
+          nodeId: 'set-1',
+          fieldPath: 'parameters.assignments.assignments[0].value',
+          patches: [{ find: 'old', replace: 'new' }]
+        }]
+      });
+
+      expect(result.success).toBe(true);
+      const container = findSetNode(result).parameters.assignments;
+      expect(container.assignments[0].value).toBe('new value');
+      expect(Object.prototype.hasOwnProperty.call(container, 'assignments[0]')).toBe(false);
+    });
+
+    it('should report a malformed bracket path in patchNodeField', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'patchNodeField' as const,
+          nodeId: 'set-1',
+          fieldPath: 'parameters.assignments.assignments[x].value',
+          patches: [{ find: 'old', replace: 'new' }]
+        }]
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors![0].message).toContain('malformed bracket index');
+    });
+
+    it('should report an out-of-range bracket path in patchNodeField', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'patchNodeField' as const,
+          nodeId: 'set-1',
+          fieldPath: 'parameters.assignments.assignments[5].value',
+          patches: [{ find: 'old', replace: 'new' }]
+        }]
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors![0].message).toContain('does not exist');
+    });
+
+    it('should reject an index equal to the array length', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'updateNode' as const,
+          nodeId: 'set-1',
+          updates: { 'parameters.assignments.assignments[2].value': 'appended' }
+        }]
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors![0].message).toContain('out of range');
+    });
+
+    it('should apply __patch_find_replace through a bracket path', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'updateNode' as const,
+          nodeId: 'set-1',
+          updates: {
+            'parameters.assignments.assignments[0].value': {
+              __patch_find_replace: [{ find: 'old', replace: 'new' }]
+            }
+          }
+        }]
+      });
+
+      expect(result.success).toBe(true);
+      const container = findSetNode(result).parameters.assignments;
+      expect(container.assignments[0].value).toBe('new value');
+      expect(Object.prototype.hasOwnProperty.call(container, 'assignments[0]')).toBe(false);
+    });
+
+    it('should reject empty path segments', async () => {
+      for (const path of [
+        'parameters..url',
+        'parameters.',
+        '.parameters',
+        ''
+      ]) {
+        const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+          id: 'test',
+          operations: [{
+            type: 'updateNode' as const,
+            nodeId: 'set-1',
+            updates: { [path]: 'new value' }
+          }]
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.errors![0].message).toContain('empty path segment');
+      }
+    });
+
+    it('should reject an empty path segment in patchNodeField', async () => {
+      const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+        id: 'test',
+        operations: [{
+          type: 'patchNodeField' as const,
+          nodeId: 'set-1',
+          fieldPath: 'parameters..assignments',
+          patches: [{ find: 'old', replace: 'new' }]
+        }]
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors![0].message).toContain('empty path segment');
+    });
+
+    it('should reject a non-numeric dot segment applied to an array', async () => {
+      for (const path of [
+        'parameters.assignments.assignments.-1.value',
+        'parameters.assignments.assignments.length'
+      ]) {
+        const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+          id: 'test',
+          operations: [{
+            type: 'updateNode' as const,
+            nodeId: 'set-1',
+            updates: { [path]: 0 }
+          }]
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.errors![0].message).toContain('is not an array index');
+      }
+    });
+
+    it('should remove several elements of the same array in one updates object', async () => {
+      const workflow = JSON.parse(JSON.stringify(baseWorkflow));
+      workflow.nodes.push({
+        id: 'list-1',
+        name: 'List',
+        type: 'n8n-nodes-base.code',
+        typeVersion: 2,
+        position: [900, 300],
+        parameters: { items: [{ label: 'A' }, { label: 'B' }, { label: 'C' }] }
+      });
+
+      const result = await diffEngine.applyDiff(workflow, {
+        id: 'test',
+        operations: [{
+          type: 'updateNode' as const,
+          nodeId: 'list-1',
+          updates: {
+            'parameters.items[0]': null,
+            'parameters.items[1]': null
+          }
+        }]
+      });
+
+      expect(result.success).toBe(true);
+      const items = result.workflow!.nodes.find((n: any) => n.id === 'list-1')!.parameters.items as any;
+      expect(items).toEqual([{ label: 'C' }]);
+    });
+
+    describe('atomic updates', () => {
+      it('should leave the node untouched when a later update path fails', async () => {
+        const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+          id: 'test',
+          operations: [{
+            type: 'updateNode' as const,
+            nodeId: 'set-1',
+            updates: {
+              'parameters.mode': 'manual',
+              'parameters.created[0].value': 'never applied'
+            }
+          }]
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.errors![0].message).toContain('expects an array');
+      });
+
+      it('should not leave remnants of a failed updates object under continueOnError', async () => {
+        const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+          id: 'test',
+          continueOnError: true,
+          operations: [
+            {
+              type: 'updateNode' as const,
+              nodeId: 'set-1',
+              updates: {
+                'parameters.mode': 'manual',
+                'parameters.created[0].value': 'never applied'
+              }
+            },
+            {
+              type: 'updateNode' as const,
+              nodeId: 'set-1',
+              updates: { 'parameters.assignments.assignments[1].value': 'applied' }
+            }
+          ]
+        });
+
+        expect(result.applied).toEqual([1]);
+        expect(result.failed).toEqual([0]);
+        const setNode = findSetNode(result);
+        expect(setNode.parameters.created).toBeUndefined();
+        expect(setNode.parameters.mode).toBeUndefined();
+        expect(setNode.parameters.assignments.assignments[1].value).toBe('applied');
+      });
+
+      it('should not apply earlier keys when a later key is out of range', async () => {
+        const result = await diffEngine.applyDiff(buildSetWorkflow(), {
+          id: 'test',
+          continueOnError: true,
+          operations: [{
+            type: 'updateNode' as const,
+            nodeId: 'set-1',
+            updates: {
+              'parameters.mode': 'manual',
+              'parameters.assignments.assignments[9].value': 'never applied'
+            }
+          }]
+        });
+
+        expect(result.failed).toEqual([0]);
+        const setNode = findSetNode(result);
+        expect(setNode.parameters.mode).toBeUndefined();
+        expect(setNode.parameters.assignments.assignments).toHaveLength(2);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Closes #950. Closes #949.

## Fix 1 — `updateNode` silently wrote a junk key for bracket-index paths (#950)

`setNestedProperty`/`getNestedProperty` split property paths only on dots, so an `updates` key like `parameters.assignments.assignments[0].value` treated `assignments[0]` as one literal key: the diff engine created a junk `"assignments[0]"` property on the array, reported success, and never touched the element. `patchNodeField` shared the helpers and was safe only by accident.

- A shared tokenizer (`parsePropertyPath`) resolves bracket segments as array indices (digits only, multi-bracket supported) for both operations; prototype-pollution guards apply to every parsed segment.
- Silent-corruption forms now error instead: malformed brackets (`a[x]`, `a[]`, unclosed), out-of-range indices, empty segments (`a..b`), and — on writes — non-index segments on arrays (`parameters.arr.length: 0` used to truncate the array silently).
- An `updates` object applies to a deep-cloned draft swapped in only on success: a failing key leaves the node untouched, including under `continueOnError`.
- Removal by index splices (no JSON `null` holes), and batched removals on the same array apply highest-index-first, so `[0]` + `[1]` on `[A,B,C]` removes A and B — previously it removed A and C while reporting success.
- Legacy dot-numeric paths (`assignments.0.value`) behave exactly as before; appending via `index === length` is deliberately rejected (pinned by test) — the tool doc says so.

## Fix 2 — `search_nodes` returned node types that don't exist (#949)

The npm-fallback community sync derived the type suffix by string-mangling the package name: `n8n-nodes-globals` → `n8n-nodes-globals.globals`, but the package's only node is `globalConstants`, so every workflow built from the search result failed to import ("Install this node…").

- The suffix now comes from the package's own `package.json` `n8n.nodes` manifest: first parseable entry's basename, with a leading acronym lowercased as a unit (`PDFGeneration.node.js` → `pdfGeneration` — plain lowerFirst would fabricate `pDFGeneration`). The old heuristic survives only as a logged fallback, fetched with a 1-attempt/5s budget so a sick registry can't stall the sync.
- Rows are keyed by `node_type`, so a fix alone would have left the stale row beside the corrected one (or been skipped entirely by `--update`). The sync now self-heals: a stored type that no longer matches is re-keyed in place — stale unverified row(s) dropped, README and AI summary carried over — in both full and `--update` modes. Core/verified rows are structurally unreachable by the cleanup (`is_community = 1 AND is_verified = 0`, and core rows never carry `npm_package_name`).
- **Bundled DB repaired in this PR** (separate commit): 45 fabricated types re-keyed — e.g. `…globals` → `…globalConstants`, `…deepseekchatmodel` → `…lmChatDeepSeek`, `…telegramgrampro` → `…telegramMtproto`, `…docxconverter` → `…docxToText` — 1,460 community nodes total (1,295 verified, 165 unverified), `n8n-nodes-globals.globalConstants` verified present with docs intact.

## Known limits (stated, not hidden)

- The filename-derived name is still a heuristic; ground truth is the node descriptor's `description.name`, which only tarball parsing could read. Isolated mismatches remain possible for unverified npm-sourced packages.
- Multi-node npm packages still produce one row (first parseable `n8n.nodes` entry) — candidate for a follow-up issue.

## Testing

- 30+ new unit tests across the diff engine and community sync, each observed red on unfixed code first; the junk-key regression asserts on the exact wrapper object the bug corrupted.
- Full unit suite: 160 files, 5,473 passed / 35 skipped / 0 failed. `npm run typecheck` clean.
- Review provenance: independent Claude + Codex review rounds, all findings adjudicated and either fixed or pinned by test.

Note on versioning: this PR carries 2.66.3; #963 carries 2.67.0. Whichever merges second should rebase its version (this one would become 2.67.1 if it lands after).

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)