### PR TITLE
docs: sync skills pack to n8n-skills v1.27.0 (evaluations run/cancel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.67.1] - 2026-07-29
+
+### Changed
+
+- **Bundled skills pack synced to n8n-skills v1.27.0.** The pack still described `n8n_evaluations` as read-only and gated on n8n 2.30 only. The router one-liner, the tools-expert API list, and the WORKFLOW_GUIDE section now document the `run` and `cancel` actions that shipped in 2.67.0: per-action version gating (reads on 2.30+, run/cancel on 2.32+), the `testRun` scope and `workflow:execute` requirements, the 402/403/405/409 error semantics, and a warning to confirm with the user before starting a run, since a run executes the workflow against its whole dataset with real side effects.
+
 ## [2.67.0] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Bundled skills pack synced to n8n-skills v1.27.1.** The pack still described `n8n_evaluations` as read-only and gated on n8n 2.30 only. The router one-liner, the tools-expert API list, and the WORKFLOW_GUIDE section now document the `run` and `cancel` actions that shipped in 2.67.0: per-action version gating (reads on 2.30+, run/cancel on 2.32+), the `testRun` scope and `workflow:execute` requirements, the 402/403/405/409 error semantics, and a warning to confirm with the user before starting a run, since a run executes the workflow against its whole dataset with real side effects.
+- **Bundled skills pack synced to n8n-skills v1.27.2.** The pack still described `n8n_evaluations` as read-only and gated on n8n 2.30 only. The router one-liner, the tools-expert API list, and the WORKFLOW_GUIDE section now document the `run` and `cancel` actions that shipped in 2.67.0: per-action version gating (reads on 2.30+, run/cancel on 2.32+), the `testRun` scope and `workflow:execute` requirements, the 402/403/405/409 error semantics, and a warning to confirm with the user before starting a run, since a run executes the workflow against its whole dataset with real side effects.
 
 ## [2.67.0] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Bundled skills pack synced to n8n-skills v1.27.0.** The pack still described `n8n_evaluations` as read-only and gated on n8n 2.30 only. The router one-liner, the tools-expert API list, and the WORKFLOW_GUIDE section now document the `run` and `cancel` actions that shipped in 2.67.0: per-action version gating (reads on 2.30+, run/cancel on 2.32+), the `testRun` scope and `workflow:execute` requirements, the 402/403/405/409 error semantics, and a warning to confirm with the user before starting a run, since a run executes the workflow against its whole dataset with real side effects.
+- **Bundled skills pack synced to n8n-skills v1.27.1.** The pack still described `n8n_evaluations` as read-only and gated on n8n 2.30 only. The router one-liner, the tools-expert API list, and the WORKFLOW_GUIDE section now document the `run` and `cancel` actions that shipped in 2.67.0: per-action version gating (reads on 2.30+, run/cancel on 2.32+), the `testRun` scope and `workflow:execute` requirements, the 402/403/405/409 error semantics, and a warning to confirm with the user before starting a run, since a run executes the workflow against its whole dataset with real side effects.
 
 ## [2.67.0] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Bundled skills pack synced to n8n-skills v1.27.2.** The pack still described `n8n_evaluations` as read-only and gated on n8n 2.30 only. The router one-liner, the tools-expert API list, and the WORKFLOW_GUIDE section now document the `run` and `cancel` actions that shipped in 2.67.0: per-action version gating (reads on 2.30+, run/cancel on 2.32+), the `testRun` scope and `workflow:execute` requirements, the 402/403/405/409 error semantics, and a warning to confirm with the user before starting a run, since a run executes the workflow against its whole dataset with real side effects.
+- **Bundled skills pack synced to n8n-skills v1.27.3.** The pack still described `n8n_evaluations` as read-only and gated on n8n 2.30 only. The router one-liner, the tools-expert API list, and the WORKFLOW_GUIDE section now document the `run` and `cancel` actions that shipped in n8n-mcp 2.67.0: per-action version gating (reads on 2.30+, run/cancel on 2.32+), the `testRun` scope and `workflow:execute` requirements, the 402/403/405/409 error semantics, and a warning to confirm with the user before starting a run, since a run executes the workflow against its whole dataset with real side effects.
 
 ## [2.67.0] - 2026-07-29
 

