### PR TITLE
fix: store every node of multi-node community packages (#967)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.67.2] - 2026-07-29
+
+### Fixed
+
+- **The community npm sync stores every node a package ships (#967).** The sync stored exactly one row per npm package — the first parseable `n8n.nodes` manifest entry — so multi-node packages lost the rest: `@custom-js/n8n-nodes-pdf-toolkit` declares 18 nodes and the database held one. The sync now stores one row per manifest entry, sharing the package's README and AI summary across siblings, with trigger/webhook detection reading each node's own name instead of the package name (the package's trigger node was previously invisible, and a `*-trigger` package name used to mark every sibling a trigger). The v2.66.3 stale-row self-heal becomes a set-diff that still touches only unverified community rows, the save-prune-seed sequence runs in one transaction, and a package whose package.json cannot be fetched is skipped untouched instead of collapsing to a single heuristic row — a transient registry failure previously became data loss. Shared AI summaries are prompted with the package's node list rather than one sibling's identity, fetch statistics report packages and node rows separately, and the bundled database is refreshed with the recovered sibling nodes.
+
 ## [2.67.1] - 2026-07-29
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.67.1",
+  "version": "2.67.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.67.1",
+      "version": "2.67.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.67.1",
+  "version": "2.67.2",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/community/community-node-service.ts
+++ b/src/community/community-node-service.ts
@@ -22,9 +22,16 @@ export interface SyncResult {
     errors: string[];
   };
   npm: {
+    /** Packages returned by the registry search */
     fetched: number;
+    /** Packages written */
     saved: number;
+    /** Packages left untouched */
     skipped: number;
+    /** Rows written — a package can ship several nodes */
+    nodesSaved: number;
+    /** Rows dropped because the package no longer declares them */
+    nodesRemoved: number;
     errors: string[];
   };
   duration: number;
@@ -47,6 +54,30 @@ export interface SyncOptions {
  * registry must not stretch a sync of hundreds of packages by hours.
  */
 const NPM_MANIFEST_FETCH = { maxRetries: 1, timeout: 5000 } as const;
+
+/**
+ * Upper bound on the rows a single npm package may contribute. The manifest is
+ * arbitrary third-party input; a package declaring thousands of entries would
+ * otherwise fill the shipped database and overrun SQLite's variable limit in the
+ * set-diff.
+ */
+const MAX_NODES_PER_PACKAGE = 100;
+
+/**
+ * Where an npm package's node names came from.
+ * - `manifest`: parsed from the package's own `n8n.nodes` array — authoritative.
+ * - `fallback`: package.json was read but declares no usable node entry, so the
+ *   names are the package-name heuristic.
+ * - `unavailable`: package.json could not be read at all. The names are the same
+ *   heuristic, but nothing about the package's real nodes is known, so stored
+ *   rows must not be re-keyed against them.
+ */
+type NpmNodeNameSource = 'manifest' | 'fallback' | 'unavailable';
+
+interface ResolvedNpmNodeNames {
+  names: string[];
+  source: NpmNodeNameSource;
+}
 
 /**
  * Derive a node name from an n8n node entry point declared in package.json.
@@ -97,7 +128,7 @@ export class CommunityNodeService {
     const startTime = Date.now();
     const result: SyncResult = {
       verified: { fetched: 0, saved: 0, skipped: 0, errors: [] },
-      npm: { fetched: 0, saved: 0, skipped: 0, errors: [] },
+      npm: { fetched: 0, saved: 0, skipped: 0, nodesSaved: 0, nodesRemoved: 0, errors: [] },
       duration: 0,
     };
 
@@ -125,7 +156,8 @@ export class CommunityNodeService {
     result.duration = Date.now() - startTime;
     logger.info(
       `Community node sync complete in ${(result.duration / 1000).toFixed(1)}s: ` +
-        `${result.verified.saved} verified, ${result.npm.saved} npm`
+        `${result.verified.saved} verified, ` +
+        `${result.npm.nodesSaved} npm node(s) from ${result.npm.saved} package(s)`
     );
 
     return result;
@@ -199,7 +231,14 @@ export class CommunityNodeService {
     progressCallback?: (message: string, current: number, total: number) => void,
     skipExisting?: boolean
   ): Promise<SyncResult['npm']> {
-    const result = { fetched: 0, saved: 0, skipped: 0, errors: [] as string[] };
+    const result = {
+      fetched: 0,
+      saved: 0,
+      skipped: 0,
+      nodesSaved: 0,
+      nodesRemoved: 0,
+      errors: [] as string[],
+    };
 
     // Fetch npm packages
     const npmPackages = await this.fetcher.fetchNpmPackages(limit, progressCallback);
@@ -232,29 +271,52 @@ export class CommunityNodeService {
           continue;
         }
 
-        const existing = this.repository.getNodeByNpmPackage(packageName);
+        const existingRows = this.repository.getNodesByNpmPackage(packageName);
+        const resolved = await this.resolveNpmNodeNames(packageName, pkg.package.version);
 
-        // For npm packages, we create a basic node entry with metadata
-        // Full schema extraction would require downloading and parsing the tarball
-        const parsedNode = await this.npmPackageToParsedNode(pkg);
-        const staleRow = this.staleCommunityRow(existing, parsedNode.nodeType);
-
-        // Skip if already exists and skipExisting is true. A row keyed by an
-        // outdated node type is the one case that must not be skipped — only a
-        // re-key corrects it.
-        if (skipExisting && existing && !staleRow) {
+        // A registry miss yields the package-name heuristic, which says nothing
+        // about the nodes the package actually ships. Re-keying stored rows
+        // against it would delete correct rows and reinstate a fabricated type
+        // (#949), so leave the package alone until a manifest can be read.
+        if (resolved.source === 'unavailable' && existingRows.length > 0) {
+          logger.warn(
+            `Skipping ${packageName}: package.json unavailable, keeping ${existingRows.length} stored row(s)`
+          );
           result.skipped++;
           continue;
         }
 
-        // Save to database
-        this.repository.saveNode(parsedNode);
+        // For npm packages, we create a basic node entry with metadata
+        // Full schema extraction would require downloading and parsing the tarball
+        const parsedNodes = this.npmPackageToParsedNodes(pkg, resolved);
+        const nodeTypes = parsedNodes.map((node) => node.nodeType);
+        const staleRows = this.staleCommunityRows(existingRows, nodeTypes);
 
-        if (staleRow) {
-          this.replaceStaleCommunityRow(packageName, staleRow, parsedNode.nodeType);
+        // Skip if already exists and skipExisting is true. Stored rows that no
+        // longer match the resolved set are the one case that must not be
+        // skipped — only a re-sync corrects them.
+        const upToDate =
+          existingRows.length > 0 && !this.rowsOutOfSync(existingRows, nodeTypes, staleRows);
+        if (skipExisting && upToDate) {
+          result.skipped++;
+          continue;
         }
 
+        // One package, one unit of work: a partial write would leave both the new
+        // and the stale rows in search results, and rows saved without their docs
+        // look current to the next --update run.
+        this.repository.transaction(() => {
+          for (const parsedNode of parsedNodes) {
+            this.repository.saveNode(parsedNode);
+          }
+
+          this.pruneStaleCommunityRows(packageName, staleRows, nodeTypes);
+          this.carryOverPackageDocs(existingRows, nodeTypes);
+        });
+
         result.saved++;
+        result.nodesSaved += parsedNodes.length;
+        result.nodesRemoved += staleRows.length;
 
         if (progressCallback) {
           progressCallback(`Saving npm packages`, result.saved + result.skipped, npmPackages.length);
@@ -264,7 +326,10 @@ export class CommunityNodeService {
       }
     }
 
-    logger.info(`npm packages: ${result.saved} saved, ${result.skipped} skipped`);
+    logger.info(
+      `npm packages: ${result.saved} saved (${result.nodesSaved} node row(s), ` +
+        `${result.nodesRemoved} removed), ${result.skipped} skipped`
+    );
     return result;
   }
 
@@ -346,20 +411,24 @@ export class CommunityNodeService {
   }
 
   /**
-   * Convert npm package info to basic ParsedNode.
-   * Note: This is a minimal entry - full schema requires tarball parsing.
+   * Convert npm package info to one basic ParsedNode per node the package ships.
+   * Note: These are minimal entries - full schema requires tarball parsing.
+   * Everything except the node name and type is package-level and shared.
    */
-  private async npmPackageToParsedNode(
-    pkg: NpmSearchResult
-  ): Promise<ParsedNode & CommunityNodeFields> {
+  private npmPackageToParsedNodes(
+    pkg: NpmSearchResult,
+    resolved: ResolvedNpmNodeNames
+  ): (ParsedNode & CommunityNodeFields)[] {
     const { package: pkgInfo, score } = pkg;
 
-    const nodeName = await this.resolveNpmNodeName(pkgInfo.name, pkgInfo.version);
-    const nodeType = `${pkgInfo.name}.${nodeName}`;
+    // Once a package resolves to several nodes, each row's own name is the only
+    // signal that tells them apart — the package name would flag every row of
+    // n8n-nodes-foo-trigger as a trigger. A single row keeps both signals.
+    const perNodeSignal = resolved.names.length > 1;
 
-    return {
+    return resolved.names.map((nodeName) => ({
       // Core ParsedNode fields (minimal - no schema available)
-      nodeType,
+      nodeType: `${pkgInfo.name}.${nodeName}`,
       packageName: pkgInfo.name,
       displayName: nodeName,
       description: pkgInfo.description || `Community node from ${pkgInfo.name}`,
@@ -369,8 +438,8 @@ export class CommunityNodeService {
       credentials: [],
       operations: [],
       isAITool: false,
-      isTrigger: pkgInfo.name.includes('trigger'),
-      isWebhook: pkgInfo.name.includes('webhook'),
+      isTrigger: this.matchesRole(pkgInfo.name, nodeName, 'trigger', perNodeSignal),
+      isWebhook: this.matchesRole(pkgInfo.name, nodeName, 'webhook', perNodeSignal),
       isVersioned: false,
       // No descriptor available without parsing the npm tarball — declarative community
       // nodes default to typeVersion 1 at runtime when version isn't declared.
@@ -386,7 +455,24 @@ export class CommunityNodeService {
       npmVersion: pkgInfo.version,
       npmDownloads: Math.round(score.detail.popularity * 10000), // Approximate
       communityFetchedAt: new Date().toISOString(),
-    };
+    }));
+  }
+
+  /**
+   * Decide whether an npm-only node plays a role (trigger, webhook) from the
+   * names available. Only the node's own name counts once the package resolves
+   * to several nodes; see npmPackageToParsedNodes.
+   */
+  private matchesRole(
+    packageName: string,
+    nodeName: string,
+    role: string,
+    perNodeSignal: boolean
+  ): boolean {
+    if (nodeName.toLowerCase().includes(role)) {
+      return true;
+    }
+    return perNodeSignal ? false : packageName.includes(role);
   }
 
   /**
@@ -415,75 +501,125 @@ export class CommunityNodeService {
   }
 
   /**
-   * A stored row is stale when this sync resolves a different node type for the
-   * same npm package, which happens for packages saved under the fabricated
-   * package-name type (#949). Verified rows carry the real node name from
-   * Strapi and are never re-keyed.
+   * The stored rows for a package are out of sync when this sync resolves a node
+   * type the package has no row for, or when an unverified row is keyed by a type
+   * the package no longer declares — the shape left behind by the fabricated
+   * package-name types (#949) and by the one-row-per-package sync (#967).
+   * Verified rows carry the real node name from Strapi and are never re-keyed.
    */
-  private staleCommunityRow(existing: any, nodeType: string): any | undefined {
-    if (!existing || !existing.isCommunity || existing.isVerified) {
-      return undefined;
-    }
-    return existing.nodeType && existing.nodeType !== nodeType ? existing : undefined;
+  private rowsOutOfSync(existingRows: any[], nodeTypes: string[], staleRows: any[]): boolean {
+    const storedTypes = new Set(existingRows.map((row) => row.nodeType));
+    return nodeTypes.some((nodeType) => !storedTypes.has(nodeType)) || staleRows.length > 0;
   }
 
-  /**
-   * Drop the rows this package no longer resolves to and carry the generated
-   * documentation over to the new row, which saveNode could not preserve
-   * because preservation is keyed by node type.
-   */
-  private replaceStaleCommunityRow(packageName: string, staleRow: any, nodeType: string): void {
-    const removed = this.repository.deleteStaleCommunityNodes(packageName, nodeType);
-    logger.info(
-      `Re-keyed ${packageName}: "${staleRow.nodeType}" -> "${nodeType}" (${removed} outdated row(s) removed)`
+  private staleCommunityRows(existingRows: any[], nodeTypes: string[]): any[] {
+    const keep = new Set(nodeTypes);
+    return existingRows.filter(
+      (row) => row.isCommunity && !row.isVerified && row.nodeType && !keep.has(row.nodeType)
     );
+  }
 
-    if (staleRow.npmReadme) {
-      this.repository.updateNodeReadme(nodeType, staleRow.npmReadme);
+  /**
+   * Drop the rows this package no longer resolves to.
+   */
+  private pruneStaleCommunityRows(
+    packageName: string,
+    staleRows: any[],
+    nodeTypes: string[]
+  ): void {
+    if (staleRows.length === 0) {
+      return;
     }
-    if (staleRow.aiDocumentationSummary) {
-      this.repository.updateNodeAISummary(nodeType, staleRow.aiDocumentationSummary);
+
+    this.repository.deleteStaleCommunityNodes(packageName, nodeTypes);
+    // Report the rows matched in the pre-delete snapshot: the sql.js adapter does
+    // not return a real change count.
+    logger.info(
+      `${packageName}: removed ${staleRows.length} row(s) the package no longer declares ` +
+        `(${staleRows.map((row) => row.nodeType).join(', ')})`
+    );
+  }
+
+  /**
+   * Documentation is generated per package but stored per row, so a row this sync
+   * re-keyed or added arrives empty — saveNode only preserves docs under the same
+   * node type. Seed those rows from whatever the package already had.
+   */
+  private carryOverPackageDocs(existingRows: any[], nodeTypes: string[]): void {
+    const readme = existingRows.find((row) => row.npmReadme)?.npmReadme;
+    const summary = existingRows.find((row) => row.aiDocumentationSummary)?.aiDocumentationSummary;
+    if (!readme && !summary) {
+      return;
+    }
+
+    const storedByType = new Map(existingRows.map((row) => [row.nodeType, row]));
+    for (const nodeType of nodeTypes) {
+      const stored = storedByType.get(nodeType);
+      if (readme && !stored?.npmReadme) {
+        this.repository.updateNodeReadme(nodeType, readme);
+      }
+      if (summary && !stored?.aiDocumentationSummary) {
+        this.repository.updateNodeAISummary(nodeType, summary);
+      }
     }
   }
 
   /**
-   * Resolve the node name for an npm-only package.
+   * Resolve the node names for an npm-only package.
    *
    * The package.json `n8n.nodes` array lists the package's node entry points
    * (e.g. "dist/nodes/GlobalConstants/GlobalConstants.node.js"), which carry the
-   * real node name. Deriving it from the package name instead fabricated node
-   * types that do not exist in n8n (#949).
-   *
-   * Only the first entry is used: the npm path stores one row per package.
+   * real node names. Deriving them from the package name instead fabricated node
+   * types that do not exist in n8n (#949); using only the first entry hid every
+   * other node a package ships (#967).
    */
-  private async resolveNpmNodeName(packageName: string, version?: string): Promise<string> {
-    let entries: unknown[] = [];
+  private async resolveNpmNodeNames(
+    packageName: string,
+    version?: string
+  ): Promise<ResolvedNpmNodeNames> {
+    let packageJson: any = null;
 
     try {
-      const packageJson = await this.fetcher.fetchPackageJson(
-        packageName,
-        version,
-        NPM_MANIFEST_FETCH
-      );
-      if (Array.isArray(packageJson?.n8n?.nodes)) {
-        entries = packageJson.n8n.nodes;
-      }
+      packageJson = await this.fetcher.fetchPackageJson(packageName, version, NPM_MANIFEST_FETCH);
     } catch (error: any) {
       logger.warn(`Could not fetch package.json for ${packageName}: ${error.message}`);
     }
 
+    const fallback = this.extractNodeNameFromPackage(packageName);
+
+    // fetchPackageJson resolves to null once every attempt failed, so a registry
+    // miss is not always a thrown error.
+    if (!packageJson) {
+      logger.warn(
+        `Could not read package.json for ${packageName}, falling back to the package-name heuristic: "${fallback}"`
+      );
+      return { names: [fallback], source: 'unavailable' };
+    }
+
+    const entries: unknown[] = Array.isArray(packageJson?.n8n?.nodes) ? packageJson.n8n.nodes : [];
+    const nodeNames = new Set<string>();
     for (const entry of entries) {
       const nodeName = typeof entry === 'string' ? extractNodeNameFromEntryPath(entry) : undefined;
       if (nodeName) {
-        return nodeName;
+        nodeNames.add(nodeName);
       }
     }
 
-    const fallback = this.extractNodeNameFromPackage(packageName);
+    if (nodeNames.size > 0) {
+      const names = [...nodeNames];
+      if (names.length > MAX_NODES_PER_PACKAGE) {
+        logger.warn(
+          `${packageName} declares ${names.length} nodes, storing the first ${MAX_NODES_PER_PACKAGE}`
+        );
+        names.length = MAX_NODES_PER_PACKAGE;
+      }
+      return { names, source: 'manifest' };
+    }
+
     logger.warn(
       `No usable n8n.nodes entry for ${packageName}, falling back to the package-name heuristic: "${fallback}"`
     );
-    return fallback;
+    return { names: [fallback], source: 'fallback' };
   }
 
   /**
@@ -494,7 +630,7 @@ export class CommunityNodeService {
    *
    * Note: We use lowercase because most community nodes follow this convention.
    * Verified nodes from Strapi have the correct casing in nodeDesc.name.
-   * Only a fallback — see resolveNpmNodeName.
+   * Only a fallback — see resolveNpmNodeNames.
    */
   private extractNodeNameFromPackage(packageName: string): string {
     // Remove scope if present

--- a/src/community/community-node-service.ts
+++ b/src/community/community-node-service.ts
@@ -305,18 +305,19 @@ export class CommunityNodeService {
         // One package, one unit of work: a partial write would leave both the new
         // and the stale rows in search results, and rows saved without their docs
         // look current to the next --update run.
-        this.repository.transaction(() => {
+        const removed = this.repository.transaction(() => {
           for (const parsedNode of parsedNodes) {
             this.repository.saveNode(parsedNode);
           }
 
-          this.pruneStaleCommunityRows(packageName, staleRows, nodeTypes);
+          const pruned = this.pruneStaleCommunityRows(packageName, staleRows, nodeTypes);
           this.carryOverPackageDocs(existingRows, nodeTypes);
+          return pruned;
         });
 
         result.saved++;
         result.nodesSaved += parsedNodes.length;
-        result.nodesRemoved += staleRows.length;
+        result.nodesRemoved += removed;
 
         if (progressCallback) {
           progressCallback(`Saving npm packages`, result.saved + result.skipped, npmPackages.length);
@@ -520,24 +521,23 @@ export class CommunityNodeService {
   }
 
   /**
-   * Drop the rows this package no longer resolves to.
+   * Drop the rows this package no longer resolves to, returning how many went.
    */
   private pruneStaleCommunityRows(
     packageName: string,
     staleRows: any[],
     nodeTypes: string[]
-  ): void {
+  ): number {
     if (staleRows.length === 0) {
-      return;
+      return 0;
     }
 
-    this.repository.deleteStaleCommunityNodes(packageName, nodeTypes);
-    // Report the rows matched in the pre-delete snapshot: the sql.js adapter does
-    // not return a real change count.
+    const removed = this.repository.deleteStaleCommunityNodes(packageName, nodeTypes);
     logger.info(
-      `${packageName}: removed ${staleRows.length} row(s) the package no longer declares ` +
+      `${packageName}: removed ${removed} row(s) the package no longer declares ` +
         `(${staleRows.map((row) => row.nodeType).join(', ')})`
     );
+    return removed;
   }
 
   /**

--- a/src/community/documentation-batch-processor.ts
+++ b/src/community/documentation-batch-processor.ts
@@ -168,10 +168,11 @@ export class DocumentationBatchProcessor {
       return { fetched: 0, failed: 0, skipped: 0, errors: [] };
     }
 
-    // Get package names
-    const packageNames = nodes
-      .map((n) => n.npmPackageName)
-      .filter((name): name is string => !!name);
+    // Get package names. READMEs are package-level, so the rows of a multi-node
+    // package resolve to a single fetch (#967).
+    const packageNames = [
+      ...new Set(nodes.map((n) => n.npmPackageName).filter((name): name is string => !!name)),
+    ];
 
     // Fetch READMEs in batches
     const readmeMap = await this.fetcher.fetchReadmesBatch(
@@ -245,14 +246,38 @@ export class DocumentationBatchProcessor {
 
     logger.info(`LLM connection successful: ${connectionTest.message}`);
 
-    // Prepare inputs for batch generation
-    const inputs: DocumentationInput[] = nodes.map((node) => ({
-      nodeType: node.nodeType,
-      displayName: node.displayName,
-      description: node.description,
-      readme: node.npmReadme || '',
-      npmPackageName: node.npmPackageName,
-    }));
+    // The rows of a multi-node package share one README, so summarising each row
+    // would repeat the same LLM call. Generate once per package and fan the
+    // result out to its rows (#967).
+    const packageGroups = new Map<string, any[]>();
+    for (const node of nodes) {
+      const key = node.npmPackageName || node.nodeType;
+      const group = packageGroups.get(key);
+      if (group) {
+        group.push(node);
+      } else {
+        packageGroups.set(key, [node]);
+      }
+    }
+
+    // Prepare inputs for batch generation - one per package, keyed by the
+    // representative row's node type so results map back to their group. The
+    // prompt gets the package's node names, not the representative's identity:
+    // the summary is stored on every row of the package.
+    const targetsByNodeType = new Map<string, any[]>();
+    const inputs: DocumentationInput[] = [];
+    for (const group of packageGroups.values()) {
+      const [representative] = group;
+      targetsByNodeType.set(representative.nodeType, group);
+      inputs.push({
+        nodeType: representative.nodeType,
+        displayName: representative.displayName,
+        description: representative.description,
+        readme: representative.npmReadme || '',
+        npmPackageName: representative.npmPackageName,
+        nodeNames: group.map((node) => node.displayName || node.nodeType),
+      });
+    }
 
     // Generate summaries in parallel
     const results = await this.generator.generateBatch(inputs, concurrency, progressCallback);
@@ -263,22 +288,30 @@ export class DocumentationBatchProcessor {
     const errors: string[] = [];
 
     for (const result of results) {
+      // A result that maps to no group is stored under its own node type.
+      const targets = targetsByNodeType.get(result.nodeType) ?? [{ nodeType: result.nodeType }];
+
       if (result.error) {
         errors.push(`${result.nodeType}: ${result.error}`);
-        failed++;
-      } else {
+        failed += targets.length;
+        continue;
+      }
+
+      for (const target of targets) {
         try {
-          this.repository.updateNodeAISummary(result.nodeType, result.summary);
+          this.repository.updateNodeAISummary(target.nodeType, result.summary);
           generated++;
         } catch (error) {
-          const msg = `Failed to save summary for ${result.nodeType}: ${error}`;
+          const msg = `Failed to save summary for ${target.nodeType}: ${error}`;
           errors.push(msg);
           failed++;
         }
       }
     }
 
-    logger.info(`AI summary generation complete: ${generated} generated, ${failed} failed`);
+    logger.info(
+      `AI summary generation complete: ${generated} row(s) from ${inputs.length} package(s), ${failed} failed`
+    );
     return { generated, failed, skipped: 0, errors };
   }
 

--- a/src/community/documentation-generator.ts
+++ b/src/community/documentation-generator.ts
@@ -32,6 +32,11 @@ export interface DocumentationInput {
   description?: string;
   readme: string;
   npmPackageName?: string;
+  /**
+   * Names of every node the package ships. Set when the summary will be stored
+   * on all of them, so the prompt describes the package rather than one node.
+   */
+  nodeNames?: string[];
 }
 
 /**
@@ -202,6 +207,23 @@ export class DocumentationGenerator {
   private buildPrompt(input: DocumentationInput): string {
     // Truncate README to avoid token limits (keep first ~6000 chars)
     const truncatedReadme = this.truncateReadme(input.readme, 6000);
+
+    // A package-scoped summary is stored on every node the package ships, so
+    // naming one of them would attribute the text to the wrong node.
+    if (input.nodeNames?.length) {
+      return `
+Package Information:
+- Package: ${input.npmPackageName || 'unknown'}
+- Nodes: ${input.nodeNames.join(', ')}
+- Description: ${input.description || 'No description provided'}
+
+README Content:
+${truncatedReadme}
+
+Based on the README and package information above, generate a structured documentation summary
+covering the package as a whole, including every node listed above.
+`.trim();
+    }
 
     return `
 Node Information:

--- a/src/database/node-repository.ts
+++ b/src/database/node-repository.ts
@@ -711,9 +711,10 @@ export class NodeRepository {
 
   /**
    * Delete unverified community rows for an npm package that are keyed by a node
-   * type outside the given set. Rows are keyed by node_type, so a sync that
-   * resolves a corrected (#949) or larger (#967) set of node types for a package
-   * would otherwise insert new rows and leave the outdated ones in search results.
+   * type outside the given set, returning how many rows were removed. Rows are
+   * keyed by node_type, so a sync that resolves a corrected (#949) or larger
+   * (#967) set of node types for a package would otherwise insert new rows and
+   * leave the outdated ones in search results.
    */
   deleteStaleCommunityNodes(npmPackageName: string, keepNodeTypes: string[]): number {
     // "Keep nothing" is a caller bug, not an intent to wipe the package: deleting
@@ -722,12 +723,26 @@ export class NodeRepository {
       return 0;
     }
 
-    const result = this.db.prepare(`
-      DELETE FROM nodes
+    // Both statements are built from one WHERE so the reported count cannot drift
+    // from what is deleted. The count comes from a SELECT rather than the run
+    // result because the sql.js adapter reports a fixed change count of 1.
+    const where = `
       WHERE npm_package_name = ? AND is_community = 1 AND is_verified = 0
         AND node_type NOT IN (${keepNodeTypes.map(() => '?').join(', ')})
-    `).run(npmPackageName, ...keepNodeTypes);
-    return result.changes;
+    `;
+    const params = [npmPackageName, ...keepNodeTypes];
+
+    const stale = this.db.prepare(
+      `SELECT COUNT(*) as count FROM nodes ${where}`
+    ).get(...params) as { count: number } | undefined;
+
+    const staleCount = stale?.count ?? 0;
+    if (staleCount === 0) {
+      return 0;
+    }
+
+    this.db.prepare(`DELETE FROM nodes ${where}`).run(...params);
+    return staleCount;
   }
 
   /**

--- a/src/database/node-repository.ts
+++ b/src/database/node-repository.ts
@@ -35,6 +35,14 @@ export class NodeRepository {
   }
 
   /**
+   * Run several repository writes as one unit, so a failure part-way through
+   * leaves no half-applied state behind.
+   */
+  transaction<T>(fn: () => T): T {
+    return this.db.transaction(fn);
+  }
+
+  /**
    * Age-based housekeeping: remove version backups past the retention window.
    * Called once during database initialization. Internal maintenance only —
    * not callable by tenants and not tenant-scoped (deterministic retention,
@@ -690,28 +698,35 @@ export class NodeRepository {
   }
 
   /**
-   * Get node by npm package name
+   * Get every node stored for an npm package. A package can ship several nodes,
+   * each of which gets its own row (#967).
    */
-  getNodeByNpmPackage(npmPackageName: string): any | null {
-    const row = this.db.prepare(
-      'SELECT * FROM nodes WHERE npm_package_name = ?'
-    ).get(npmPackageName) as any;
+  getNodesByNpmPackage(npmPackageName: string): any[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM nodes WHERE npm_package_name = ? ORDER BY node_type'
+    ).all(npmPackageName) as any[];
 
-    if (!row) return null;
-    return this.parseNodeRow(row);
+    return rows.map(row => this.parseNodeRow(row));
   }
 
   /**
-   * Delete unverified community rows for an npm package that are keyed by a
-   * node type other than the given one. Rows are keyed by node_type, so a sync
-   * that resolves a corrected node type for a package would otherwise insert a
-   * second row and leave the outdated one in search results (#949).
+   * Delete unverified community rows for an npm package that are keyed by a node
+   * type outside the given set. Rows are keyed by node_type, so a sync that
+   * resolves a corrected (#949) or larger (#967) set of node types for a package
+   * would otherwise insert new rows and leave the outdated ones in search results.
    */
-  deleteStaleCommunityNodes(npmPackageName: string, keepNodeType: string): number {
+  deleteStaleCommunityNodes(npmPackageName: string, keepNodeTypes: string[]): number {
+    // "Keep nothing" is a caller bug, not an intent to wipe the package: deleting
+    // every unverified row of a package is deleteCommunityNodes' job, not this one.
+    if (keepNodeTypes.length === 0) {
+      return 0;
+    }
+
     const result = this.db.prepare(`
       DELETE FROM nodes
-      WHERE npm_package_name = ? AND node_type != ? AND is_community = 1 AND is_verified = 0
-    `).run(npmPackageName, keepNodeType);
+      WHERE npm_package_name = ? AND is_community = 1 AND is_verified = 0
+        AND node_type NOT IN (${keepNodeTypes.map(() => '?').join(', ')})
+    `).run(npmPackageName, ...keepNodeTypes);
     return result.changes;
   }
 

--- a/src/scripts/fetch-community-nodes.ts
+++ b/src/scripts/fetch-community-nodes.ts
@@ -125,19 +125,21 @@ async function main(): Promise<void> {
   console.log();
 
   console.log('Verified nodes (Strapi API):');
-  console.log(`  - Fetched: ${result.verified.fetched}`);
-  console.log(`  - Saved: ${result.verified.saved}`);
-  console.log(`  - Skipped: ${result.verified.skipped}`);
+  console.log(`  - Fetched: ${result.verified.fetched} nodes`);
+  console.log(`  - Saved: ${result.verified.saved} nodes`);
+  console.log(`  - Skipped: ${result.verified.skipped} nodes`);
   if (result.verified.errors.length > 0) {
     console.log(`  - Errors: ${result.verified.errors.length}`);
     result.verified.errors.forEach((e) => console.log(`    ! ${e}`));
   }
 
   if (!cliOptions.verifiedOnly) {
+    // A package can declare several nodes, so package and node counts differ.
     console.log('\nnpm packages:');
-    console.log(`  - Fetched: ${result.npm.fetched}`);
-    console.log(`  - Saved: ${result.npm.saved}`);
-    console.log(`  - Skipped: ${result.npm.skipped}`);
+    console.log(`  - Fetched: ${result.npm.fetched} packages`);
+    console.log(`  - Saved: ${result.npm.saved} packages (${result.npm.nodesSaved} node rows)`);
+    console.log(`  - Skipped: ${result.npm.skipped} packages`);
+    console.log(`  - Removed (no longer declared): ${result.npm.nodesRemoved} node rows`);
     if (result.npm.errors.length > 0) {
       console.log(`  - Errors: ${result.npm.errors.length}`);
       result.npm.errors.forEach((e) => console.log(`    ! ${e}`));

--- a/tests/integration/community/community-nodes-integration.test.ts
+++ b/tests/integration/community/community-nodes-integration.test.ts
@@ -25,7 +25,6 @@ vi.mock('@/utils/logger', () => ({
  */
 class InMemoryDatabaseAdapter implements DatabaseAdapter {
   private nodes: Map<string, any> = new Map();
-  private nodesByNpmPackage: Map<string, any> = new Map();
 
   prepare = vi.fn((sql: string) => new InMemoryPreparedStatement(sql, this));
 
@@ -39,21 +38,22 @@ class InMemoryDatabaseAdapter implements DatabaseAdapter {
   // Data access methods for the prepared statement
   saveNode(node: any): void {
     this.nodes.set(node.node_type, node);
-    if (node.npm_package_name) {
-      this.nodesByNpmPackage.set(node.npm_package_name, node);
-    }
   }
 
   getNode(nodeType: string): any {
     return this.nodes.get(nodeType);
   }
 
-  getNodeByNpmPackage(npmPackageName: string): any {
-    return this.nodesByNpmPackage.get(npmPackageName);
+  // A package can own several rows (#967), so these derive from the node map
+  // instead of a package-keyed index.
+  getNodesByNpmPackage(npmPackageName: string): any[] {
+    return this.getAllNodes()
+      .filter((n) => n.npm_package_name === npmPackageName)
+      .sort((a, b) => a.node_type.localeCompare(b.node_type));
   }
 
   hasNodeByNpmPackage(npmPackageName: string): boolean {
-    return this.nodesByNpmPackage.has(npmPackageName);
+    return this.getNodesByNpmPackage(npmPackageName).length > 0;
   }
 
   getAllNodes(): any[] {
@@ -72,16 +72,12 @@ class InMemoryDatabaseAdapter implements DatabaseAdapter {
     const communityNodes = this.getCommunityNodes();
     for (const node of communityNodes) {
       this.nodes.delete(node.node_type);
-      if (node.npm_package_name) {
-        this.nodesByNpmPackage.delete(node.npm_package_name);
-      }
     }
     return communityNodes.length;
   }
 
   clear(): void {
     this.nodes.clear();
-    this.nodesByNpmPackage.clear();
   }
 }
 
@@ -106,9 +102,6 @@ class InMemoryPreparedStatement implements PreparedStatement {
     if (this.sql.includes('SELECT * FROM nodes WHERE node_type = ?')) {
       return this.adapter.getNode(params[0]);
     }
-    if (this.sql.includes('SELECT * FROM nodes WHERE npm_package_name = ?')) {
-      return this.adapter.getNodeByNpmPackage(params[0]);
-    }
     if (this.sql.includes('SELECT 1 FROM nodes WHERE npm_package_name = ?')) {
       return this.adapter.hasNodeByNpmPackage(params[0]) ? { '1': 1 } : undefined;
     }
@@ -123,6 +116,9 @@ class InMemoryPreparedStatement implements PreparedStatement {
   });
 
   all = vi.fn((...params: any[]) => {
+    if (this.sql.includes('SELECT * FROM nodes WHERE npm_package_name = ? ORDER BY node_type')) {
+      return this.adapter.getNodesByNpmPackage(params[0]);
+    }
     if (this.sql.includes('SELECT * FROM nodes WHERE is_community = 1')) {
       let nodes = this.adapter.getCommunityNodes();
 
@@ -336,9 +332,9 @@ describe('Community Nodes Integration', () => {
       };
       repository.saveNode(updatedNode);
 
-      const retrieved = repository.getNodeByNpmPackage('n8n-nodes-verified');
-      expect(retrieved).toBeDefined();
-      // Note: The actual update verification depends on parseNodeRow implementation
+      const retrieved = repository.getNodesByNpmPackage('n8n-nodes-verified');
+      expect(retrieved).toHaveLength(1);
+      expect(retrieved[0].displayName).toBe('Updated Verified Node');
     });
 
     it('should handle transition from unverified to verified', () => {

--- a/tests/integration/database/node-repository.test.ts
+++ b/tests/integration/database/node-repository.test.ts
@@ -458,6 +458,71 @@ describe('NodeRepository Integration Tests', () => {
     });
   });
 
+  describe('community node set-diff', () => {
+    // Exercises the generated NOT IN statement against a real SQLite engine —
+    // the unit-level mock re-implements the predicate in JS (#967).
+    const communityNode = (nodeType: string, isVerified = false): any => ({
+      ...createParsedNode(MOCK_NODES.webhook),
+      nodeType,
+      isCommunity: true,
+      isVerified,
+      npmPackageName: 'n8n-nodes-multi',
+    });
+
+    beforeEach(() => {
+      repository.saveNode(communityNode('n8n-nodes-multi.first'));
+      repository.saveNode(communityNode('n8n-nodes-multi.second'));
+      repository.saveNode(communityNode('n8n-nodes-multi.stale'));
+      repository.saveNode(communityNode('n8n-nodes-multi.verified', true));
+      repository.saveNode({
+        ...createParsedNode(MOCK_NODES.httpRequest),
+        isCommunity: true,
+        isVerified: false,
+        npmPackageName: 'n8n-nodes-other',
+      });
+    });
+
+    it('should return every row of a package', () => {
+      const nodes = repository.getNodesByNpmPackage('n8n-nodes-multi');
+
+      expect(nodes.map((n: any) => n.nodeType)).toEqual([
+        'n8n-nodes-multi.first',
+        'n8n-nodes-multi.second',
+        'n8n-nodes-multi.stale',
+        'n8n-nodes-multi.verified',
+      ]);
+    });
+
+    it('should delete only the unverified rows outside the keep set', () => {
+      const removed = repository.deleteStaleCommunityNodes('n8n-nodes-multi', [
+        'n8n-nodes-multi.first',
+        'n8n-nodes-multi.second',
+      ]);
+
+      expect(removed).toBe(1);
+      expect(repository.getNodesByNpmPackage('n8n-nodes-multi').map((n: any) => n.nodeType)).toEqual(
+        ['n8n-nodes-multi.first', 'n8n-nodes-multi.second', 'n8n-nodes-multi.verified']
+      );
+      expect(repository.getNodesByNpmPackage('n8n-nodes-other')).toHaveLength(1);
+    });
+
+    it('should treat node types as data, not SQL', () => {
+      const removed = repository.deleteStaleCommunityNodes('n8n-nodes-multi', [
+        "n8n-nodes-multi.first'; DROP TABLE nodes; --",
+      ]);
+
+      expect(removed).toBe(3);
+      expect(repository.getNodeCount()).toBe(2); // verified row + the other package
+    });
+
+    it('should no-op on an empty keep set', () => {
+      const removed = repository.deleteStaleCommunityNodes('n8n-nodes-multi', []);
+
+      expect(removed).toBe(0);
+      expect(repository.getNodesByNpmPackage('n8n-nodes-multi')).toHaveLength(4);
+    });
+  });
+
   describe('searchNodeProperties', () => {
     beforeEach(() => {
       const node: ParsedNode = {

--- a/tests/unit/community/community-node-service.test.ts
+++ b/tests/unit/community/community-node-service.test.ts
@@ -889,6 +889,7 @@ describe('CommunityNodeService', () => {
 
     it('should still re-key when package.json is readable but declares no node', async () => {
       mockFetcher.fetchPackageJson.mockResolvedValue({ name: 'n8n-nodes-npm-test' });
+      (mockRepository.deleteStaleCommunityNodes as any).mockReturnValue(2);
 
       const result = await service.syncNpmNodes();
 
@@ -1218,7 +1219,7 @@ describe('CommunityNodeService', () => {
       expect(mockRepository.deleteStaleCommunityNodes).not.toHaveBeenCalled();
     });
 
-    it('should accumulate removed rows across packages', async () => {
+    it('should accumulate the rows each package reported removing', async () => {
       const otherPackage: NpmSearchResult = {
         ...mockNpmPackage,
         package: { ...mockNpmPackage.package, name: 'n8n-nodes-other' },
@@ -1228,10 +1229,12 @@ describe('CommunityNodeService', () => {
         { ...staleRow, nodeType: `${packageName}.old`, npmPackageName: packageName },
         { ...staleRow, nodeType: `${packageName}.older`, npmPackageName: packageName },
       ]);
+      (mockRepository.deleteStaleCommunityNodes as any).mockReturnValue(2);
 
       const result = await service.syncNpmNodes();
 
       expect(result.saved).toBe(2);
+      expect(mockRepository.deleteStaleCommunityNodes).toHaveBeenCalledTimes(2);
       expect(result.nodesRemoved).toBe(4);
     });
   });

--- a/tests/unit/community/community-node-service.test.ts
+++ b/tests/unit/community/community-node-service.test.ts
@@ -100,8 +100,9 @@ describe('CommunityNodeService', () => {
     mockRepository = {
       saveNode: vi.fn(),
       hasNodeByNpmPackage: vi.fn().mockReturnValue(false),
-      getNodeByNpmPackage: vi.fn().mockReturnValue(null),
+      getNodesByNpmPackage: vi.fn().mockReturnValue([]),
       deleteStaleCommunityNodes: vi.fn().mockReturnValue(0),
+      transaction: vi.fn((fn: () => any) => fn()),
       updateNodeReadme: vi.fn(),
       updateNodeAISummary: vi.fn(),
       getCommunityNodes: vi.fn().mockReturnValue([]),
@@ -316,17 +317,23 @@ describe('CommunityNodeService', () => {
 
     it('should skip existing packages when skipExisting is true', async () => {
       mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
-      (mockRepository.getNodeByNpmPackage as any).mockReturnValue({
-        nodeType: 'n8n-nodes-npm-test.npmtest',
-        npmPackageName: 'n8n-nodes-npm-test',
-        isCommunity: true,
-        isVerified: false,
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: { nodes: ['dist/nodes/npmtest.node.js'] },
       });
+      (mockRepository.getNodesByNpmPackage as any).mockReturnValue([
+        {
+          nodeType: 'n8n-nodes-npm-test.npmtest',
+          npmPackageName: 'n8n-nodes-npm-test',
+          isCommunity: true,
+          isVerified: false,
+        },
+      ]);
 
       const result = await service.syncNpmNodes(100, undefined, true);
 
       expect(result.skipped).toBe(1);
       expect(result.saved).toBe(0);
+      expect(mockRepository.saveNode).not.toHaveBeenCalled();
     });
 
     it('should respect limit parameter', async () => {
@@ -571,7 +578,7 @@ describe('CommunityNodeService', () => {
     });
   });
 
-  describe('npmPackageToParsedNode (via syncNpmNodes)', () => {
+  describe('npmPackageToParsedNodes (via syncNpmNodes)', () => {
     it('should convert npm package to ParsedNode format', async () => {
       mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
 
@@ -708,7 +715,7 @@ describe('CommunityNodeService', () => {
       );
     });
 
-    it('should use the first n8n.nodes entry that names a node file (#949)', async () => {
+    it('should ignore n8n.nodes entries that do not name a node file (#949)', async () => {
       mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
       mockFetcher.fetchPackageJson.mockResolvedValue({
         n8n: { nodes: ['dist/README.js', 'dist/nodes/Foo/Foo.node.js'] },
@@ -716,6 +723,7 @@ describe('CommunityNodeService', () => {
 
       await service.syncNpmNodes();
 
+      expect(mockRepository.saveNode).toHaveBeenCalledTimes(1);
       expect(mockRepository.saveNode).toHaveBeenCalledWith(
         expect.objectContaining({
           nodeType: 'n8n-nodes-npm-test.foo',
@@ -770,32 +778,13 @@ describe('CommunityNodeService', () => {
       );
     });
 
-    it('should use the first entry of a multi-node n8n.nodes array (#949)', async () => {
-      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
-      mockFetcher.fetchPackageJson.mockResolvedValue({
-        n8n: {
-          nodes: [
-            'dist/nodes/FirstNode/FirstNode.node.js',
-            'dist/nodes/SecondNode/SecondNode.node.js',
-          ],
-        },
-      });
-
-      await service.syncNpmNodes();
-
-      expect(mockRepository.saveNode).toHaveBeenCalledWith(
-        expect.objectContaining({
-          nodeType: 'n8n-nodes-npm-test.firstNode',
-        })
-      );
-    });
-
     it('should fall back to the package-name heuristic when n8n.nodes is missing (#949)', async () => {
       mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
       mockFetcher.fetchPackageJson.mockResolvedValue({ name: 'n8n-nodes-npm-test' });
 
       await service.syncNpmNodes();
 
+      expect(mockRepository.saveNode).toHaveBeenCalledTimes(1);
       expect(mockRepository.saveNode).toHaveBeenCalledWith(
         expect.objectContaining({
           nodeType: 'n8n-nodes-npm-test.npmtest',
@@ -838,9 +827,265 @@ describe('CommunityNodeService', () => {
         })
       );
     });
+
+    it('should cap the rows a single package can contribute', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: {
+          nodes: Array.from({ length: 150 }, (_, i) => `dist/nodes/Node${i}/Node${i}.node.js`),
+        },
+      });
+
+      const result = await service.syncNpmNodes();
+
+      expect(result.nodesSaved).toBe(100);
+      expect(mockRepository.saveNode).toHaveBeenCalledTimes(100);
+    });
   });
 
-  describe('stale node type re-keying (#949)', () => {
+  describe('unreadable package.json (#967)', () => {
+    const storedRows = [
+      {
+        nodeType: 'n8n-nodes-npm-test.first',
+        npmPackageName: 'n8n-nodes-npm-test',
+        isCommunity: true,
+        isVerified: false,
+      },
+      {
+        nodeType: 'n8n-nodes-npm-test.second',
+        npmPackageName: 'n8n-nodes-npm-test',
+        isCommunity: true,
+        isVerified: false,
+      },
+    ];
+
+    beforeEach(() => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      (mockRepository.getNodesByNpmPackage as any).mockReturnValue(storedRows);
+    });
+
+    it('should leave stored rows untouched when the registry request fails', async () => {
+      mockFetcher.fetchPackageJson.mockRejectedValue(new Error('npm registry down'));
+
+      const result = await service.syncNpmNodes();
+
+      expect(result.skipped).toBe(1);
+      expect(result.saved).toBe(0);
+      expect(result.nodesRemoved).toBe(0);
+      expect(mockRepository.saveNode).not.toHaveBeenCalled();
+      expect(mockRepository.deleteStaleCommunityNodes).not.toHaveBeenCalled();
+    });
+
+    it('should leave stored rows untouched when the registry returns no package.json', async () => {
+      // fetchPackageJson resolves to null once its retries are exhausted.
+      mockFetcher.fetchPackageJson.mockResolvedValue(null);
+
+      const result = await service.syncNpmNodes();
+
+      expect(result.skipped).toBe(1);
+      expect(mockRepository.saveNode).not.toHaveBeenCalled();
+      expect(mockRepository.deleteStaleCommunityNodes).not.toHaveBeenCalled();
+    });
+
+    it('should still re-key when package.json is readable but declares no node', async () => {
+      mockFetcher.fetchPackageJson.mockResolvedValue({ name: 'n8n-nodes-npm-test' });
+
+      const result = await service.syncNpmNodes();
+
+      expect(result.saved).toBe(1);
+      expect(result.nodesRemoved).toBe(2);
+      expect(mockRepository.deleteStaleCommunityNodes).toHaveBeenCalledWith('n8n-nodes-npm-test', [
+        'n8n-nodes-npm-test.npmtest',
+      ]);
+    });
+
+    it('should still store a new package whose package.json cannot be read', async () => {
+      (mockRepository.getNodesByNpmPackage as any).mockReturnValue([]);
+      mockFetcher.fetchPackageJson.mockRejectedValue(new Error('npm registry down'));
+
+      const result = await service.syncNpmNodes();
+
+      expect(result.saved).toBe(1);
+      expect(mockRepository.saveNode).toHaveBeenCalledWith(
+        expect.objectContaining({ nodeType: 'n8n-nodes-npm-test.npmtest' })
+      );
+    });
+  });
+
+  describe('multi-node packages (#967)', () => {
+    const savedNodeTypes = () =>
+      (mockRepository.saveNode as any).mock.calls.map(([node]: any[]) => node.nodeType);
+
+    it('should store one row per n8n.nodes entry', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: {
+          nodes: [
+            'dist/nodes/FirstNode/FirstNode.node.js',
+            'dist/nodes/SecondNode/SecondNode.node.js',
+            'dist/nodes/PDFGeneration/PDFGeneration.node.js',
+          ],
+        },
+      });
+
+      const result = await service.syncNpmNodes();
+
+      expect(savedNodeTypes()).toEqual([
+        'n8n-nodes-npm-test.firstNode',
+        'n8n-nodes-npm-test.secondNode',
+        'n8n-nodes-npm-test.pdfGeneration',
+      ]);
+      expect(result.saved).toBe(1);
+      expect(result.nodesSaved).toBe(3);
+    });
+
+    it('should give each row its own display name and share package metadata', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: {
+          nodes: ['dist/nodes/Waha/WAHA.node.js', 'dist/nodes/Waha/WAHATrigger.node.js'],
+        },
+      });
+
+      await service.syncNpmNodes();
+
+      const [first, second] = (mockRepository.saveNode as any).mock.calls.map(
+        ([node]: any[]) => node
+      );
+      expect(first.displayName).toBe('wAHA');
+      expect(second.displayName).toBe('wahaTrigger');
+      expect(first.description).toBe(second.description);
+      expect(first.npmVersion).toBe(second.npmVersion);
+      expect(first.npmPackageName).toBe(second.npmPackageName);
+      // The trigger sibling is recognisable from its own name, not the package name.
+      expect(first.isTrigger).toBe(false);
+      expect(second.isTrigger).toBe(true);
+    });
+
+    it('should not let the package name flag every row of a trigger package', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([
+        {
+          ...mockNpmPackage,
+          package: { ...mockNpmPackage.package, name: 'n8n-nodes-foo-trigger' },
+        },
+      ]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: { nodes: ['dist/nodes/Foo/Foo.node.js', 'dist/nodes/Foo/FooTrigger.node.js'] },
+      });
+
+      await service.syncNpmNodes();
+
+      const [action, trigger] = (mockRepository.saveNode as any).mock.calls.map(
+        ([node]: any[]) => node
+      );
+      expect(action.nodeType).toBe('n8n-nodes-foo-trigger.foo');
+      expect(action.isTrigger).toBe(false);
+      expect(trigger.isTrigger).toBe(true);
+    });
+
+    it('should keep the package-name signal for a single-node package', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([
+        {
+          ...mockNpmPackage,
+          package: { ...mockNpmPackage.package, name: 'n8n-nodes-foo-trigger' },
+        },
+      ]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: { nodes: ['dist/nodes/Foo/Foo.node.js'] },
+      });
+
+      await service.syncNpmNodes();
+
+      expect(mockRepository.saveNode).toHaveBeenCalledWith(
+        expect.objectContaining({ nodeType: 'n8n-nodes-foo-trigger.foo', isTrigger: true })
+      );
+    });
+
+    it('should write, prune and seed docs for a package in one transaction', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: { nodes: ['dist/nodes/Foo/Foo.node.js'] },
+      });
+      (mockRepository.getNodesByNpmPackage as any).mockReturnValue([
+        {
+          nodeType: 'n8n-nodes-npm-test.old',
+          npmPackageName: 'n8n-nodes-npm-test',
+          isCommunity: true,
+          isVerified: false,
+          npmReadme: '# Readme',
+        },
+      ]);
+      let insideTransaction = false;
+      const wroteOutsideTransaction: string[] = [];
+      const record = (name: string) => {
+        if (!insideTransaction) {
+          wroteOutsideTransaction.push(name);
+        }
+      };
+      (mockRepository.saveNode as any).mockImplementation(() => record('saveNode'));
+      (mockRepository.deleteStaleCommunityNodes as any).mockImplementation(() => record('delete'));
+      (mockRepository.updateNodeReadme as any).mockImplementation(() => record('updateNodeReadme'));
+      (mockRepository.transaction as any).mockImplementation((fn: () => void) => {
+        insideTransaction = true;
+        try {
+          return fn();
+        } finally {
+          insideTransaction = false;
+        }
+      });
+
+      await service.syncNpmNodes();
+
+      expect(mockRepository.transaction).toHaveBeenCalledTimes(1);
+      expect(wroteOutsideTransaction).toEqual([]);
+      expect(mockRepository.saveNode).toHaveBeenCalled();
+      expect(mockRepository.deleteStaleCommunityNodes).toHaveBeenCalled();
+      expect(mockRepository.updateNodeReadme).toHaveBeenCalled();
+    });
+
+    it('should deduplicate repeated n8n.nodes entries', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: {
+          nodes: [
+            'dist/nodes/Foo/Foo.node.js',
+            'dist/nodes/Foo/Foo.node.ts',
+            'dist/nodes/Bar/Bar.node.js',
+          ],
+        },
+      });
+
+      const result = await service.syncNpmNodes();
+
+      expect(savedNodeTypes()).toEqual(['n8n-nodes-npm-test.foo', 'n8n-nodes-npm-test.bar']);
+      expect(result.nodesSaved).toBe(2);
+    });
+
+    it('should add missing sibling rows even when skipExisting is set', async () => {
+      mockFetcher.fetchNpmPackages.mockResolvedValue([mockNpmPackage]);
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: {
+          nodes: ['dist/nodes/Foo/Foo.node.js', 'dist/nodes/Bar/Bar.node.js'],
+        },
+      });
+      (mockRepository.getNodesByNpmPackage as any).mockReturnValue([
+        {
+          nodeType: 'n8n-nodes-npm-test.foo',
+          npmPackageName: 'n8n-nodes-npm-test',
+          isCommunity: true,
+          isVerified: false,
+        },
+      ]);
+
+      const result = await service.syncNpmNodes(100, undefined, true);
+
+      expect(result.skipped).toBe(0);
+      expect(result.nodesSaved).toBe(2);
+      expect(savedNodeTypes()).toContain('n8n-nodes-npm-test.bar');
+    });
+  });
+
+  describe('stale node type set-diff (#949, #967)', () => {
     const globalsPackage: NpmSearchResult = {
       ...mockNpmPackage,
       package: { ...mockNpmPackage.package, name: 'n8n-nodes-globals' },
@@ -863,18 +1108,19 @@ describe('CommunityNodeService', () => {
     });
 
     it('should replace a row keyed by the old node type and carry over its docs', async () => {
-      (mockRepository.getNodeByNpmPackage as any).mockReturnValue(staleRow);
+      (mockRepository.getNodesByNpmPackage as any).mockReturnValue([staleRow]);
+      (mockRepository.deleteStaleCommunityNodes as any).mockReturnValue(1);
 
       const result = await service.syncNpmNodes();
 
       expect(result.saved).toBe(1);
+      expect(result.nodesRemoved).toBe(1);
       expect(mockRepository.saveNode).toHaveBeenCalledWith(
         expect.objectContaining({ nodeType: 'n8n-nodes-globals.globalConstants' })
       );
-      expect(mockRepository.deleteStaleCommunityNodes).toHaveBeenCalledWith(
-        'n8n-nodes-globals',
-        'n8n-nodes-globals.globalConstants'
-      );
+      expect(mockRepository.deleteStaleCommunityNodes).toHaveBeenCalledWith('n8n-nodes-globals', [
+        'n8n-nodes-globals.globalConstants',
+      ]);
       expect(mockRepository.updateNodeReadme).toHaveBeenCalledWith(
         'n8n-nodes-globals.globalConstants',
         '# Globals'
@@ -885,8 +1131,64 @@ describe('CommunityNodeService', () => {
       );
     });
 
+    it('should keep the rows the package still declares and drop only the rest', async () => {
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: {
+          nodes: [
+            'dist/nodes/GlobalConstants/GlobalConstants.node.js',
+            'dist/nodes/GlobalVars/GlobalVars.node.js',
+          ],
+        },
+      });
+      (mockRepository.getNodesByNpmPackage as any).mockReturnValue([
+        staleRow,
+        { ...staleRow, nodeType: 'n8n-nodes-globals.globalConstants' },
+      ]);
+
+      await service.syncNpmNodes();
+
+      const [packageName, keepTypes] = (mockRepository.deleteStaleCommunityNodes as any).mock
+        .calls[0];
+      expect(packageName).toBe('n8n-nodes-globals');
+      expect(keepTypes).toHaveLength(2);
+      expect(keepTypes).toEqual(
+        expect.arrayContaining([
+          'n8n-nodes-globals.globalConstants',
+          'n8n-nodes-globals.globalVars',
+        ])
+      );
+    });
+
+    it('should carry the package docs over to a newly added sibling row', async () => {
+      mockFetcher.fetchPackageJson.mockResolvedValue({
+        n8n: {
+          nodes: [
+            'dist/nodes/GlobalConstants/GlobalConstants.node.js',
+            'dist/nodes/GlobalVars/GlobalVars.node.js',
+          ],
+        },
+      });
+      (mockRepository.getNodesByNpmPackage as any).mockReturnValue([
+        { ...staleRow, nodeType: 'n8n-nodes-globals.globalConstants' },
+      ]);
+
+      await service.syncNpmNodes();
+
+      // The existing row keeps its own docs (saveNode preserves them by node type).
+      expect(mockRepository.updateNodeReadme).toHaveBeenCalledTimes(1);
+      expect(mockRepository.updateNodeReadme).toHaveBeenCalledWith(
+        'n8n-nodes-globals.globalVars',
+        '# Globals'
+      );
+      expect(mockRepository.updateNodeAISummary).toHaveBeenCalledTimes(1);
+      expect(mockRepository.updateNodeAISummary).toHaveBeenCalledWith(
+        'n8n-nodes-globals.globalVars',
+        { summary: 'existing summary' }
+      );
+    });
+
     it('should re-key even when skipExisting is set', async () => {
-      (mockRepository.getNodeByNpmPackage as any).mockReturnValue(staleRow);
+      (mockRepository.getNodesByNpmPackage as any).mockReturnValue([staleRow]);
 
       const result = await service.syncNpmNodes(100, undefined, true);
 
@@ -896,10 +1198,9 @@ describe('CommunityNodeService', () => {
     });
 
     it('should leave a row with the same node type alone', async () => {
-      (mockRepository.getNodeByNpmPackage as any).mockReturnValue({
-        ...staleRow,
-        nodeType: 'n8n-nodes-globals.globalConstants',
-      });
+      (mockRepository.getNodesByNpmPackage as any).mockReturnValue([
+        { ...staleRow, nodeType: 'n8n-nodes-globals.globalConstants' },
+      ]);
 
       await service.syncNpmNodes();
 
@@ -908,14 +1209,30 @@ describe('CommunityNodeService', () => {
     });
 
     it('should never re-key a verified row', async () => {
-      (mockRepository.getNodeByNpmPackage as any).mockReturnValue({
-        ...staleRow,
-        isVerified: true,
-      });
+      (mockRepository.getNodesByNpmPackage as any).mockReturnValue([
+        { ...staleRow, isVerified: true },
+      ]);
 
       await service.syncNpmNodes();
 
       expect(mockRepository.deleteStaleCommunityNodes).not.toHaveBeenCalled();
+    });
+
+    it('should accumulate removed rows across packages', async () => {
+      const otherPackage: NpmSearchResult = {
+        ...mockNpmPackage,
+        package: { ...mockNpmPackage.package, name: 'n8n-nodes-other' },
+      };
+      mockFetcher.fetchNpmPackages.mockResolvedValue([globalsPackage, otherPackage]);
+      (mockRepository.getNodesByNpmPackage as any).mockImplementation((packageName: string) => [
+        { ...staleRow, nodeType: `${packageName}.old`, npmPackageName: packageName },
+        { ...staleRow, nodeType: `${packageName}.older`, npmPackageName: packageName },
+      ]);
+
+      const result = await service.syncNpmNodes();
+
+      expect(result.saved).toBe(2);
+      expect(result.nodesRemoved).toBe(4);
     });
   });
 

--- a/tests/unit/community/documentation-batch-processor.test.ts
+++ b/tests/unit/community/documentation-batch-processor.test.ts
@@ -356,6 +356,7 @@ describe('DocumentationBatchProcessor', () => {
       const manyNodes = Array.from({ length: 10 }, (_, i) =>
         createMockCommunityNode({
           nodeType: `node${i}`,
+          npmPackageName: `pkg${i}`,
           npmReadme: `# README ${i}`,
         })
       );
@@ -684,9 +685,94 @@ describe('DocumentationBatchProcessor', () => {
       expect(result.readmesFetched).toBe(0);
       expect(result.readmesFailed).toBe(0);
     });
+
+    it('should fetch a README once for a package that ships several nodes (#967)', async () => {
+      const nodes = [
+        createMockCommunityNode({ nodeType: 'pkg1.first', npmPackageName: 'pkg1' }),
+        createMockCommunityNode({ nodeType: 'pkg1.second', npmPackageName: 'pkg1' }),
+      ];
+
+      vi.mocked(mockRepository.getCommunityNodes).mockReturnValue(nodes);
+      vi.mocked(mockFetcher.fetchReadmesBatch).mockResolvedValue(
+        new Map([['pkg1', '# README']])
+      );
+
+      const result = await processor.processAll({ readmeOnly: true });
+
+      expect(mockFetcher.fetchReadmesBatch).toHaveBeenCalledWith(['pkg1'], undefined, 5);
+      // Both rows still get the README.
+      expect(result.readmesFetched).toBe(2);
+      expect(mockRepository.updateNodeReadme).toHaveBeenCalledWith('pkg1.first', '# README');
+      expect(mockRepository.updateNodeReadme).toHaveBeenCalledWith('pkg1.second', '# README');
+    });
   });
 
   describe('summary generation edge cases', () => {
+    it('should generate one summary per package and store it on every row (#967)', async () => {
+      const nodes = [
+        createMockCommunityNode({
+          nodeType: 'pkg1.first',
+          displayName: 'First',
+          npmPackageName: 'pkg1',
+          npmReadme: '# README',
+        }),
+        createMockCommunityNode({
+          nodeType: 'pkg1.second',
+          displayName: 'Second',
+          npmPackageName: 'pkg1',
+          npmReadme: '# README',
+        }),
+      ];
+
+      vi.mocked(mockRepository.getCommunityNodes).mockReturnValue(nodes);
+      vi.mocked(mockGenerator.generateBatch).mockResolvedValue([
+        { nodeType: 'pkg1.first', summary: createMockDocumentationSummary('pkg1') },
+      ]);
+
+      const result = await processor.processAll({ summaryOnly: true });
+
+      const inputs = vi.mocked(mockGenerator.generateBatch).mock.calls[0][0];
+      expect(inputs).toHaveLength(1);
+      // The prompt must describe the package, not whichever sibling was picked.
+      expect(inputs[0].nodeNames).toEqual(['First', 'Second']);
+      expect(inputs[0].npmPackageName).toBe('pkg1');
+      expect(result.summariesGenerated).toBe(2);
+      expect(mockRepository.updateNodeAISummary).toHaveBeenCalledWith(
+        'pkg1.first',
+        expect.any(Object)
+      );
+      expect(mockRepository.updateNodeAISummary).toHaveBeenCalledWith(
+        'pkg1.second',
+        expect.any(Object)
+      );
+    });
+
+    it('should count every row of a package as failed when its summary fails (#967)', async () => {
+      const nodes = [
+        createMockCommunityNode({
+          nodeType: 'pkg1.first',
+          npmPackageName: 'pkg1',
+          npmReadme: '# README',
+        }),
+        createMockCommunityNode({
+          nodeType: 'pkg1.second',
+          npmPackageName: 'pkg1',
+          npmReadme: '# README',
+        }),
+      ];
+
+      vi.mocked(mockRepository.getCommunityNodes).mockReturnValue(nodes);
+      vi.mocked(mockGenerator.generateBatch).mockResolvedValue([
+        { nodeType: 'pkg1.first', summary: {} as any, error: 'LLM timeout' },
+      ]);
+
+      const result = await processor.processAll({ summaryOnly: true });
+
+      expect(result.summariesGenerated).toBe(0);
+      expect(result.summariesFailed).toBe(2);
+      expect(mockRepository.updateNodeAISummary).not.toHaveBeenCalled();
+    });
+
     it('should skip nodes without README for summary generation', async () => {
       const nodes = [
         createMockCommunityNode({ nodeType: 'node1', npmReadme: '# README' }),
@@ -851,6 +937,7 @@ describe('DocumentationBatchProcessor', () => {
         description: 'A test node',
         readme: '# Test README\nThis is a test.',
         npmPackageName: 'n8n-nodes-test',
+        nodeNames: ['Test Node'],
       });
     });
 

--- a/tests/unit/community/documentation-generator.test.ts
+++ b/tests/unit/community/documentation-generator.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  DocumentationGenerator,
+  DocumentationInput,
+} from '@/community/documentation-generator';
+
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function buildPrompt(input: DocumentationInput): string {
+  // The constructor only configures an HTTP client, so no server is contacted.
+  const generator = new DocumentationGenerator({ baseUrl: 'http://localhost:1/v1' });
+  return (generator as any).buildPrompt(input);
+}
+
+const baseInput: DocumentationInput = {
+  nodeType: 'n8n-nodes-pdf.mergePdfs',
+  displayName: 'mergePdfs',
+  description: 'PDF toolkit',
+  readme: '# PDF toolkit',
+  npmPackageName: 'n8n-nodes-pdf',
+};
+
+describe('DocumentationGenerator - prompt', () => {
+  it('should describe the package, not one sibling, when node names are given (#967)', () => {
+    const prompt = buildPrompt({
+      ...baseInput,
+      nodeNames: ['mergePdfs', 'html2Pdf', 'addWatermark'],
+    });
+
+    expect(prompt).toContain('n8n-nodes-pdf');
+    expect(prompt).toContain('mergePdfs, html2Pdf, addWatermark');
+    // The summary is stored on every node of the package, so no single node may
+    // be presented as the subject.
+    expect(prompt).not.toContain('- Name: mergePdfs');
+    expect(prompt).not.toContain('n8n-nodes-pdf.mergePdfs');
+  });
+
+  it('should keep the single-node prompt when no node names are given', () => {
+    const prompt = buildPrompt(baseInput);
+
+    expect(prompt).toContain('- Name: mergePdfs');
+    expect(prompt).toContain('- Type: n8n-nodes-pdf.mergePdfs');
+  });
+
+  it('should include the README in both shapes', () => {
+    expect(buildPrompt(baseInput)).toContain('# PDF toolkit');
+    expect(buildPrompt({ ...baseInput, nodeNames: ['mergePdfs'] })).toContain('# PDF toolkit');
+  });
+});

--- a/tests/unit/database/node-repository-community.test.ts
+++ b/tests/unit/database/node-repository-community.test.ts
@@ -101,21 +101,23 @@ class MockPreparedStatement implements PreparedStatement {
       });
     }
 
-    // getNodeByNpmPackage
-    if (this.sql.includes('SELECT * FROM nodes WHERE npm_package_name = ?')) {
-      this.get = vi.fn((npmPackageName: string) => {
+    // getNodesByNpmPackage
+    if (this.sql.includes('SELECT * FROM nodes WHERE npm_package_name = ? ORDER BY node_type')) {
+      this.all = vi.fn((npmPackageName: string) => {
         const nodes = this.mockData.get('community_nodes') || [];
-        return nodes.find((n: any) => n.npm_package_name === npmPackageName);
+        return nodes
+          .filter((n: any) => n.npm_package_name === npmPackageName)
+          .sort((a: any, b: any) => a.node_type.localeCompare(b.node_type));
       });
     }
 
     // deleteStaleCommunityNodes
-    if (this.sql.includes('DELETE FROM nodes') && this.sql.includes('node_type != ?')) {
-      this.run = vi.fn((npmPackageName: string, keepNodeType: string): RunResult => {
+    if (this.sql.includes('DELETE FROM nodes') && this.sql.includes('npm_package_name = ?')) {
+      this.run = vi.fn((npmPackageName: string, ...keepNodeTypes: string[]): RunResult => {
         const nodes = this.mockData.get('community_nodes') || [];
         const remaining = nodes.filter((n: any) => !(
           n.npm_package_name === npmPackageName &&
-          n.node_type !== keepNodeType &&
+          !keepNodeTypes.includes(n.node_type) &&
           n.is_community === 1 &&
           n.is_verified === 0
         ));
@@ -396,37 +398,6 @@ describe('NodeRepository - Community Node Methods', () => {
     });
   });
 
-  describe('getNodeByNpmPackage', () => {
-    beforeEach(() => {
-      mockAdapter._setMockData('community_nodes', [...sampleCommunityNodes]);
-    });
-
-    it('should return node for existing package', () => {
-      const node = repository.getNodeByNpmPackage('n8n-nodes-verified');
-
-      expect(node).toBeDefined();
-      expect(node.npmPackageName).toBe('n8n-nodes-verified');
-      expect(node.displayName).toBe('Verified Test Node');
-    });
-
-    it('should return null for non-existent package', () => {
-      const node = repository.getNodeByNpmPackage('n8n-nodes-nonexistent');
-
-      expect(node).toBeNull();
-    });
-
-    it('should correctly parse all community fields', () => {
-      const node = repository.getNodeByNpmPackage('n8n-nodes-popular');
-
-      expect(node).toBeDefined();
-      expect(node.isCommunity).toBe(true);
-      expect(node.isVerified).toBe(true);
-      expect(node.isWebhook).toBe(true);
-      expect(node.isVersioned).toBe(true);
-      expect(node.npmDownloads).toBe(50000);
-    });
-  });
-
   describe('deleteCommunityNodes', () => {
     beforeEach(() => {
       mockAdapter._setMockData('community_nodes', [...sampleCommunityNodes]);
@@ -447,6 +418,42 @@ describe('NodeRepository - Community Node Methods', () => {
     });
   });
 
+  describe('getNodesByNpmPackage', () => {
+    const siblingRow = {
+      ...sampleCommunityNodes[1],
+      node_type: 'n8n-nodes-unverified.otherNode',
+    };
+
+    beforeEach(() => {
+      mockAdapter._setMockData('community_nodes', [...sampleCommunityNodes, siblingRow]);
+    });
+
+    it('should return every row a package stores', () => {
+      const nodes = repository.getNodesByNpmPackage('n8n-nodes-unverified');
+
+      expect(nodes.map((n: any) => n.nodeType)).toEqual([
+        'n8n-nodes-unverified.otherNode',
+        'n8n-nodes-unverified.testNode',
+      ]);
+      expect(nodes.every((n: any) => n.isCommunity)).toBe(true);
+    });
+
+    it('should return an empty array for an unknown package', () => {
+      expect(repository.getNodesByNpmPackage('n8n-nodes-nonexistent')).toEqual([]);
+    });
+
+    it('should parse the community fields of each row', () => {
+      const [node] = repository.getNodesByNpmPackage('n8n-nodes-popular');
+
+      expect(node.npmPackageName).toBe('n8n-nodes-popular');
+      expect(node.displayName).toBe('Popular Test Node');
+      expect(node.isVerified).toBe(true);
+      expect(node.isWebhook).toBe(true);
+      expect(node.isVersioned).toBe(true);
+      expect(node.npmDownloads).toBe(50000);
+    });
+  });
+
   describe('deleteStaleCommunityNodes', () => {
     const staleRow = {
       ...sampleCommunityNodes[1],
@@ -458,10 +465,9 @@ describe('NodeRepository - Community Node Methods', () => {
     });
 
     it('should remove rows of the package that are keyed by another node type', () => {
-      const deletedCount = repository.deleteStaleCommunityNodes(
-        'n8n-nodes-unverified',
-        'n8n-nodes-unverified.testNode'
-      );
+      const deletedCount = repository.deleteStaleCommunityNodes('n8n-nodes-unverified', [
+        'n8n-nodes-unverified.testNode',
+      ]);
 
       expect(deletedCount).toBe(1);
       const remaining = mockAdapter._getMockData('community_nodes');
@@ -472,11 +478,27 @@ describe('NodeRepository - Community Node Methods', () => {
       ]);
     });
 
+    it('should keep every node type in the set (#967)', () => {
+      const deletedCount = repository.deleteStaleCommunityNodes('n8n-nodes-unverified', [
+        'n8n-nodes-unverified.testNode',
+        'n8n-nodes-unverified.unverified',
+      ]);
+
+      expect(deletedCount).toBe(0);
+      expect(mockAdapter._getMockData('community_nodes')).toHaveLength(4);
+    });
+
+    it('should no-op on an empty keep set rather than wipe the package', () => {
+      const deletedCount = repository.deleteStaleCommunityNodes('n8n-nodes-unverified', []);
+
+      expect(deletedCount).toBe(0);
+      expect(mockAdapter._getMockData('community_nodes')).toHaveLength(4);
+    });
+
     it('should never remove verified rows', () => {
-      const deletedCount = repository.deleteStaleCommunityNodes(
-        'n8n-nodes-verified',
-        'n8n-nodes-verified.renamed'
-      );
+      const deletedCount = repository.deleteStaleCommunityNodes('n8n-nodes-verified', [
+        'n8n-nodes-verified.renamed',
+      ]);
 
       expect(deletedCount).toBe(0);
       expect(mockAdapter._getMockData('community_nodes')).toHaveLength(4);

--- a/tests/unit/database/node-repository-community.test.ts
+++ b/tests/unit/database/node-repository-community.test.ts
@@ -53,6 +53,18 @@ class MockPreparedStatement implements PreparedStatement {
     this.setupMockBehavior();
   }
 
+  /** Rows the stale-community-node WHERE clause matches. */
+  private staleRows(npmPackageName: string, keepNodeTypes: string[]): any[] {
+    const nodes = this.mockData.get('community_nodes') || [];
+    return nodes.filter(
+      (n: any) =>
+        n.npm_package_name === npmPackageName &&
+        n.is_community === 1 &&
+        n.is_verified === 0 &&
+        !keepNodeTypes.includes(n.node_type)
+    );
+  }
+
   private setupMockBehavior() {
     // Community nodes queries
     if (this.sql.includes('SELECT * FROM nodes WHERE is_community = 1')) {
@@ -111,18 +123,27 @@ class MockPreparedStatement implements PreparedStatement {
       });
     }
 
+    // deleteStaleCommunityNodes - count of the rows the DELETE will match
+    if (this.sql.includes('SELECT COUNT(*) as count FROM nodes') &&
+        this.sql.includes('npm_package_name = ?')) {
+      this.get = vi.fn((npmPackageName: string, ...keepNodeTypes: string[]) => ({
+        count: this.staleRows(npmPackageName, keepNodeTypes).length,
+      }));
+    }
+
     // deleteStaleCommunityNodes
     if (this.sql.includes('DELETE FROM nodes') && this.sql.includes('npm_package_name = ?')) {
       this.run = vi.fn((npmPackageName: string, ...keepNodeTypes: string[]): RunResult => {
+        const stale = new Set(
+          this.staleRows(npmPackageName, keepNodeTypes).map((n: any) => n.node_type)
+        );
         const nodes = this.mockData.get('community_nodes') || [];
-        const remaining = nodes.filter((n: any) => !(
-          n.npm_package_name === npmPackageName &&
-          !keepNodeTypes.includes(n.node_type) &&
-          n.is_community === 1 &&
-          n.is_verified === 0
-        ));
-        this.mockData.set('community_nodes', remaining);
-        return { changes: nodes.length - remaining.length, lastInsertRowid: 0 };
+        this.mockData.set(
+          'community_nodes',
+          nodes.filter((n: any) => !stale.has(n.node_type))
+        );
+        // Mirrors the sql.js adapter, which cannot report a real change count.
+        return { changes: 1, lastInsertRowid: 0 };
       });
     }
 
@@ -486,6 +507,25 @@ describe('NodeRepository - Community Node Methods', () => {
 
       expect(deletedCount).toBe(0);
       expect(mockAdapter._getMockData('community_nodes')).toHaveLength(4);
+    });
+
+    it('should report the real number of rows removed, not the run() change count', () => {
+      // The mock run() returns changes: 1 like the sql.js adapter does, so a count
+      // taken from the DELETE result would under-report a multi-row set-diff.
+      mockAdapter._setMockData('community_nodes', [
+        ...sampleCommunityNodes,
+        staleRow,
+        { ...staleRow, node_type: 'n8n-nodes-unverified.alsoStale' },
+      ]);
+
+      const deletedCount = repository.deleteStaleCommunityNodes('n8n-nodes-unverified', [
+        'n8n-nodes-unverified.testNode',
+      ]);
+
+      expect(deletedCount).toBe(2);
+      expect(
+        mockAdapter._getMockData('community_nodes').map((n: any) => n.node_type)
+      ).not.toContain('n8n-nodes-unverified.alsoStale');
     });
 
     it('should no-op on an empty keep set rather than wipe the package', () => {


### PR DESCRIPTION
## Summary

Fixes #967: the community npm sync stored exactly one database row per npm package (the first parseable `n8n.nodes` manifest entry), so multi-node packages lost every node after the first — `@custom-js/n8n-nodes-pdf-toolkit` declares 18 nodes and the database held one; `@devlikeapro/n8n-nodes-waha` ships a node and a trigger and only the node existed.

## Changes

- **One row per manifest entry** (`community-node-service.ts`): `resolveNpmNodeNames` returns all deduped parseable entries (name derivation unchanged from #964, incl. the leading-acronym rule and the logged package-name fallback), capped at 100 per package with a warning.
- **Fetch failure is no longer data loss**: the resolution result carries its source (`manifest` / `fallback` / `unavailable`). An unreachable package.json (which `fetchPackageJson` signals by resolving `null`, not throwing) skips the package untouched — previously a transient registry timeout collapsed a package to a single heuristic row and, with set-diff pruning, would have deleted every correct sibling.
- **Set-diff self-heal** (`node-repository.ts`): `deleteStaleCommunityNodes(pkg, keepTypes[])` prunes rows no longer declared by the package — still guarded to `is_community = 1 AND is_verified = 0`, no-op on an empty keep set, parameterized `NOT IN`.
- **Atomic per-package sync**: save + prune + doc-seed run in one repository `transaction()` (honored by both the better-sqlite3 and sql.js adapters).
- **Per-node trigger/webhook detection** from each node's own name — a `*-trigger` package name no longer marks every sibling a trigger, and `wahaTrigger` is now correctly flagged.
- **Docs stay package-level, correctly shared**: siblings inherit the package README and AI summary; the batch processor fetches one README and generates one summary per package (instead of N identical LLM calls), and the summary prompt is package-scoped (package name + node list) so no sibling's identity skews the shared text.
- `getNodeByNpmPackage` removed (dead after multi-row; returned an arbitrary row). Fetch statistics report packages and node rows separately.
- **Bundled DB refreshed**: 60 npm packages → 133 node rows (was 1:1), 1,569 community nodes total; pdf-toolkit has all 18, recovered rows share their package docs, one stale row removed.

## Review

Implemented and fix-rounded by an Opus agent; independently reviewed by a Claude code-reviewer and Codex (both flagged the fetch-failure prune hazard; both sets of findings fixed with revert-tested regression tests); scoped re-review verdict APPROVED. Typecheck, build, full unit suite (5,531 passed) and integration suites green.

## Known limits

- Node names remain filename-derived heuristics; ground truth (`description.name`) would require tarball parsing (noted in #967). Casing can differ between siblings (`wAHA` vs `wahaTrigger`).
- A readable package.json without `n8n.nodes` still re-keys to the single fallback name — same deliberate behavior as #964, now pinned by a test.
- Registry-outage skips land in the same "skipped" stat bucket as healthy skips.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)
