### PR TITLE
feat(community): add MiniMax provider preset for docs generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -228,6 +228,31 @@ ENABLE_MULTI_TENANT=false
 # Set to true to automatically generate metadata when running fetch:templates
 # METADATA_GENERATION_ENABLED=false
 
+# =========================
+# COMMUNITY DOCS LLM CONFIGURATION
+# =========================
+# Optional: LLM used by the community-node documentation generator
+# (npm run generate:docs). Defaults to a local OpenAI-compatible server.
+
+# Provider preset — selects regional base URLs, a default model and thinking
+# handling for a known cloud provider. Supported: minimax
+# N8N_MCP_LLM_PROVIDER=minimax
+
+# Region for the selected provider preset: global (default) or cn
+# N8N_MCP_LLM_REGION=global
+
+# Model name. When a provider preset is set this defaults to the preset's model
+# (minimax => MiniMax-M3); override to use another preset model (e.g. MiniMax-M2.7)
+# N8N_MCP_LLM_MODEL=MiniMax-M3
+
+# API key for the MiniMax preset (falls back to N8N_MCP_LLM_API_KEY / OPENAI_API_KEY)
+# MINIMAX_API_KEY=
+
+# Explicit overrides (take precedence over the provider preset)
+# N8N_MCP_LLM_BASE_URL=http://localhost:1234/v1
+# N8N_MCP_LLM_API_KEY=
+# N8N_MCP_LLM_TIMEOUT=60000
+
 # ========================================
 # INTEGRATION TESTING CONFIGURATION
 # ========================================

--- a/src/community/documentation-generator.ts
+++ b/src/community/documentation-generator.ts
@@ -79,6 +79,141 @@ const DEFAULT_CONFIG: Required<Omit<DocumentationGeneratorConfig, 'baseUrl' | 't
 };
 
 /**
+ * Deployment region for provider presets that expose regional endpoints.
+ * `global` is the international endpoint; `cn` is the mainland-China endpoint.
+ */
+export type LLMRegion = 'global' | 'cn';
+
+/**
+ * Thinking (reasoning) behaviour of a preset model.
+ * - `adaptive`: the model decides when to emit reasoning
+ * - `disabled`: reasoning can be turned off
+ * - `always_on`: reasoning is always emitted and cannot be disabled
+ */
+export type LLMThinkingMode = 'adaptive' | 'disabled' | 'always_on';
+
+/**
+ * A model offered by a provider preset.
+ */
+export interface LLMProviderModel {
+  /** Thinking modes this model supports; the first entry is the default. */
+  thinking: LLMThinkingMode[];
+}
+
+/**
+ * A first-class provider preset for the OpenAI-compatible documentation
+ * generator. Presets remove the need to hand-configure base URL, model and
+ * thinking handling for a known cloud provider.
+ */
+export interface LLMProviderPreset {
+  /** OpenAI-compatible chat-completions base URLs, keyed by region. */
+  baseUrls: Record<LLMRegion, string>;
+  /** Region used when `N8N_MCP_LLM_REGION` is unset. */
+  defaultRegion: LLMRegion;
+  /** Model used when `N8N_MCP_LLM_MODEL` is unset. */
+  defaultModel: string;
+  /** Supported models and their thinking behaviour. */
+  models: Record<string, LLMProviderModel>;
+  /**
+   * Whether to send the vLLM-only `chat_template_kwargs.enable_thinking` body
+   * field. Cloud OpenAI-compatible APIs reject unknown params (HTTP 400), so
+   * this is false for them; their reasoning output is removed by the
+   * `<think>...</think>` stripping in `extractJson` instead.
+   */
+  sendThinkingKwargs: boolean;
+  /** Environment variables checked, in order, for the API key. */
+  apiKeyEnvVars: string[];
+}
+
+/**
+ * Built-in provider presets. A preset is selected with `N8N_MCP_LLM_PROVIDER`.
+ */
+export const LLM_PROVIDER_PRESETS: Record<string, LLMProviderPreset> = {
+  minimax: {
+    baseUrls: {
+      global: 'https://api.minimax.io/v1',
+      cn: 'https://api.minimaxi.com/v1',
+    },
+    defaultRegion: 'global',
+    defaultModel: 'MiniMax-M3',
+    models: {
+      'MiniMax-M3': { thinking: ['adaptive', 'disabled'] },
+      'MiniMax-M2.7': { thinking: ['always_on'] },
+    },
+    // MiniMax is a cloud OpenAI-compatible API and rejects unknown body params,
+    // so the vLLM-only chat_template_kwargs field is never sent. Reasoning
+    // output (always on for MiniMax-M2.7) is removed by <think> stripping.
+    sendThinkingKwargs: false,
+    apiKeyEnvVars: ['MINIMAX_API_KEY'],
+  },
+};
+
+/**
+ * The active provider preset resolved from environment configuration.
+ */
+export interface ResolvedProviderPreset {
+  /** Lower-cased provider name (e.g. `minimax`). */
+  provider: string;
+  /** The selected preset definition. */
+  preset: LLMProviderPreset;
+  /** The resolved region. */
+  region: LLMRegion;
+  /** OpenAI-compatible base URL for the resolved region. */
+  baseUrl: string;
+  /** Default model for the preset. */
+  defaultModel: string;
+  /** API key discovered via the preset's fallback env vars, if any. */
+  apiKey?: string;
+  /** Whether the provider understands the vLLM-only chat_template_kwargs field. */
+  sendThinkingKwargs: boolean;
+}
+
+/**
+ * Resolve the active provider preset from environment configuration.
+ *
+ * Returns `undefined` when no known provider is selected, in which case the
+ * caller keeps its own base-URL/model resolution.
+ */
+export function resolveProviderPreset(
+  env: Record<string, string | undefined> = process.env
+): ResolvedProviderPreset | undefined {
+  const providerName = env.N8N_MCP_LLM_PROVIDER?.trim().toLowerCase();
+  if (!providerName) {
+    return undefined;
+  }
+
+  const preset = LLM_PROVIDER_PRESETS[providerName];
+  if (!preset) {
+    logger.warn(`Unknown N8N_MCP_LLM_PROVIDER "${providerName}"; ignoring provider preset.`);
+    return undefined;
+  }
+
+  let region: LLMRegion = preset.defaultRegion;
+  const regionEnv = env.N8N_MCP_LLM_REGION?.trim().toLowerCase();
+  if (regionEnv) {
+    if (regionEnv in preset.baseUrls) {
+      region = regionEnv as LLMRegion;
+    } else {
+      logger.warn(
+        `Unknown N8N_MCP_LLM_REGION "${regionEnv}" for provider "${providerName}"; using "${region}".`
+      );
+    }
+  }
+
+  const apiKey = preset.apiKeyEnvVars.map((name) => env[name]).find(Boolean);
+
+  return {
+    provider: providerName,
+    preset,
+    region,
+    baseUrl: preset.baseUrls[region],
+    defaultModel: preset.defaultModel,
+    ...(apiKey ? { apiKey } : {}),
+    sendThinkingKwargs: preset.sendThinkingKwargs,
+  };
+}
+
+/**
  * Generates structured documentation summaries for community nodes
  * using a local LLM via OpenAI-compatible API.
  */