--- a/data/skills/n8n-mcp-tools-expert/SKILL.md
+++ b/data/skills/n8n-mcp-tools-expert/SKILL.md
@@ -293,7 +293,7 @@ See [OPERATIONS_GUIDE.md](OPERATIONS_GUIDE.md) for examples.
 - n8n_list_workflows, n8n_get_workflow, n8n_delete_workflow
 - n8n_test_workflow
 - n8n_executions
-- n8n_evaluations (reads: n8n 2.30+; run/cancel: n8n 2.32+ — API key must be created on that version or later for the testRun scopes)
+- n8n_evaluations (reads: n8n 2.30+ with an API key created on 2.30+; run/cancel: n8n 2.32+ with a key created on 2.32+ — older keys lack the testRun scopes)
 - n8n_deploy_template
 - n8n_workflow_versions
 - n8n_autofix_workflow

--- a/data/skills/n8n-mcp-tools-expert/SKILL.md
+++ b/data/skills/n8n-mcp-tools-expert/SKILL.md
@@ -293,7 +293,7 @@ See [OPERATIONS_GUIDE.md](OPERATIONS_GUIDE.md) for examples.
 - n8n_list_workflows, n8n_get_workflow, n8n_delete_workflow
 - n8n_test_workflow
 - n8n_executions
-- n8n_evaluations (n8n 2.30+; read evaluation test runs — API key must be created on 2.30+ for testRun scopes)
+- n8n_evaluations (reads: n8n 2.30+; run/cancel: n8n 2.32+ — API key must be created on that version or later for the testRun scopes)
 - n8n_deploy_template
 - n8n_workflow_versions
 - n8n_autofix_workflow

