### PR TITLE
Verify a rollback against the server before reporting it as failed

### DIFF
--- a/src/mcp/handlers-workflow-diff.ts
+++ b/src/mcp/handlers-workflow-diff.ts
@@ -5,7 +5,8 @@
 
 import { z } from 'zod';
 import { randomUUID } from 'crypto';
-import { McpToolResponse } from '../types/n8n-api';
+import { isDeepStrictEqual } from 'node:util';
+import { McpToolResponse, Workflow } from '../types/n8n-api';
 import { WorkflowDiffRequest, WorkflowDiffOperation, WorkflowDiffValidationError } from '../types/workflow-diff';
 import { WorkflowDiffEngine } from '../services/workflow-diff-engine';
 import { getN8nApiClient } from './handlers-n8n-manager';
@@ -48,28 +49,26 @@ function compareVersions(
   return 'unknown';
 }
 
-// Deterministic serialisation so two workflows that differ only in key order compare equal.
-function stableStringify(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
-  if (value && typeof value === 'object') {
-    const entries = Object.keys(value as Record<string, unknown>)
-      .sort()
-      .map(key => `${JSON.stringify(key)}:${stableStringify((value as Record<string, unknown>)[key])}`);
-    return `{${entries.join(',')}}`;
+// The shape an update would send, for comparing two reads of the same workflow. Cloned because
+// cleanWorkflowForUpdate() mutates: it assigns a random webhookId to webhook nodes that lack one,
+// which is also why that field is dropped here. Without both, every workflow containing a webhook
+// node would compare unequal to itself.
+function writableShape(workflow: Workflow): Record<string, unknown> {
+  const cleaned = cleanWorkflowForUpdate(structuredClone(workflow)) as Record<string, unknown>;
+  const nodes = cleaned.nodes;
+  if (Array.isArray(nodes)) {
+    for (const node of nodes) {
+      if (node && typeof node === 'object') delete (node as Record<string, unknown>).webhookId;
+    }
   }
-  return JSON.stringify(value) ?? 'null';
+  return cleaned;
 }
 
-// Compare only the fields an update PUT actually sends. Version identity cannot be used to verify
-// a rollback: a successful rollback writes a new version, so compareVersions() reports 'changed'
-// even when the content was fully restored.
-function sameWritableContent(a: unknown, b: unknown): boolean {
-  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') return false;
+// Compare only the fields the update allowlist accepts. Version identity cannot verify a rollback:
+// a successful rollback writes a new version, so compareVersions() reports 'changed' regardless.
+function sameWritableContent(a: Workflow, b: Workflow): boolean {
   try {
-    return (
-      stableStringify(cleanWorkflowForUpdate(a as any)) ===
-      stableStringify(cleanWorkflowForUpdate(b as any))
-    );
+    return isDeepStrictEqual(writableShape(a), writableShape(b));
   } catch {
     return false;
   }
@@ -465,11 +464,9 @@ export async function handleUpdatePartialWorkflow(
           } catch (rollbackErr) {
             rollbackErrorMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
 
-            // A rollback PUT can persist and then throw. n8n's public API commits the workflow
-            // content before it checks publish permission, so a caller allowed to edit but not to
-            // publish gets an error on a write that landed. Trusting the throw tells the user their
-            // workflow may be broken when it was in fact restored, which invites a riskier recovery
-            // than doing nothing. Verify against the server instead.
+            // n8n can persist a rollback PUT and then reject it: the public API commits workflow
+            // content before it checks publish permission. Verify against the server rather than
+            // trusting the throw, or we warn of a broken workflow that was in fact restored.
             try {
               const afterRollback = await client.getWorkflow(input.id);
               if (sameWritableContent(afterRollback, workflowBefore)) {

--- a/src/mcp/handlers-workflow-diff.ts
+++ b/src/mcp/handlers-workflow-diff.ts
@@ -12,7 +12,7 @@ import { getN8nApiClient } from './handlers-n8n-manager';
 import { N8nApiError, getUserFriendlyErrorMessage } from '../utils/n8n-errors';
 import { logger } from '../utils/logger';
 import { InstanceContext, getInstanceScopeId } from '../types/instance-context';
-import { validateWorkflowStructure } from '../services/n8n-validation';
+import { validateWorkflowStructure, cleanWorkflowForUpdate } from '../services/n8n-validation';
 import { NodeRepository } from '../database/node-repository';
 import { WorkflowVersioningService } from '../services/workflow-versioning-service';
 import { WorkflowValidator } from '../services/workflow-validator';
@@ -46,6 +46,33 @@ function compareVersions(
     return a.updatedAt === b.updatedAt ? 'same' : 'changed';
   }
   return 'unknown';
+}
+
+// Deterministic serialisation so two workflows that differ only in key order compare equal.
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const entries = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableStringify((value as Record<string, unknown>)[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+// Compare only the fields an update PUT actually sends. Version identity cannot be used to verify
+// a rollback: a successful rollback writes a new version, so compareVersions() reports 'changed'
+// even when the content was fully restored.
+function sameWritableContent(a: unknown, b: unknown): boolean {
+  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') return false;
+  try {
+    return (
+      stableStringify(cleanWorkflowForUpdate(a as any)) ===
+      stableStringify(cleanWorkflowForUpdate(b as any))
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -422,6 +449,7 @@ export async function handleUpdatePartialWorkflow(
 
           // Either persist-then-fail OR couldn't determine — attempt rollback.
           let rollbackPerformed = false;
+          let rollbackVerifiedAfterError = false;
           let rollbackErrorMessage: string | undefined;
           try {
             // No authoredGroups here: restoring the graph matters, frames do not. If the snapshot's
@@ -436,11 +464,34 @@ export async function handleUpdatePartialWorkflow(
             });
           } catch (rollbackErr) {
             rollbackErrorMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
-            logger.error('updateWorkflow failed AND rollback failed', {
-              workflowId: input.id,
-              originalError: updateError instanceof Error ? updateError.message : String(updateError),
-              rollbackError: rollbackErrorMessage,
-            });
+
+            // A rollback PUT can persist and then throw. n8n's public API commits the workflow
+            // content before it checks publish permission, so a caller allowed to edit but not to
+            // publish gets an error on a write that landed. Trusting the throw tells the user their
+            // workflow may be broken when it was in fact restored, which invites a riskier recovery
+            // than doing nothing. Verify against the server instead.
+            try {
+              const afterRollback = await client.getWorkflow(input.id);
+              if (sameWritableContent(afterRollback, workflowBefore)) {
+                rollbackPerformed = true;
+                rollbackVerifiedAfterError = true;
+                logger.warn('rollback PUT errored but content matches the prior state; treating as rolled back', {
+                  workflowId: input.id,
+                  rollbackError: rollbackErrorMessage,
+                });
+                rollbackErrorMessage = undefined;
+              }
+            } catch (verifyErr) {
+              logger.debug('post-rollback verification GET failed', verifyErr);
+            }
+
+            if (!rollbackPerformed) {
+              logger.error('updateWorkflow failed AND rollback failed', {
+                workflowId: input.id,
+                originalError: updateError instanceof Error ? updateError.message : String(updateError),
+                rollbackError: rollbackErrorMessage,
+              });
+            }
           }
 
           // Re-throw with rollback context attached so the outer N8nApiError
@@ -454,6 +505,7 @@ export async function handleUpdatePartialWorkflow(
             const augmentedDetails: Record<string, unknown> = {
               ...((updateError.details as Record<string, unknown>) ?? {}),
               rollbackPerformed,
+              ...(rollbackVerifiedAfterError ? { rollbackVerifiedAfterError: true } : {}),
               ...(folderMoveInPayload && rollbackPerformed ? { folderMoveMayHavePersisted: true } : {}),
               ...(rollbackErrorMessage ? { rollbackError: rollbackErrorMessage } : {}),
               ...(workflowBefore.versionId ? { priorVersionId: workflowBefore.versionId } : {}),

--- a/src/mcp/handlers-workflow-diff.ts
+++ b/src/mcp/handlers-workflow-diff.ts
@@ -51,14 +51,19 @@ function compareVersions(
 
 // The shape an update would send, for comparing two reads of the same workflow. Cloned because
 // cleanWorkflowForUpdate() mutates: it assigns a random webhookId to webhook nodes that lack one,
-// which is also why that field is dropped here. Without both, every workflow containing a webhook
-// node would compare unequal to itself.
+// so two reads of one workflow would otherwise compare unequal to themselves. Only those generated
+// ids are dropped; a webhookId the workflow already carried is real content and stays compared.
 function writableShape(workflow: Workflow): Record<string, unknown> {
+  const generated = new Set(
+    (workflow.nodes ?? []).filter(node => !node.webhookId).map(node => node.id),
+  );
   const cleaned = cleanWorkflowForUpdate(structuredClone(workflow)) as Record<string, unknown>;
   const nodes = cleaned.nodes;
   if (Array.isArray(nodes)) {
     for (const node of nodes) {
-      if (node && typeof node === 'object') delete (node as Record<string, unknown>).webhookId;
+      if (node && typeof node === 'object' && generated.has(node.id)) {
+        delete (node as Record<string, unknown>).webhookId;
+      }
     }
   }
   return cleaned;

--- a/tests/unit/mcp/handlers-workflow-diff.test.ts
+++ b/tests/unit/mcp/handlers-workflow-diff.test.ts
@@ -1182,6 +1182,53 @@ describe('handlers-workflow-diff', () => {
       });
     });
 
+    it('should treat a rollback as performed when its PUT errored but the content was restored', async () => {
+      // n8n's public API commits workflow content before it checks publish permission, so a
+      // rollback PUT can persist and then throw. Version identity cannot settle it: the restored
+      // workflow necessarily carries a new versionId, so the writable content is what must be
+      // compared. Reporting a broken workflow here invites a riskier recovery than doing nothing.
+      const before = createTestWorkflow({ versionId: 'v1' });
+      const afterPersist = createTestWorkflow({ versionId: 'v2' });
+      const afterRollback = createTestWorkflow({ versionId: 'v3' });
+      const validationError = new N8nValidationError('Invalid workflow structure', {
+        field: 'connections',
+        message: 'Invalid connection configuration',
+      });
+      const publishRefused = new N8nNotFoundError(
+        'You do not have permission to activate this workflow. Ask the owner to share it with you.',
+      );
+
+      mockApiClient.getWorkflow
+        .mockResolvedValueOnce(before)
+        .mockResolvedValueOnce(afterPersist)
+        .mockResolvedValueOnce(afterRollback);
+      mockDiffEngine.applyDiff.mockResolvedValue({
+        success: true,
+        workflow: before,
+        operationsApplied: 1,
+        message: 'Success',
+        errors: [],
+      });
+      mockApiClient.updateWorkflow
+        .mockRejectedValueOnce(validationError)
+        .mockRejectedValueOnce(publishRefused);
+
+      const result = await handleUpdatePartialWorkflow({
+        id: 'test-id',
+        operations: [{ type: 'updateNode', nodeId: 'node1', updates: {} }],
+      }, mockRepository);
+
+      expect(mockApiClient.updateWorkflow).toHaveBeenCalledTimes(2);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('workflow restored to prior state');
+      expect(result.error).not.toContain('rollback also failed');
+      expect(result.details).toMatchObject({
+        rollbackPerformed: true,
+        rollbackVerifiedAfterError: true,
+      });
+      expect(result.details).not.toHaveProperty('rollbackError');
+    });
+
     it('should handle input validation errors', async () => {
       const invalidInput = {
         id: 'test-id',

--- a/tests/unit/mcp/handlers-workflow-diff.test.ts
+++ b/tests/unit/mcp/handlers-workflow-diff.test.ts
@@ -1150,7 +1150,10 @@ describe('handlers-workflow-diff', () => {
 
       mockApiClient.getWorkflow
         .mockResolvedValueOnce(before)
-        .mockResolvedValueOnce(afterPersist);
+        .mockResolvedValueOnce(afterPersist)
+        // The post-rollback verification read fails too, so the outcome stays inconclusive and the
+        // warning stands. Explicit rather than relying on an unconfigured mock.
+        .mockRejectedValueOnce(new N8nServerError('n8n unreachable', 503));
       mockDiffEngine.applyDiff.mockResolvedValue({
         success: true,
         workflow: before,
@@ -1187,9 +1190,12 @@ describe('handlers-workflow-diff', () => {
       // rollback PUT can persist and then throw. Version identity cannot settle it: the restored
       // workflow necessarily carries a new versionId, so the writable content is what must be
       // compared. Reporting a broken workflow here invites a riskier recovery than doing nothing.
-      const before = createTestWorkflow({ versionId: 'v1' });
-      const afterPersist = createTestWorkflow({ versionId: 'v2' });
-      const afterRollback = createTestWorkflow({ versionId: 'v3' });
+      // Names differ so the fixture actually models a reverted change rather than passing on
+      // workflows that were identical all along.
+      const before = createTestWorkflow({ name: 'Original Workflow', versionId: 'v1' });
+      const attempted = createTestWorkflow({ name: 'Renamed Workflow', versionId: 'v1' });
+      const afterPersist = createTestWorkflow({ name: 'Renamed Workflow', versionId: 'v2' });
+      const afterRollback = createTestWorkflow({ name: 'Original Workflow', versionId: 'v3' });
       const validationError = new N8nValidationError('Invalid workflow structure', {
         field: 'connections',
         message: 'Invalid connection configuration',
@@ -1204,7 +1210,7 @@ describe('handlers-workflow-diff', () => {
         .mockResolvedValueOnce(afterRollback);
       mockDiffEngine.applyDiff.mockResolvedValue({
         success: true,
-        workflow: before,
+        workflow: attempted,
         operationsApplied: 1,
         message: 'Success',
         errors: [],
@@ -1215,7 +1221,7 @@ describe('handlers-workflow-diff', () => {
 
       const result = await handleUpdatePartialWorkflow({
         id: 'test-id',
-        operations: [{ type: 'updateNode', nodeId: 'node1', updates: {} }],
+        operations: [{ type: 'updateName', name: 'Renamed Workflow' }],
       }, mockRepository);
 
       expect(mockApiClient.updateWorkflow).toHaveBeenCalledTimes(2);
@@ -1227,6 +1233,117 @@ describe('handlers-workflow-diff', () => {
         rollbackVerifiedAfterError: true,
       });
       expect(result.details).not.toHaveProperty('rollbackError');
+    });
+
+    it('should still report rollback failure when the content was not restored', async () => {
+      // The verification must not turn every rollback failure into a success: if the server still
+      // holds the attempted change, the warning has to stand.
+      const before = createTestWorkflow({ name: 'Original Workflow', versionId: 'v1' });
+      const attempted = createTestWorkflow({ name: 'Renamed Workflow', versionId: 'v1' });
+      const afterPersist = createTestWorkflow({ name: 'Renamed Workflow', versionId: 'v2' });
+      const validationError = new N8nValidationError('Invalid workflow structure', {
+        field: 'connections',
+        message: 'Invalid connection configuration',
+      });
+      const rollbackFailure = new N8nServerError('n8n unreachable', 503);
+
+      mockApiClient.getWorkflow
+        .mockResolvedValueOnce(before)
+        .mockResolvedValueOnce(afterPersist)
+        .mockResolvedValueOnce(afterPersist);
+      mockDiffEngine.applyDiff.mockResolvedValue({
+        success: true,
+        workflow: attempted,
+        operationsApplied: 1,
+        message: 'Success',
+        errors: [],
+      });
+      mockApiClient.updateWorkflow
+        .mockRejectedValueOnce(validationError)
+        .mockRejectedValueOnce(rollbackFailure);
+
+      const result = await handleUpdatePartialWorkflow({
+        id: 'test-id',
+        operations: [{ type: 'updateName', name: 'Renamed Workflow' }],
+      }, mockRepository);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('rollback also failed');
+      expect(result.details).toMatchObject({
+        rollbackPerformed: false,
+        rollbackError: 'n8n unreachable',
+      });
+      expect(result.details).not.toHaveProperty('rollbackVerifiedAfterError');
+    });
+
+    it('should verify a restored workflow that contains a webhook node', async () => {
+      // Guards a subtle trap: the update allowlist assigns a random webhookId to webhook nodes that
+      // lack one, and does so in place. Comparing the raw cleaned output would mutate both reads and
+      // give each a different id, so a webhook workflow would never compare equal to itself.
+      const webhookNode = {
+        id: 'hook1',
+        name: 'Webhook',
+        type: 'n8n-nodes-base.webhook',
+        typeVersion: 2,
+        position: [0, 0],
+        parameters: { path: 'incoming' },
+      };
+      const before = createTestWorkflow({
+        name: 'Original Workflow',
+        versionId: 'v1',
+        nodes: [webhookNode],
+        connections: {},
+      });
+      const attempted = createTestWorkflow({
+        name: 'Renamed Workflow',
+        versionId: 'v1',
+        nodes: [webhookNode],
+        connections: {},
+      });
+      const afterPersist = createTestWorkflow({
+        name: 'Renamed Workflow',
+        versionId: 'v2',
+        nodes: [webhookNode],
+        connections: {},
+      });
+      const afterRollback = createTestWorkflow({
+        name: 'Original Workflow',
+        versionId: 'v3',
+        nodes: [webhookNode],
+        connections: {},
+      });
+      const validationError = new N8nValidationError('Invalid workflow structure', {
+        field: 'connections',
+        message: 'Invalid connection configuration',
+      });
+      const publishRefused = new N8nNotFoundError(
+        'You do not have permission to activate this workflow. Ask the owner to share it with you.',
+      );
+
+      mockApiClient.getWorkflow
+        .mockResolvedValueOnce(before)
+        .mockResolvedValueOnce(afterPersist)
+        .mockResolvedValueOnce(afterRollback);
+      mockDiffEngine.applyDiff.mockResolvedValue({
+        success: true,
+        workflow: attempted,
+        operationsApplied: 1,
+        message: 'Success',
+        errors: [],
+      });
+      mockApiClient.updateWorkflow
+        .mockRejectedValueOnce(validationError)
+        .mockRejectedValueOnce(publishRefused);
+
+      const result = await handleUpdatePartialWorkflow({
+        id: 'test-id',
+        operations: [{ type: 'updateName', name: 'Renamed Workflow' }],
+      }, mockRepository);
+
+      expect(result.details).toMatchObject({
+        rollbackPerformed: true,
+        rollbackVerifiedAfterError: true,
+      });
     });
 
     it('should handle input validation errors', async () => {

--- a/tests/unit/mcp/handlers-workflow-diff.test.ts
+++ b/tests/unit/mcp/handlers-workflow-diff.test.ts
@@ -1346,6 +1346,70 @@ describe('handlers-workflow-diff', () => {
       });
     });
 
+    it('should still report rollback failure when only a pre-existing webhookId differs', async () => {
+      // A webhookId the workflow already carried is real content, not a value the allowlist made up,
+      // so a change to one means the prior state was not restored. Only generated ids are ignored.
+      const hook = (webhookId: string) => ({
+        id: 'hook1',
+        name: 'Webhook',
+        type: 'n8n-nodes-base.webhook',
+        typeVersion: 2,
+        position: [0, 0],
+        parameters: { path: 'incoming' },
+        webhookId,
+      });
+      const before = createTestWorkflow({
+        name: 'Original Workflow',
+        versionId: 'v1',
+        nodes: [hook('stable-hook-id')],
+        connections: {},
+      });
+      const afterPersist = createTestWorkflow({
+        name: 'Original Workflow',
+        versionId: 'v2',
+        nodes: [hook('stable-hook-id')],
+        connections: {},
+      });
+      const afterRollback = createTestWorkflow({
+        name: 'Original Workflow',
+        versionId: 'v3',
+        nodes: [hook('replaced-hook-id')],
+        connections: {},
+      });
+      const validationError = new N8nValidationError('Invalid workflow structure', {
+        field: 'connections',
+        message: 'Invalid connection configuration',
+      });
+      const publishRefused = new N8nNotFoundError(
+        'You do not have permission to activate this workflow. Ask the owner to share it with you.',
+      );
+
+      mockApiClient.getWorkflow
+        .mockResolvedValueOnce(before)
+        .mockResolvedValueOnce(afterPersist)
+        .mockResolvedValueOnce(afterRollback);
+      mockDiffEngine.applyDiff.mockResolvedValue({
+        success: true,
+        workflow: before,
+        operationsApplied: 1,
+        message: 'Success',
+        errors: [],
+      });
+      mockApiClient.updateWorkflow
+        .mockRejectedValueOnce(validationError)
+        .mockRejectedValueOnce(publishRefused);
+
+      const result = await handleUpdatePartialWorkflow({
+        id: 'test-id',
+        operations: [{ type: 'updateName', name: 'Original Workflow' }],
+      }, mockRepository);
+
+      expect(result.error).toContain('rollback also failed');
+      expect(result.details).toMatchObject({
+        rollbackPerformed: false,
+      });
+    });
+
     it('should handle input validation errors', async () => {
       const invalidInput = {
         id: 'test-id',


### PR DESCRIPTION
## What happens now

When `n8n_update_partial_workflow` fails, the handler re-PUTs the previous body as a rollback. If that rollback PUT persists and *then* throws, the catch block records `rollbackPerformed: false` and the tool reports:

```
(rollback also failed; workflow may be in a broken state — try n8n_workflow_versions for a backup)
```

even though the content was restored. Verified against n8n 2.31.3: after two such reported failures, workflow content matched the pre-edit state exactly.

The rollback PUT persists-then-throws because n8n's public API commits workflow content before it checks publish permission. A caller allowed to edit but not to publish therefore receives an error on a write that landed. The behaviour is correct; the report is not. Telling someone their workflow may be broken when it is not invites a riskier recovery than doing nothing.

This is not limited to older n8n. On 2.34.x the content is still committed in `WorkflowService.update` before `activateWorkflow` performs the `workflow:publish` check, so the same persist-then-error pattern applies. What changed in 2.34 is that the active-version pointer no longer moves, not the ordering of the write and the check.

## What this changes

After the rollback PUT throws, re-read the workflow and compare the fields the update allowlist accepts. If they match the snapshot, report `rollbackPerformed: true`, add `rollbackVerifiedAfterError: true`, and surface only the original error. If the read fails or the content differs, the existing warning stands.

Two things worth calling out:

- **Version identity cannot be used for this check.** A successful rollback writes a new version, so `compareVersions()` reports `changed` whether or not the content was restored.
- **`cleanWorkflowForUpdate()` assigns a random `webhookId`** to webhook nodes that lack one, and does so in place. Comparing its output directly would mutate both reads and give each a different id, so any workflow containing a webhook node could never compare equal to itself. The comparison clones before cleaning and drops that generated field.

Comparison uses `isDeepStrictEqual` rather than bespoke serialisation.

## Tests

Three cases added to `tests/unit/mcp/handlers-workflow-diff.test.ts`: content restored after a throwing rollback, content *not* restored so the warning stands, and a restored workflow containing a webhook node. The existing "both PUTs fail" case now rejects its verification read explicitly rather than relying on an unconfigured mock. 60 tests pass in that file.