@@ -392,10 +527,18 @@ Guidelines:
  * Create a documentation generator with environment variable configuration
  */
 export function createDocumentationGenerator(): DocumentationGenerator {
-  const baseUrl = process.env.N8N_MCP_LLM_BASE_URL || 'http://localhost:1234/v1';
-  const model = process.env.N8N_MCP_LLM_MODEL || 'qwen3-4b-thinking-2507';
+  // A provider preset (N8N_MCP_LLM_PROVIDER) supplies regional base URLs, a
+  // default model, an API-key fallback and thinking handling for a known cloud
+  // provider. Explicit N8N_MCP_LLM_* vars still take precedence over it.
+  const provider = resolveProviderPreset();
+
+  const baseUrl =
+    process.env.N8N_MCP_LLM_BASE_URL || provider?.baseUrl || 'http://localhost:1234/v1';
+  const model =
+    process.env.N8N_MCP_LLM_MODEL || provider?.defaultModel || 'qwen3-4b-thinking-2507';
   const timeout = parseInt(process.env.N8N_MCP_LLM_TIMEOUT || '60000', 10);
-  const apiKey = process.env.N8N_MCP_LLM_API_KEY || process.env.OPENAI_API_KEY;
+  const apiKey =
+    process.env.N8N_MCP_LLM_API_KEY || provider?.apiKey || process.env.OPENAI_API_KEY;
   // Only set temperature for local LLM servers; cloud APIs like OpenAI may
   // not support custom values. Parse the URL and check the hostname suffix
   // instead of `baseUrl.includes('openai.com')` so an arbitrary URL like
@@ -413,13 +556,32 @@ export function createDocumentationGenerator(): DocumentationGenerator {
     // Malformed URL — fall through with the default (treat as local).
   }
 
+  // Provider-specific thinking handling: a preset knows whether its API
+  // understands the vLLM-only chat_template_kwargs field; otherwise fall back
+  // to host detection. Presets target cloud APIs, so temperature is left to
+  // the provider default rather than forced to a local-server value.
+  const sendThinkingKwargs = provider ? provider.sendThinkingKwargs : isLocalServer;
+  const setTemperature = provider ? false : isLocalServer;
+
+  if (provider) {
+    const modelInfo = provider.preset.models[model];
+    if (modelInfo) {
+      logger.info(
+        `Using ${provider.provider} model ${model} ` +
+          `(region: ${provider.region}, thinking: ${modelInfo.thinking.join('/')})`
+      );
+    } else {
+      logger.warn(`Model "${model}" is not a known ${provider.provider} model; sending it as-is.`);
+    }
+  }
+
   return new DocumentationGenerator({
     baseUrl,
     model,
     timeout,
     ...(apiKey ? { apiKey } : {}),
-    ...(isLocalServer ? { temperature: 0.3 } : {}),
+    ...(setTemperature ? { temperature: 0.3 } : {}),
     // Only vLLM/local servers understand chat_template_kwargs; cloud APIs reject it.
-    sendThinkingKwargs: isLocalServer,
+    sendThinkingKwargs,
   });
 }