--- a/data/skills/n8n-mcp-tools-expert/WORKFLOW_GUIDE.md
+++ b/data/skills/n8n-mcp-tools-expert/WORKFLOW_GUIDE.md
@@ -926,7 +926,7 @@ n8n_executions({
 
 **Use when**: Working with evaluation test runs — starting or cancelling a run, polling one in progress, comparing metrics across runs, pulling per-case results into a report or dashboard.
 
-Reads (`list_runs`/`get_run`/`list_cases`) require n8n >= 2.30; `run`/`cancel` require n8n >= 2.32. Either way the API key must be created on that version or later — older keys silently lack the `testRun` scopes, so a 403 means "re-create the API key", not a bug. For `run`/`cancel` a 403 can also mean the key's owner lacks `workflow:execute` on the workflow. Runs exist only for workflows with an evaluation trigger.
+Reads (`list_runs`/`get_run`/`list_cases`) require n8n >= 2.30 and an API key created on 2.30+; `run`/`cancel` require n8n >= 2.32 and a key created on 2.32+ — older keys silently lack the `testRun` scopes. A 403 has three causes: a key created before the action's minimum version (re-create it), evaluations not licensed on the plan, or — for `run`/`cancel` — the key's owner lacking `workflow:execute` on the workflow. Runs exist only for workflows with an evaluation trigger.
 
 ### List Test Runs
 ```javascript
@@ -990,7 +990,7 @@ n8n_evaluations({
 - Pre-2.32 instances answer `run` with 405 (the route exists, GET-only) and `cancel` with 404 (the route does not exist); the tool folds both into its upgrade guidance
 - 409 on `run` = the workflow has no evaluation trigger; 409 on `cancel` = the run already finished
 - 402 on `run` = the license's evaluation-run quota is exhausted
-- Evaluations are license/quota-gated in n8n — an instance without the feature simply has no runs
+- Evaluations are license/quota-gated in n8n — an unlicensed instance answers `run`/`cancel` with 403, and its reads have no runs to return
 - Compare `metrics` across runs of the same workflow to catch prompt/model regressions
 
 ---

--- a/data/skills/n8n-mcp-tools-expert/WORKFLOW_GUIDE.md
+++ b/data/skills/n8n-mcp-tools-expert/WORKFLOW_GUIDE.md
@@ -926,7 +926,7 @@ n8n_executions({
 
 **Use when**: Working with evaluation test runs — starting or cancelling a run, polling one in progress, comparing metrics across runs, pulling per-case results into a report or dashboard.
 
-Reads (`list_runs`/`get_run`/`list_cases`) require n8n >= 2.30 and an API key created on 2.30+; `run`/`cancel` require n8n >= 2.32 and a key created on 2.32+ — older keys silently lack the `testRun` scopes. A 403 has three causes: a key created before the action's minimum version (re-create it), evaluations not licensed on the plan, or — for `run`/`cancel` — the key's owner lacking `workflow:execute` on the workflow. Runs exist only for workflows with an evaluation trigger.
+Reads (`list_runs`/`get_run`/`list_cases`) require n8n >= 2.30 and an API key created on 2.30+; `run`/`cancel` require n8n >= 2.32 and a key created on 2.32+ — older keys silently lack the `testRun` scopes. A 403 can mean: a key created before the action's minimum version (re-create it), evaluations not licensed on the plan, or the key's owner lacking access to the workflow — for `run`/`cancel`, specifically the `workflow:execute` scope. Runs exist only for workflows with an evaluation trigger.
 
 ### List Test Runs
 ```javascript

--- a/data/skills/n8n-mcp-tools-expert/WORKFLOW_GUIDE.md
+++ b/data/skills/n8n-mcp-tools-expert/WORKFLOW_GUIDE.md
@@ -981,12 +981,13 @@ n8n_evaluations({
   workflowId: "workflow-id",
   runId: "run-id"
 })
-// → accepted; the run moves to status "cancelled"
+// → {id, status: "cancelled"} plus a note: in-flight cases stop
+// asynchronously — confirm with get_run that the run reached "cancelled"
 ```
 
 **Gotchas**:
 - A 404 can mean three things: the instance predates the action's minimum version, the workflowId is wrong, or the runId belongs to a different workflow (the tool's error message disambiguates using the instance version when it can read it)
-- Pre-2.32 instances answer `run`/`cancel` with 405, not 404 — the route exists but only accepts GET; the tool maps this to an upgrade hint
+- Pre-2.32 instances answer `run` with 405 (the route exists, GET-only) and `cancel` with 404 (the route does not exist); the tool folds both into its upgrade guidance
 - 409 on `run` = the workflow has no evaluation trigger; 409 on `cancel` = the run already finished
 - 402 on `run` = the license's evaluation-run quota is exhausted
 - Evaluations are license/quota-gated in n8n — an instance without the feature simply has no runs

--- a/data/skills/n8n-mcp-tools-expert/WORKFLOW_GUIDE.md
+++ b/data/skills/n8n-mcp-tools-expert/WORKFLOW_GUIDE.md
@@ -924,9 +924,9 @@ n8n_executions({
 
 ## n8n_evaluations (EVALUATION TEST RUNS)
 
-**Use when**: Reading evaluation test runs — polling a run started in the editor, comparing metrics across runs, pulling per-case results into a report or dashboard.
+**Use when**: Working with evaluation test runs — starting or cancelling a run, polling one in progress, comparing metrics across runs, pulling per-case results into a report or dashboard.
 
-Read-only. Requires n8n >= 2.30 **and an API key created on 2.30+** — keys created earlier silently lack the `testRun` scopes, so a 403 means "re-create the API key", not a bug. Runs exist only for workflows with an evaluation trigger that have been run from the n8n editor; triggering runs via the public API is not yet supported by n8n (planned upstream, will arrive as `run`/`cancel` actions).
+Reads (`list_runs`/`get_run`/`list_cases`) require n8n >= 2.30; `run`/`cancel` require n8n >= 2.32. Either way the API key must be created on that version or later — older keys silently lack the `testRun` scopes, so a 403 means "re-create the API key", not a bug. For `run`/`cancel` a 403 can also mean the key's owner lacks `workflow:execute` on the workflow. Runs exist only for workflows with an evaluation trigger.
 
 ### List Test Runs
 ```javascript
@@ -962,8 +962,33 @@ n8n_evaluations({
 // with n8n_executions({action: "get", id: executionId, mode: "error"})
 ```
 
+### Start a Run
+```javascript
+n8n_evaluations({
+  action: "run",
+  workflowId: "workflow-id"
+})
+// → {id, status: "new", createdAt} — poll with get_run until completed
+```
+`run` executes the workflow once per dataset row — real nodes fire (HTTP calls,
+DB writes, sends) and LLM metric calls cost money. Ask the user before starting
+a run, especially against a large dataset.
+
+### Cancel a Run
+```javascript
+n8n_evaluations({
+  action: "cancel",
+  workflowId: "workflow-id",
+  runId: "run-id"
+})
+// → accepted; the run moves to status "cancelled"
+```
+
 **Gotchas**:
-- A 404 can mean three things: the instance predates 2.30, the workflowId is wrong, or the runId belongs to a different workflow (the tool's error message disambiguates using the instance version)
+- A 404 can mean three things: the instance predates the action's minimum version, the workflowId is wrong, or the runId belongs to a different workflow (the tool's error message disambiguates using the instance version when it can read it)
+- Pre-2.32 instances answer `run`/`cancel` with 405, not 404 — the route exists but only accepts GET; the tool maps this to an upgrade hint
+- 409 on `run` = the workflow has no evaluation trigger; 409 on `cancel` = the run already finished
+- 402 on `run` = the license's evaluation-run quota is exhausted
 - Evaluations are license/quota-gated in n8n — an instance without the feature simply has no runs
 - Compare `metrics` across runs of the same workflow to catch prompt/model regressions
 
@@ -1072,7 +1097,7 @@ update → update → update → ... (56s avg between edits)
 - `n8n_workflow_versions` - Version control & rollback
 - `n8n_test_workflow` - Trigger execution
 - `n8n_executions` - Manage executions
-- `n8n_evaluations` - Read evaluation test runs (n8n 2.30+, read-only)
+- `n8n_evaluations` - Evaluation test runs: reads (n8n 2.30+), run/cancel (n8n 2.32+)
 - `n8n_manage_datatable` - Data table and row management
 - `n8n_manage_credentials` - Credential CRUD + schema discovery
 - `n8n_audit_instance` - Security audit (built-in + custom scan)

--- a/data/skills/using-n8n-mcp-skills/SKILL.md
+++ b/data/skills/using-n8n-mcp-skills/SKILL.md
@@ -131,7 +131,7 @@ closes the gap where a tool's full description isn't loaded until first use.
 **Test & run**
 - `n8n_test_workflow` — runs real nodes (Code, HTTP, DB writes, sends all fire). Ask the user before running when side effects exist.
 - `n8n_executions` — list/inspect executions. **There is no `execute_workflow` tool.**
-- `n8n_evaluations` — evaluation test runs: list runs, aggregated metrics, per-case results (n8n ≥ 2.30), plus `run`/`cancel` to start or stop a run (n8n ≥ 2.32). `run` executes the workflow against its whole dataset — real nodes fire, so ask the user first. A 403 usually means the API key predates the feature (re-create it for the testRun scopes); for `run`/`cancel` it can also mean the key's owner lacks `workflow:execute` on the workflow.
+- `n8n_evaluations` — evaluation test runs: list runs, aggregated metrics, per-case results (n8n ≥ 2.30), plus `run`/`cancel` to start or stop a run (n8n ≥ 2.32). `run` executes the workflow against its whole dataset — real nodes fire, so ask the user first. A 403 means the API key was created before the action's minimum version (re-create it for the testRun scopes), evaluations aren't licensed on the plan, or — for `run`/`cancel` — the key's owner lacks `workflow:execute` on the workflow.
 
 **Data, credentials, audit**
 - `n8n_manage_datatable` — Data Table CRUD, filtering, dry-run.

--- a/data/skills/using-n8n-mcp-skills/SKILL.md
+++ b/data/skills/using-n8n-mcp-skills/SKILL.md
@@ -131,7 +131,7 @@ closes the gap where a tool's full description isn't loaded until first use.
 **Test & run**
 - `n8n_test_workflow` — runs real nodes (Code, HTTP, DB writes, sends all fire). Ask the user before running when side effects exist.
 - `n8n_executions` — list/inspect executions. **There is no `execute_workflow` tool.**
-- `n8n_evaluations` — evaluation test runs: list runs, aggregated metrics, per-case results (n8n ≥ 2.30), plus `run`/`cancel` to start or stop a run (n8n ≥ 2.32). `run` executes the workflow against its whole dataset — real nodes fire, so ask the user first. A 403 means the API key was created before the action's minimum version (re-create it for the testRun scopes), evaluations aren't licensed on the plan, or — for `run`/`cancel` — the key's owner lacks `workflow:execute` on the workflow.
+- `n8n_evaluations` — evaluation test runs: list runs, aggregated metrics, per-case results (n8n ≥ 2.30), plus `run`/`cancel` to start or stop a run (n8n ≥ 2.32). `run` executes the workflow against its whole dataset — real nodes fire, so ask the user first. A 403 can mean the API key was created before the action's minimum version (re-create it for the testRun scopes), evaluations aren't licensed on the plan, or the key's owner lacks access to the workflow — for `run`/`cancel`, specifically the `workflow:execute` scope.
 
 **Data, credentials, audit**
 - `n8n_manage_datatable` — Data Table CRUD, filtering, dry-run.

--- a/data/skills/using-n8n-mcp-skills/SKILL.md
+++ b/data/skills/using-n8n-mcp-skills/SKILL.md
@@ -131,7 +131,7 @@ closes the gap where a tool's full description isn't loaded until first use.
 **Test & run**
 - `n8n_test_workflow` — runs real nodes (Code, HTTP, DB writes, sends all fire). Ask the user before running when side effects exist.
 - `n8n_executions` — list/inspect executions. **There is no `execute_workflow` tool.**
-- `n8n_evaluations` — read evaluation test runs (n8n ≥ 2.30): list runs, aggregated metrics, per-case results. Read-only — runs are started from the n8n editor, not the API; a 403 usually means the API key predates 2.30 (re-create it for the testRun scopes).
+- `n8n_evaluations` — evaluation test runs: list runs, aggregated metrics, per-case results (n8n ≥ 2.30), plus `run`/`cancel` to start or stop a run (n8n ≥ 2.32). `run` executes the workflow against its whole dataset — real nodes fire, so ask the user first. A 403 usually means the API key predates the feature (re-create it for the testRun scopes); for `run`/`cancel` it can also mean the key's owner lacks `workflow:execute` on the workflow.
 
 **Data, credentials, audit**
 - `n8n_manage_datatable` — Data Table CRUD, filtering, dry-run.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.67.0",
+  "version": "2.67.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.67.0",
+      "version": "2.67.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.67.0",
+  "version": "2.67.1",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/integration/n8n-api/executions/get-execution.test.ts
+++ b/tests/integration/n8n-api/executions/get-execution.test.ts
@@ -75,7 +75,7 @@ describe('Integration: handleGetExecution', () => {
 
       // Should have basic execution info
       if (data.status) {
-        expect(['success', 'error', 'running', 'waiting']).toContain(data.status);
+        expect(['success', 'error', 'running', 'waiting', 'canceled', 'crashed', 'new', 'unknown']).toContain(data.status);
       }
     });
   });

--- a/tests/integration/n8n-api/executions/list-executions.test.ts
+++ b/tests/integration/n8n-api/executions/list-executions.test.ts
@@ -255,7 +255,7 @@ describe('Integration: handleListExecutions', () => {
         expect(execution).toHaveProperty('id');
 
         if (execution.status) {
-          expect(['success', 'error', 'running', 'waiting']).toContain(execution.status);
+          expect(['success', 'error', 'running', 'waiting', 'canceled', 'crashed', 'new', 'unknown']).toContain(execution.status);
         }
       }
     });


### PR DESCRIPTION
## Summary

Syncs the bundled skills pack (`data/skills/`) to **n8n-skills v1.27.3** (czlonkowski/n8n-skills@408670d). Follow-up to #963: four spots in the pack still described `n8n_evaluations` as read-only and n8n-2.30-only after the `run`/`cancel` actions shipped in v2.67.0.

## Changes

Docs/data only — no source changes.

- `data/skills/using-n8n-mcp-skills/SKILL.md` — router one-liner now covers `run`/`cancel` (n8n ≥ 2.32), the side-effect warning, and the two 403 causes (stale key vs missing `workflow:execute`).
- `data/skills/n8n-mcp-tools-expert/SKILL.md` — API-tools list entry states per-action version gating.
- `data/skills/n8n-mcp-tools-expert/WORKFLOW_GUIDE.md` — evaluations section gains Start/Cancel examples, per-action gating, and the live-verified error semantics (405 on pre-2.32 routes, 409 no-eval-trigger / already-finished, 402 quota); summary list entry updated.
- `tests/integration/n8n-api/executions/` — the two status assertions now accept n8n's full execution-status vocabulary. The live test instance holds a `canceled` execution (left by #963's cancel smoke test), which failed the old success/error/running/waiting allow-list on unrelated runs.
- `package.json` / `package-lock.json` / `CHANGELOG.md` — v2.67.1 so the corrected pack ships to npm/Docker users.

Content matches the behavior live-verified on n8n 2.32.6 during #963's smoke tests.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)




