### PR TITLE
fix: n8n_executions never reads ai_* connection data for AI Agent sub-nodes

### DIFF
--- a/src/services/error-execution-processor.ts
+++ b/src/services/error-execution-processor.ts
@@ -59,11 +59,54 @@ function extractConnectionBranches(connections: unknown): unknown[][] {
 }
 
 /**
- * Get the first output branch's items for a run, across `main` and any
- * `ai_*` connection types.
+ * Whether a node's runData entry has any connection-type data at all
+ * (as opposed to genuinely having zero items in an existing branch).
  */
-function getRunOutputItems(run: any): unknown[] {
-  return extractConnectionBranches(run?.data)[0] || [];
+function nodeHasConnectionData(nodeData: unknown): boolean {
+  if (!Array.isArray(nodeData)) return false;
+  return nodeData.some(run => extractConnectionBranches(run?.data).length > 0);
+}
+
+/**
+ * Get a node's first-branch output items, merged across every run in
+ * run order.
+ *
+ * A node's runData entry is an array of runs, not a single run: nodes
+ * invoked more than once within an execution (e.g. an AI Agent's Chat
+ * Model, called once to decide to call a tool and again to produce the
+ * final answer) get one array entry per invocation. Reading only
+ * `nodeData[0]` silently drops every later invocation's data.
+ */
+function getAllRunsOutputItems(nodeData: unknown): unknown[] {
+  const merged: unknown[] = [];
+  if (!Array.isArray(nodeData)) return merged;
+
+  for (const run of nodeData) {
+    const branches = extractConnectionBranches(run?.data);
+    if (branches[0]) {
+      merged.push(...branches[0]);
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Find the error from a node's runs, if any. A node invoked multiple
+ * times only fails on one of its runs, and the last run with an error is
+ * the one that actually stopped the branch, so it wins over any earlier
+ * error.
+ */
+function getAnyRunError(nodeData: unknown): any {
+  if (!Array.isArray(nodeData)) return undefined;
+
+  let found: any;
+  for (const run of nodeData) {
+    if (run?.error) {
+      found = run.error;
+    }
+  }
+  return found;
 }
 
 /**
@@ -164,9 +207,9 @@ function extractPrimaryError(
   const errorNode = error?.node as Record<string, unknown> | undefined;
   const nodeName = (errorNode?.name as string) || lastNode || 'Unknown';
 
-  // Also check runData for node-level errors
+  // Also check runData for node-level errors, across every run of the node
   const nodeRunData = runData[nodeName];
-  const nodeError = nodeRunData?.[0]?.error;
+  const nodeError = getAnyRunError(nodeRunData);
 
   const stackTrace = (error?.stack || nodeError?.stack) as string | undefined;
 
@@ -211,7 +254,7 @@ function extractUpstreamContext(
     .filter(([name, data]) => {
       if (name === errorNodeName) return false;
       const runs = data as any[];
-      return getRunOutputItems(runs?.[0]).length > 0 && !runs?.[0]?.error;
+      return getAllRunsOutputItems(runs).length > 0 && !getAnyRunError(runs);
     })
     .map(([name, data]) => ({
       name,
@@ -286,11 +329,11 @@ function extractNodeOutput(
   itemsLimit: number
 ): ErrorAnalysis['upstreamContext'] | undefined {
   const nodeData = runData[nodeName];
-  const branches = extractConnectionBranches(nodeData?.[0]?.data);
-  if (branches.length === 0) return undefined;
-  const items = branches[0];
+  if (!nodeHasConnectionData(nodeData)) return undefined;
+  const items = getAllRunsOutputItems(nodeData);
 
-  // Sanitize sample items to remove sensitive data
+  // Sanitize sample items to remove sensitive data (flat, run-ordered
+  // across every invocation of the node)
   const rawSamples = items.slice(0, itemsLimit);
   const sanitizedSamples = rawSamples.map((item: unknown) => sanitizeData(item));
 
@@ -321,8 +364,8 @@ function buildExecutionPath(
     for (const nodeName of upstreamNodes) {
       const nodeData = runData[nodeName];
       const runs = nodeData as any[] | undefined;
-      const hasError = runs?.[0]?.error;
-      const itemCount = getRunOutputItems(runs?.[0]).length;
+      const hasError = getAnyRunError(runs);
+      const itemCount = getAllRunsOutputItems(runs).length;
 
       path.push({
         nodeName,
@@ -353,8 +396,8 @@ function buildExecutionPath(
     for (const { name, data } of nodesByTime) {
       path.push({
         nodeName: name,
-        status: data?.[0]?.error ? 'error' : 'success',
-        itemCount: getRunOutputItems(data?.[0]).length,
+        status: getAnyRunError(data) ? 'error' : 'success',
+        itemCount: getAllRunsOutputItems(data).length,
         executionTime: data?.[0]?.executionTime
       });
     }
@@ -376,7 +419,7 @@ function findAdditionalErrors(
     if (nodeName === primaryErrorNode) continue;
 
     const runs = data as any[];
-    const error = runs?.[0]?.error;
+    const error = getAnyRunError(runs);
     if (error) {
       additional.push({
         nodeName,

--- a/src/services/error-execution-processor.ts
+++ b/src/services/error-execution-processor.ts
@@ -33,6 +33,40 @@ export interface ErrorProcessorOptions {
 const MAX_STACK_LINES = 3;
 
 /**
+ * Extract per-branch item arrays from a task-data connections object
+ * (e.g. `run.data`). Regular nodes populate `main`, but LangChain AI
+ * Agent sub-nodes (Chat Model, Output Parser, Tool, Memory, etc.) use
+ * special `ai_*` connection types instead. A node's task data only ever
+ * populates one of these keys, so merging all of them is equivalent to
+ * "whichever one this node uses".
+ */
+function extractConnectionBranches(connections: unknown): unknown[][] {
+  const branches: unknown[][] = [];
+
+  if (!connections || typeof connections !== 'object') {
+    return branches;
+  }
+
+  for (const value of Object.values(connections as Record<string, unknown>)) {
+    if (Array.isArray(value)) {
+      for (const branch of value) {
+        branches.push(Array.isArray(branch) ? branch : []);
+      }
+    }
+  }
+
+  return branches;
+}
+
+/**
+ * Get the first output branch's items for a run, across `main` and any
+ * `ai_*` connection types.
+ */
+function getRunOutputItems(run: any): unknown[] {
+  return extractConnectionBranches(run?.data)[0] || [];
+}
+
+/**
  * Keys that could enable prototype pollution attacks
  * These are blocked entirely from processing
  */
@@ -177,7 +211,7 @@ function extractUpstreamContext(
     .filter(([name, data]) => {
       if (name === errorNodeName) return false;
       const runs = data as any[];
-      return runs?.[0]?.data?.main?.[0]?.length > 0 && !runs?.[0]?.error;
+      return getRunOutputItems(runs?.[0]).length > 0 && !runs?.[0]?.error;
     })
     .map(([name, data]) => ({
       name,
@@ -252,9 +286,9 @@ function extractNodeOutput(
   itemsLimit: number
 ): ErrorAnalysis['upstreamContext'] | undefined {
   const nodeData = runData[nodeName];
-  if (!nodeData?.[0]?.data?.main?.[0]) return undefined;
-
-  const items = nodeData[0].data.main[0];
+  const branches = extractConnectionBranches(nodeData?.[0]?.data);
+  if (branches.length === 0) return undefined;
+  const items = branches[0];
 
   // Sanitize sample items to remove sensitive data
   const rawSamples = items.slice(0, itemsLimit);
@@ -288,7 +322,7 @@ function buildExecutionPath(
       const nodeData = runData[nodeName];
       const runs = nodeData as any[] | undefined;
       const hasError = runs?.[0]?.error;
-      const itemCount = runs?.[0]?.data?.main?.[0]?.length || 0;
+      const itemCount = getRunOutputItems(runs?.[0]).length;
 
       path.push({
         nodeName,
@@ -320,7 +354,7 @@ function buildExecutionPath(
       path.push({
         nodeName: name,
         status: data?.[0]?.error ? 'error' : 'success',
-        itemCount: data?.[0]?.data?.main?.[0]?.length || 0,
+        itemCount: getRunOutputItems(data?.[0]).length,
         executionTime: data?.[0]?.executionTime
       });
     }

--- a/src/services/execution-processor.ts
+++ b/src/services/execution-processor.ts
@@ -150,6 +150,73 @@ function getRunInputData(run: any): unknown[][] {
 }
 
 /**
+ * Merge per-branch item arrays across every run of a node, aligned by
+ * branch/port index, in run order.
+ *
+ * A node's `runData` entry is an array of runs, not a single run: nodes
+ * invoked more than once within an execution (e.g. an AI Agent's Chat
+ * Model, called once to decide to call a tool and again to produce the
+ * final answer) get one array entry per invocation. Reading only
+ * `nodeData[0]` silently drops every later invocation's data - this
+ * merges branch[i] of every run into a single flat, run-ordered branch[i],
+ * so `itemsLimit` truncation still behaves like "first N items overall".
+ */
+function mergeRunsByBranch(nodeData: unknown, selector: (run: any) => unknown[][]): unknown[][] {
+  const merged: unknown[][] = [];
+
+  if (!Array.isArray(nodeData)) {
+    return merged;
+  }
+
+  for (const run of nodeData) {
+    const branches = selector(run);
+    branches.forEach((items, branchIndex) => {
+      if (!merged[branchIndex]) {
+        merged[branchIndex] = [];
+      }
+      merged[branchIndex].push(...items);
+    });
+  }
+
+  return merged;
+}
+
+/**
+ * Get output data across `main`/`ai_*` connection types AND across every
+ * run of the node (see {@link mergeRunsByBranch}).
+ */
+function getAllRunsOutputData(nodeData: unknown): unknown[][] {
+  return mergeRunsByBranch(nodeData, getRunOutputData);
+}
+
+/**
+ * Get input data (`inputOverride`) across every run of the node.
+ */
+function getAllRunsInputData(nodeData: unknown): unknown[][] {
+  return mergeRunsByBranch(nodeData, getRunInputData);
+}
+
+/**
+ * Find the error from a node's runs, if any. A node invoked multiple times
+ * only fails on one of its runs, and n8n does not necessarily record that
+ * as the first one - the last run with an error is the one that actually
+ * stopped the branch, so it wins over any earlier error.
+ */
+function getAnyRunError(nodeData: unknown): unknown {
+  if (!Array.isArray(nodeData)) {
+    return undefined;
+  }
+
+  let found: unknown;
+  for (const run of nodeData) {
+    if (run?.error) {
+      found = run.error;
+    }
+  }
+  return found;
+}
+
+/**
  * Count items in execution data
  */
 function countItems(nodeData: unknown): { input: number; output: number } {
@@ -207,11 +274,10 @@ export function generatePreview(execution: Execution): {
     const nodeData = runData[nodeName];
     const itemCounts = countItems(nodeData);
 
-    // Extract structure from first run's first output item
+    // Extract structure from the first available output item across all runs
     let dataStructure: Record<string, unknown> = {};
     if (Array.isArray(nodeData) && nodeData.length > 0) {
-      const firstRun = nodeData[0];
-      const firstItem = getRunOutputData(firstRun)?.[0]?.[0];
+      const firstItem = getAllRunsOutputData(nodeData)?.[0]?.[0];
       if (firstItem) {
         dataStructure = extractStructure(firstItem) as Record<string, unknown>;
       }
@@ -500,7 +566,11 @@ export function filterExecutionData(
       continue;
     }
 
-    // Get first run data
+    // Node-level metadata (executionTime) still comes from the first run;
+    // item data and error status are aggregated across every run below,
+    // since a node invoked multiple times in one execution (e.g. an AI
+    // Agent's Chat Model, called once to decide to call a tool and again
+    // to produce the final answer) produces one runData entry per call.
     const firstRun = nodeData[0];
     const itemCounts = countItems(nodeData);
     totalItems += itemCounts.output;
@@ -512,16 +582,17 @@ export function filterExecutionData(
       status: 'success',
     };
 
-    // Check for errors
-    if (firstRun.error) {
+    // Check for errors across all runs, not just the first
+    const runError = getAnyRunError(nodeData);
+    if (runError) {
       nodeResult.status = 'error';
-      nodeResult.error = extractErrorMessage(firstRun.error);
+      nodeResult.error = extractErrorMessage(runError);
     }
 
     // Handle full mode - include all data
     if (mode === 'full') {
       nodeResult.data = {
-        output: getRunOutputData(firstRun),
+        output: getAllRunsOutputData(nodeData),
         metadata: {
           totalItems: itemCounts.output,
           itemsShown: itemCounts.output,
@@ -529,13 +600,14 @@ export function filterExecutionData(
         },
       };
 
-      const inputData = getRunInputData(firstRun);
+      const inputData = getAllRunsInputData(nodeData);
       if (includeInputData && inputData.length > 0) {
         nodeResult.data.input = inputData;
       }
     } else {
-      // Summary or filtered mode - apply limits
-      const outputData = getRunOutputData(firstRun);
+      // Summary or filtered mode - apply limits (flat, run-ordered across
+      // every invocation of the node)
+      const outputData = getAllRunsOutputData(nodeData);
       const { truncated, metadata } = truncateItems(outputData, itemsLimit);
 
       if (metadata.truncated) {
@@ -547,7 +619,7 @@ export function filterExecutionData(
         metadata,
       };
 
-      const inputData = getRunInputData(firstRun);
+      const inputData = getAllRunsInputData(nodeData);
       if (includeInputData && inputData.length > 0) {
         nodeResult.data.input = inputData;
       }

--- a/src/services/execution-processor.ts
+++ b/src/services/execution-processor.ts
@@ -106,6 +106,50 @@ function estimateDataSize(data: unknown): number {
 }
 
 /**
+ * Extract per-branch item arrays from a task-data connections object
+ * (e.g. `run.data` or `run.inputOverride`).
+ *
+ * Regular nodes connect via the `main` connection type, but LangChain
+ * AI Agent sub-nodes (Chat Model, Output Parser, Tool, Memory, etc.)
+ * connect via special `ai_*` connection types (ai_languageModel,
+ * ai_outputParser, ai_tool, ai_memory, ai_embedding, ...) instead of
+ * `main`. A node's task data only ever populates one of these keys, so
+ * merging all of them is equivalent to "whichever one this node uses".
+ */
+function extractConnectionBranches(connections: unknown): unknown[][] {
+  const branches: unknown[][] = [];
+
+  if (!connections || typeof connections !== 'object') {
+    return branches;
+  }
+
+  for (const value of Object.values(connections as Record<string, unknown>)) {
+    if (Array.isArray(value)) {
+      for (const branch of value) {
+        branches.push(Array.isArray(branch) ? branch : []);
+      }
+    }
+  }
+
+  return branches;
+}
+
+/**
+ * Get a run's output data across `main` and any `ai_*` connection types.
+ */
+function getRunOutputData(run: any): unknown[][] {
+  return extractConnectionBranches(run?.data);
+}
+
+/**
+ * Get a run's input data (n8n stores this under `inputOverride`, keyed by
+ * connection type, mirroring the `data` field's shape).
+ */
+function getRunInputData(run: any): unknown[][] {
+  return extractConnectionBranches(run?.inputOverride);
+}
+
+/**
  * Count items in execution data
  */
 function countItems(nodeData: unknown): { input: number; output: number } {
@@ -116,15 +160,11 @@ function countItems(nodeData: unknown): { input: number; output: number } {
   }
 
   for (const run of nodeData) {
-    if (run?.data?.main) {
-      const mainData = run.data.main;
-      if (Array.isArray(mainData)) {
-        for (const output of mainData) {
-          if (Array.isArray(output)) {
-            counts.output += output.length;
-          }
-        }
-      }
+    for (const output of getRunOutputData(run)) {
+      counts.output += output.length;
+    }
+    for (const input of getRunInputData(run)) {
+      counts.input += input.length;
     }
   }
 
@@ -171,7 +211,7 @@ export function generatePreview(execution: Execution): {
     let dataStructure: Record<string, unknown> = {};
     if (Array.isArray(nodeData) && nodeData.length > 0) {
       const firstRun = nodeData[0];
-      const firstItem = firstRun?.data?.main?.[0]?.[0];
+      const firstItem = getRunOutputData(firstRun)?.[0]?.[0];
       if (firstItem) {
         dataStructure = extractStructure(firstItem) as Record<string, unknown>;
       }
@@ -481,7 +521,7 @@ export function filterExecutionData(
     // Handle full mode - include all data
     if (mode === 'full') {
       nodeResult.data = {
-        output: firstRun.data?.main || [],
+        output: getRunOutputData(firstRun),
         metadata: {
           totalItems: itemCounts.output,
           itemsShown: itemCounts.output,
@@ -489,12 +529,13 @@ export function filterExecutionData(
         },
       };
 
-      if (includeInputData && firstRun.inputData) {
-        nodeResult.data.input = firstRun.inputData;
+      const inputData = getRunInputData(firstRun);
+      if (includeInputData && inputData.length > 0) {
+        nodeResult.data.input = inputData;
       }
     } else {
       // Summary or filtered mode - apply limits
-      const outputData = firstRun.data?.main || [];
+      const outputData = getRunOutputData(firstRun);
       const { truncated, metadata } = truncateItems(outputData, itemsLimit);
 
       if (metadata.truncated) {
@@ -506,8 +547,9 @@ export function filterExecutionData(
         metadata,
       };
 
-      if (includeInputData && firstRun.inputData) {
-        nodeResult.data.input = firstRun.inputData;
+      const inputData = getRunInputData(firstRun);
+      if (includeInputData && inputData.length > 0) {
+        nodeResult.data.input = inputData;
       }
     }
 

--- a/tests/unit/services/error-execution-processor.test.ts
+++ b/tests/unit/services/error-execution-processor.test.ts
@@ -956,3 +956,123 @@ describe('ErrorExecutionProcessor - Performance', () => {
     expect(result.upstreamContext?.dataStructure).toBeDefined();
   });
 });
+
+/**
+ * Multi-run node tests
+ *
+ * A node invoked more than once within a single execution (e.g. an AI
+ * Agent's Chat Model, called once to decide to call a tool and again to
+ * produce the final answer) gets one runData array entry per invocation.
+ * Error detection and item sampling must look across every run, not just
+ * the first.
+ */
+describe('ErrorExecutionProcessor - multi-run nodes', () => {
+  function twoRunUpstreamNode() {
+    return [
+      {
+        startTime: Date.now() - 2000,
+        executionTime: 500,
+        data: { ai_languageModel: [[{ json: { text: 'first turn' } }]] },
+      },
+      {
+        startTime: Date.now() - 1000,
+        executionTime: 1200,
+        data: { ai_languageModel: [[{ json: { text: 'second turn' } }]] },
+      },
+    ];
+  }
+
+  it('should merge upstream context items across all runs (heuristic path, no workflow)', () => {
+    const execution = createMockExecution({
+      runData: {
+        'Upstream': twoRunUpstreamNode(),
+        'Error Node': createErrorNodeData(),
+      },
+    });
+
+    const result = processErrorExecution(execution);
+
+    expect(result.upstreamContext?.itemCount).toBe(2);
+    expect(result.upstreamContext?.sampleItems).toHaveLength(2);
+    expect((result.upstreamContext?.sampleItems?.[0] as any)?.json?.text).toBe('first turn');
+    expect((result.upstreamContext?.sampleItems?.[1] as any)?.json?.text).toBe('second turn');
+  });
+
+  it('should merge upstream context items across all runs (workflow path)', () => {
+    const execution = createMockExecution({
+      runData: {
+        'Upstream': twoRunUpstreamNode(),
+        'Error Node': createErrorNodeData(),
+      },
+    });
+
+    const workflow = createMockWorkflow({
+      connections: {
+        'Upstream': { main: [[{ node: 'Error Node', type: 'main', index: 0 }]] },
+      },
+      nodes: [
+        { name: 'Upstream', type: 'n8n-nodes-base.test' },
+        { name: 'Error Node', type: 'n8n-nodes-base.test' },
+      ],
+    });
+
+    const result = processErrorExecution(execution, { workflow });
+
+    expect(result.upstreamContext?.itemCount).toBe(2);
+    expect(result.upstreamContext?.sampleItems).toHaveLength(2);
+  });
+
+  it('should detect an error on a non-first run as an additional error', () => {
+    const nodeData = twoRunUpstreamNode();
+    (nodeData[1] as any).error = { message: 'Second run failed' };
+
+    const execution = createMockExecution({
+      runData: {
+        'Trigger': createSuccessfulNodeData(1),
+        'Multi-run Node': nodeData,
+        'Error Node': createErrorNodeData(),
+      },
+    });
+
+    const result = processErrorExecution(execution);
+
+    expect(result.additionalErrors).toContainEqual({
+      nodeName: 'Multi-run Node',
+      message: 'Second run failed',
+    });
+  });
+
+  it('should detect a primary error on a non-first run of the failing node', () => {
+    const nodeData = twoRunUpstreamNode();
+    (nodeData[1] as any).error = { message: 'Failed on second invocation', name: 'NodeOperationError' };
+
+    const execution = createMockExecution({
+      errorNode: 'Multi-run Error Node',
+      errorMessage: 'Failed on second invocation',
+      runData: {
+        'Trigger': createSuccessfulNodeData(1),
+        'Multi-run Error Node': nodeData,
+      },
+      hasExecutionError: false, // force fallback to node-level runData error
+    });
+
+    const result = processErrorExecution(execution);
+
+    expect(result.primaryError.message).toBe('Failed on second invocation');
+  });
+
+  it('should count itemCount across all runs in the execution path', () => {
+    const execution = createMockExecution({
+      runData: {
+        'Multi-run Node': twoRunUpstreamNode(),
+        'Error Node': createErrorNodeData(),
+      },
+    });
+
+    const result = processErrorExecution(execution, { includeExecutionPath: true });
+    const step = result.executionPath?.find(p => p.nodeName === 'Multi-run Node');
+
+    expect(step?.itemCount).toBe(2);
+    expect(step?.status).toBe('success');
+  });
+});

--- a/tests/unit/services/execution-processor.test.ts
+++ b/tests/unit/services/execution-processor.test.ts
@@ -815,3 +815,102 @@ describe('ExecutionProcessor - AI Agent sub-node connection types', () => {
     expect(nodeData?.itemsOutput).toBe(2);
   });
 });
+
+/**
+ * Multi-run node tests
+ *
+ * A node invoked more than once within a single execution (e.g. an AI
+ * Agent's Chat Model, called once to decide to call a tool and again to
+ * produce the final answer) gets one runData array entry per invocation.
+ * itemsInput/itemsOutput already summed across every run; the returned
+ * data itself must too, in run order.
+ */
+describe('ExecutionProcessor - multi-run nodes', () => {
+  function twoRunChatModel() {
+    return [
+      {
+        startTime: Date.now(),
+        executionTime: 500,
+        data: {
+          ai_languageModel: [[{ json: { text: 'first turn: deciding to call a tool', tokenUsage: { completionTokens: 56 } } }]],
+        },
+      },
+      {
+        startTime: Date.now() + 500,
+        executionTime: 1200,
+        data: {
+          ai_languageModel: [[{ json: { text: 'second turn: the real answer', tokenUsage: { completionTokens: 800 } } }]],
+        },
+      },
+    ];
+  }
+
+  it('should return items from every run, not just the first, in full mode', () => {
+    const execution = createMockExecution({
+      nodeData: { 'Chat Model': twoRunChatModel() },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'full' });
+    const nodeData = result.nodes?.['Chat Model'];
+    const flat = nodeData?.data?.output.flat() ?? [];
+
+    expect(nodeData?.itemsOutput).toBe(2);
+    expect(flat).toHaveLength(2);
+    expect(flat[0]?.json?.text).toBe('first turn: deciding to call a tool');
+    expect(flat[1]?.json?.text).toBe('second turn: the real answer');
+  });
+
+  it('should truncate across all runs in flat run order for summary/filtered mode', () => {
+    const execution = createMockExecution({
+      nodeData: { 'Chat Model': twoRunChatModel() },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'filtered', itemsLimit: 1 });
+    const nodeData = result.nodes?.['Chat Model'];
+    const flat = nodeData?.data?.output.flat() ?? [];
+
+    expect(nodeData?.itemsOutput).toBe(2);
+    expect(nodeData?.data?.metadata.truncated).toBe(true);
+    expect(flat).toHaveLength(1);
+    expect(flat[0]?.json?.text).toBe('first turn: deciding to call a tool');
+  });
+
+  it('should merge inputOverride across all runs too', () => {
+    const nodeData = twoRunChatModel();
+    (nodeData[0] as any).inputOverride = { ai_languageModel: [[{ json: { prompt: 'prompt 1' } }]] };
+    (nodeData[1] as any).inputOverride = { ai_languageModel: [[{ json: { prompt: 'prompt 2' } }]] };
+
+    const execution = createMockExecution({ nodeData: { 'Chat Model': nodeData } });
+    const result = filterExecutionData(execution, { mode: 'full', includeInputData: true });
+    const flatInput = result.nodes?.['Chat Model']?.data?.input?.flat() ?? [];
+
+    expect(flatInput).toHaveLength(2);
+    expect(flatInput[0]?.json?.prompt).toBe('prompt 1');
+    expect(flatInput[1]?.json?.prompt).toBe('prompt 2');
+  });
+
+  it('should detect an error on a non-first run', () => {
+    const nodeData = twoRunChatModel();
+    (nodeData[0] as any).error = undefined;
+    (nodeData[1] as any).error = { message: 'The AI model returned an empty response', name: 'NodeOperationError' };
+
+    const execution = createMockExecution({ nodeData: { 'Output Parser': nodeData } });
+    const result = filterExecutionData(execution, { mode: 'summary' });
+    const nodeResult = result.nodes?.['Output Parser'];
+
+    expect(nodeResult?.status).toBe('error');
+    expect(nodeResult?.error).toBe('The AI model returned an empty response');
+  });
+
+  it('should sample the first available item across runs in preview mode', () => {
+    const nodeData = twoRunChatModel();
+    // First run has no output at all; only the second run does.
+    (nodeData[0] as any).data = { ai_languageModel: [[]] };
+
+    const execution = createMockExecution({ nodeData: { 'Chat Model': nodeData } });
+    const { preview } = generatePreview(execution);
+
+    expect(preview.nodes['Chat Model'].itemCounts.output).toBe(1);
+    expect(preview.nodes['Chat Model'].dataStructure).toHaveProperty('json');
+  });
+});

--- a/tests/unit/services/execution-processor.test.ts
+++ b/tests/unit/services/execution-processor.test.ts
@@ -342,7 +342,9 @@ describe('ExecutionProcessor - Filtering', () => {
           {
             startTime: Date.now(),
             executionTime: 100,
-            inputData: [[{ json: { input: 'test' } }]],
+            inputOverride: {
+              main: [[{ json: { input: 'test' } }]],
+            },
             data: {
               main: [[{ json: { output: 'result' } }]],
             },
@@ -370,7 +372,9 @@ describe('ExecutionProcessor - Filtering', () => {
           {
             startTime: Date.now(),
             executionTime: 100,
-            inputData: [[{ json: { input: 'test' } }]],
+            inputOverride: {
+              main: [[{ json: { input: 'test' } }]],
+            },
             data: {
               main: [[{ json: { output: 'result' } }]],
             },
@@ -661,5 +665,153 @@ describe('ExecutionProcessor - Summary Statistics', () => {
     const result = filterExecutionData(execution, { mode: 'summary' });
 
     expect(result.summary?.totalItems).toBe(18);
+  });
+});
+
+/**
+ * AI Agent sub-node connection type tests
+ *
+ * LangChain AI Agent sub-nodes (Chat Model, Output Parser, Tool, Memory,
+ * Embeddings, etc.) connect to their parent Agent node via special `ai_*`
+ * connection types instead of `main`. Their task data therefore lives at
+ * `run.data.ai_languageModel`, `run.data.ai_outputParser`, `run.data.ai_tool`,
+ * etc. rather than `run.data.main`.
+ */
+describe('ExecutionProcessor - AI Agent sub-node connection types', () => {
+  it('should extract itemsOutput from ai_languageModel connection data', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'OpenAI Chat Model': [
+          {
+            startTime: Date.now(),
+            executionTime: 850,
+            data: {
+              ai_languageModel: [[{ json: { response: { generations: [[{ text: 'hi' }]] }, tokenUsage: { totalTokens: 42 } } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'full' });
+    const nodeData = result.nodes?.['OpenAI Chat Model'];
+
+    expect(nodeData?.itemsOutput).toBe(1);
+    expect(nodeData?.data?.output?.[0]?.[0]?.json?.tokenUsage?.totalTokens).toBe(42);
+  });
+
+  it('should extract itemsOutput from ai_outputParser connection data', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'Structured Output Parser': [
+          {
+            startTime: Date.now(),
+            executionTime: 5,
+            data: {
+              ai_outputParser: [[{ json: { output: { category: 'buyer_request' } } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'summary' });
+    const nodeData = result.nodes?.['Structured Output Parser'];
+
+    expect(nodeData?.itemsOutput).toBe(1);
+    expect(nodeData?.data?.output?.[0]?.[0]?.json?.output?.category).toBe('buyer_request');
+  });
+
+  it('should extract itemsOutput from ai_tool connection data', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'HTTP Request Tool': [
+          {
+            startTime: Date.now(),
+            executionTime: 200,
+            data: {
+              ai_tool: [[{ json: { result: 'tool output' } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'filtered', itemsLimit: -1 });
+    const nodeData = result.nodes?.['HTTP Request Tool'];
+
+    expect(nodeData?.itemsOutput).toBe(1);
+    expect(nodeData?.data?.output?.[0]?.[0]?.json?.result).toBe('tool output');
+  });
+
+  it('should include ai_* nodes in preview mode item counts and structure', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'OpenAI Chat Model': [
+          {
+            startTime: Date.now(),
+            executionTime: 850,
+            data: {
+              ai_languageModel: [[{ json: { tokenUsage: { totalTokens: 10 } } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const { preview } = generatePreview(execution);
+    const nodePreview = preview.nodes['OpenAI Chat Model'];
+
+    expect(nodePreview.itemCounts.output).toBe(1);
+    expect(nodePreview.dataStructure).toHaveProperty('json');
+  });
+
+  it('should extract input data from inputOverride for ai_* connection types', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'OpenAI Chat Model': [
+          {
+            startTime: Date.now(),
+            executionTime: 850,
+            inputOverride: {
+              ai_languageModel: [[{ json: { messages: ['System: hi'] } }]],
+            },
+            data: {
+              ai_languageModel: [[{ json: { tokenUsage: { totalTokens: 10 } } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'full', includeInputData: true });
+    const nodeData = result.nodes?.['OpenAI Chat Model'];
+
+    expect(nodeData?.itemsInput).toBe(1);
+    expect(nodeData?.data?.input?.[0]?.[0]?.json?.messages?.[0]).toBe('System: hi');
+  });
+
+  it('should not conflate ai_* and main data when both happen to be present', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'Mixed Node': [
+          {
+            startTime: Date.now(),
+            executionTime: 10,
+            data: {
+              main: [[{ json: { a: 1 } }]],
+              ai_tool: [[{ json: { b: 2 } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'full' });
+    const nodeData = result.nodes?.['Mixed Node'];
+
+    // Both branches should be counted/included since a node's task data
+    // could in principle populate more than one connection type.
+    expect(nodeData?.itemsOutput).toBe(2);
   });
 });


### PR DESCRIPTION
The execution processor (preview/summary/filtered/full/error modes)
only inspected run.data.main when extracting node input/output data.
Regular nodes connect via `main`, but LangChain AI Agent sub-nodes
(Chat Model, Output Parser, Tool, Memory, Embeddings, etc.) connect to
their parent Agent via special ai_* connection types instead
(ai_languageModel, ai_outputParser, ai_tool, ai_memory, ...). Their
task data lives at run.data.ai_languageModel etc., so every mode
silently returned itemsInput: 0, itemsOutput: 0, data.output: [] for
these nodes regardless of flags.

Also fixes includeInputData, which read a nonexistent `inputData`
field on the run - n8n actually stores this as `inputOverride`, keyed
by connection type the same way `data` is. This made includeInputData
a no-op for every node type, not only AI sub-nodes.

Both files now merge over every connection-type key present (main and
any ai_*) rather than hardcoding `main`, mirroring the same fix
pattern already used elsewhere in this repo for disconnected-node
detection (dynamic iteration over connection types instead of a fixed
list).

Verified against a live n8n Cloud execution with Chat Model, Output
Parser, Tool, and Memory sub-nodes: all four now report correct
itemsInput/itemsOutput/data across preview, summary, filtered, full,
and error modes.

**Update**: added a second fix (commit d227b54) for a related bug found while verifying the first one against live data.

Node-level counts (itemsInput/itemsOutput) already summed across every run of a node, but the code building the actual data.output/data.input arrays only ever read the first run. A node invoked more than once in a single execution — most commonly an AI Agent's Chat Model, called once to decide to call a tool and again to produce the final answer — has one runData entry per invocation, so every invocation after the first was silently dropped from the response while still being counted in the totals. Concretely: itemsOutput: 2 but data.output containing only the first, least useful turn, never the second (the actual answer, sometimes truncated by a max_tokens ceiling).

Fixed by merging across every run of a node (by branch/port index, in run order) instead of reading index 0, in both execution-processor.ts and error-execution-processor.ts. Error detection was extended the same way — an error on a later run is no longer invisible; this surfaced a genuine, previously-hidden error in live testing.

Note on full mode: for nodes invoked multiple times in one execution, full mode responses are now legitimately larger than before, since previously only the first invocation was ever returned (while claiming the correct total in metadata.totalItems). This is the bug being fixed, not new bloat — the size estimate that feeds the tool's preview/recommendation system already accounted for all runs before this fix, so nothing here changes what the tool recommends, only what you get if you explicitly request full anyway. summary/filtered modes remain hard-capped at itemsLimit exactly as before.