--- a/src/community/index.ts
+++ b/src/community/index.ts
@@ -24,6 +24,13 @@ export {
   DocumentationSummary,
   DocumentationSummarySchema,
   createDocumentationGenerator,
+  resolveProviderPreset,
+  LLM_PROVIDER_PRESETS,
+  LLMProviderPreset,
+  LLMProviderModel,
+  LLMThinkingMode,
+  LLMRegion,
+  ResolvedProviderPreset,
 } from './documentation-generator';
 
 export {

--- a/src/scripts/generate-community-docs.ts
+++ b/src/scripts/generate-community-docs.ts
@@ -9,9 +9,11 @@
  *   npm run generate:docs:incremental  # Skip nodes with existing data
  *
  * Environment variables:
+ *   N8N_MCP_LLM_PROVIDER  - Provider preset (e.g. minimax); sets base URL/model defaults
+ *   N8N_MCP_LLM_REGION    - Region for the provider preset: global (default) or cn
  *   N8N_MCP_LLM_BASE_URL  - LLM server URL (default: http://localhost:1234/v1)
  *   N8N_MCP_LLM_MODEL     - LLM model name (default: qwen3-4b-thinking-2507)
- *   N8N_MCP_LLM_API_KEY   - LLM API key (falls back to OPENAI_API_KEY; default: 'not-needed')
+ *   N8N_MCP_LLM_API_KEY   - LLM API key (falls back to preset key/OPENAI_API_KEY; default: 'not-needed')
  *   N8N_MCP_LLM_TIMEOUT   - Request timeout in ms (default: 60000)
  *   N8N_MCP_DB_PATH       - Database path (default: ./data/nodes.db)
  */
@@ -80,9 +82,11 @@ Options:
   --llm-concurrency=N     Parallel LLM requests (default: 3)
 
 Environment Variables:
+  N8N_MCP_LLM_PROVIDER    Provider preset (e.g. minimax); sets base URL/model defaults
+  N8N_MCP_LLM_REGION      Region for the provider preset: global (default) or cn
   N8N_MCP_LLM_BASE_URL    LLM server URL (default: http://localhost:1234/v1)
   N8N_MCP_LLM_MODEL       LLM model name (default: qwen3-4b-thinking-2507)
-  N8N_MCP_LLM_API_KEY     LLM API key (falls back to OPENAI_API_KEY; default: 'not-needed')
+  N8N_MCP_LLM_API_KEY     LLM API key (falls back to preset key/OPENAI_API_KEY; default: 'not-needed')
   N8N_MCP_LLM_TIMEOUT     Request timeout in ms (default: 60000)
   N8N_MCP_DB_PATH         Database path (default: ./data/nodes.db)
 

--- a/tests/unit/community/llm-provider-presets.test.ts
+++ b/tests/unit/community/llm-provider-presets.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  LLM_PROVIDER_PRESETS,
+  resolveProviderPreset,
+} from '@/community/documentation-generator';
+
+// Mock logger to suppress output during tests
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('LLM provider presets', () => {
+  describe('minimax preset definition', () => {
+    const preset = LLM_PROVIDER_PRESETS.minimax;
+
+    it('is registered', () => {
+      expect(preset).toBeDefined();
+    });
+
+    it('defaults to the global region and the MiniMax-M3 model', () => {
+      expect(preset.defaultRegion).toBe('global');
+      expect(preset.defaultModel).toBe('MiniMax-M3');
+    });
+
+    it('exposes both global and cn OpenAI-compatible endpoints', () => {
+      expect(preset.baseUrls.global).toBe('https://api.minimax.io/v1');
+      expect(preset.baseUrls.cn).toBe('https://api.minimaxi.com/v1');
+    });
+
+    it('describes both first-class models with their thinking modes', () => {
+      expect(Object.keys(preset.models).sort()).toEqual(['MiniMax-M2.7', 'MiniMax-M3']);
+      expect(preset.models['MiniMax-M3'].thinking).toEqual(['adaptive', 'disabled']);
+      expect(preset.models['MiniMax-M2.7'].thinking).toEqual(['always_on']);
+    });
+
+    it('does not send the vLLM-only chat_template_kwargs field (cloud API)', () => {
+      expect(preset.sendThinkingKwargs).toBe(false);
+    });
+
+    it('discovers the API key from MINIMAX_API_KEY', () => {
+      expect(preset.apiKeyEnvVars).toContain('MINIMAX_API_KEY');
+    });
+  });
+
+  describe('resolveProviderPreset', () => {
+    it('returns undefined when no provider is selected', () => {
+      expect(resolveProviderPreset({})).toBeUndefined();
+    });
+
+    it('returns undefined for an unknown provider', () => {
+      expect(resolveProviderPreset({ N8N_MCP_LLM_PROVIDER: 'does-not-exist' })).toBeUndefined();
+    });
+
+    it('resolves the minimax preset case-insensitively to the global endpoint', () => {
+      const resolved = resolveProviderPreset({ N8N_MCP_LLM_PROVIDER: 'MiniMax' });
+      expect(resolved?.provider).toBe('minimax');
+      expect(resolved?.region).toBe('global');
+      expect(resolved?.baseUrl).toBe('https://api.minimax.io/v1');
+      expect(resolved?.defaultModel).toBe('MiniMax-M3');
+      expect(resolved?.sendThinkingKwargs).toBe(false);
+    });
+
+    it('selects the cn endpoint when the region is cn', () => {
+      const resolved = resolveProviderPreset({
+        N8N_MCP_LLM_PROVIDER: 'minimax',
+        N8N_MCP_LLM_REGION: 'CN',
+      });
+      expect(resolved?.region).toBe('cn');
+      expect(resolved?.baseUrl).toBe('https://api.minimaxi.com/v1');
+    });
+
+    it('falls back to the default region for an unknown region value', () => {
+      const resolved = resolveProviderPreset({
+        N8N_MCP_LLM_PROVIDER: 'minimax',
+        N8N_MCP_LLM_REGION: 'mars',
+      });
+      expect(resolved?.region).toBe('global');
+      expect(resolved?.baseUrl).toBe('https://api.minimax.io/v1');
+    });
+
+    it('picks up the API key from the preset fallback env var', () => {
+      const resolved = resolveProviderPreset({
+        N8N_MCP_LLM_PROVIDER: 'minimax',
+        MINIMAX_API_KEY: 'test-key',
+      });
+      expect(resolved?.apiKey).toBe('test-key');
+    });
+
+    it('leaves the API key undefined when no preset env var is set', () => {
+      const resolved = resolveProviderPreset({ N8N_MCP_LLM_PROVIDER: 'minimax' });
+      expect(resolved?.apiKey).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Reason: The community-node documentation generator's LLM client had no first-class MiniMax preset, so MiniMax-M2.7 and the CN endpoint required manual base-URL/model overrides.

## Summary

Adds a first-class MiniMax provider preset to the community-node documentation generator. Set `N8N_MCP_LLM_PROVIDER=minimax` to configure the client without hand-editing the base URL, model and thinking handling.

The preset provides:

- **Both models as first-class**: `MiniMax-M3` (default) and `MiniMax-M2.7`, each with its supported thinking modes.
- **Regional endpoints**: `global` → `https://api.minimax.io/v1` (default) and `cn` → `https://api.minimaxi.com/v1`, selected with `N8N_MCP_LLM_REGION`.
- **Provider-specific thinking handling**: the vLLM-only `chat_template_kwargs.enable_thinking` body field is not sent (the API rejects unknown params), and reasoning output — always emitted by `MiniMax-M2.7` — is removed by the existing `<think>...</think>` stripping.
- **API-key discovery**: `MINIMAX_API_KEY` is added to the fallback chain (after `N8N_MCP_LLM_API_KEY`, before `OPENAI_API_KEY`).

Explicit `N8N_MCP_LLM_*` variables still take precedence over the preset.

## Changes

| File | Change |
|------|--------|
| `src/community/documentation-generator.ts` | Add `LLM_PROVIDER_PRESETS` (MiniMax), preset/model/region types, `resolveProviderPreset()`, and preset-aware factory wiring |
| `src/community/index.ts` | Export the new preset symbols |
| `src/scripts/generate-community-docs.ts` | Document `N8N_MCP_LLM_PROVIDER` / `N8N_MCP_LLM_REGION` |
| `.env.example` | Add a community-docs LLM configuration section |
| `tests/unit/community/llm-provider-presets.test.ts` | Unit tests for the preset shape and resolution |

## Checks

- `npm run typecheck` — passes
- `npx vitest run tests/unit/community/llm-provider-presets.test.ts` — 13 passed
- `npx vitest run tests/unit/community/documentation-batch-processor.test.ts` — 41 passed (no regression)

Conceived by Romuald Członkowski - www.aiadvisors.pl/en
