### PR TITLE
fix(partial-workflow): strip unknown node properties echoed by n8n GET

### DIFF
--- a/src/services/n8n-validation.ts
+++ b/src/services/n8n-validation.ts
@@ -26,12 +26,59 @@ export const workflowNodeSchema = z.preprocess(normalizeMcpWorkflowNode, z.objec
   notes: z.string().optional(),
   notesInFlow: z.boolean().optional(),
   continueOnFail: z.boolean().optional(),
+  onError: z.enum(['continueRegularOutput', 'continueErrorOutput', 'stopWorkflow']).optional(),
   retryOnFail: z.boolean().optional(),
   maxTries: z.number().optional(),
   waitBetweenTries: z.number().optional(),
   alwaysOutputData: z.boolean().optional(),
   executeOnce: z.boolean().optional(),
+  webhookId: z.string().optional(),
 }));
+
+/**
+ * Properties accepted by n8n's Public API write schema for a node.
+ * MUST stay in sync with `workflowNodeSchema` above.
+ * Used to strip unknown properties returned by GET that PUT/PATCH rejects.
+ */
+const ALLOWED_NODE_PROPERTIES = new Set([
+  'id',
+  'name',
+  'type',
+  'typeVersion',
+  'position',
+  'parameters',
+  'credentials',
+  'disabled',
+  'notes',
+  'notesInFlow',
+  'continueOnFail',
+  'onError',
+  'retryOnFail',
+  'maxTries',
+  'waitBetweenTries',
+  'alwaysOutputData',
+  'executeOnce',
+  'webhookId',
+]);
+
+/**
+ * Strip unknown properties from a single node so it conforms to n8n's write schema.
+ * n8n GET responses echo server-managed fields (e.g. issues, runIndex, data) that
+ * PUT/PATCH rejects with "must NOT have additional properties".
+ */
+export function cleanNodeForApi(node: WorkflowNode): WorkflowNode {
+  const cleaned: Partial<WorkflowNode> = {};
+  for (const key of Object.keys(node)) {
+    if (ALLOWED_NODE_PROPERTIES.has(key)) {
+      (cleaned as any)[key] = (node as any)[key];
+    }
+  }
+  // position is required; ensure it survives even if the set above drifts
+  if (!cleaned.position && node.position) {
+    cleaned.position = node.position;
+  }
+  return cleaned as WorkflowNode;
+}
 
 // Connection array schema used by all connection types
 const connectionArraySchema = z.array(
@@ -143,6 +190,11 @@ export function cleanWorkflowForCreate(workflow: Partial<Workflow>): Partial<Wor
 
   ensureWebhookIds(cleanedWorkflow.nodes);
 
+  // Strip unknown node properties that n8n GET echoes but PUT/PATCH rejects
+  if (cleanedWorkflow.nodes) {
+    cleanedWorkflow.nodes = cleanedWorkflow.nodes.map(cleanNodeForApi);
+  }
+
   return cleanedWorkflow;
 }
 
@@ -237,6 +289,11 @@ export function cleanWorkflowForUpdate(workflow: Workflow): Partial<Workflow> {
   }
 
   ensureWebhookIds(cleanedWorkflow.nodes as WorkflowNode[] | undefined);
+
+  // Strip unknown node properties that n8n GET echoes but PUT/PATCH rejects
+  if (cleanedWorkflow.nodes) {
+    cleanedWorkflow.nodes = (cleanedWorkflow.nodes as WorkflowNode[]).map(cleanNodeForApi);
+  }
 
   return cleanedWorkflow as Partial<Workflow>;
 }

--- a/tests/unit/services/n8n-validation.test.ts
+++ b/tests/unit/services/n8n-validation.test.ts
@@ -9,6 +9,7 @@ import {
   validateWorkflowSettings,
   cleanWorkflowForCreate,
   cleanWorkflowForUpdate,
+  cleanNodeForApi,
   validateWorkflowStructure,
   hasWebhookTrigger,
   getWebhookUrl,
@@ -409,6 +410,29 @@ describe('n8n-validation', () => {
         const cleaned = cleanWorkflowForCreate(workflow as Workflow);
         expect(cleaned.nodes![0].webhookId).toBeUndefined();
       });
+
+      it('should strip unknown node properties echoed by n8n GET', () => {
+        const workflow = workflowWithNodes([
+          {
+            id: 'n1',
+            name: 'Set',
+            type: 'n8n-nodes-base.set',
+            typeVersion: 3,
+            position: [100, 200],
+            parameters: {},
+            onError: 'continueErrorOutput',
+            issues: { parameters: { missing: true } },
+            runIndex: 0,
+          } as unknown as WorkflowNode,
+        ]);
+
+        const cleaned = cleanWorkflowForCreate(workflow as Workflow);
+        const node = cleaned.nodes![0];
+
+        expect(node.onError).toBe('continueErrorOutput');
+        expect(node).not.toHaveProperty('issues');
+        expect(node).not.toHaveProperty('runIndex');
+      });
     });
 
     describe('cleanWorkflowForUpdate', () => {
@@ -776,6 +800,100 @@ describe('n8n-validation', () => {
 
         const cleaned = cleanWorkflowForUpdate(workflow);
         expect(cleaned.nodes![0].webhookId).toBeUndefined();
+      });
+
+      it('should strip unknown node properties echoed by n8n GET (Issue #extra-node-props)', () => {
+        const workflow = workflowWithNodes([
+          {
+            id: 'n1',
+            name: 'Set',
+            type: 'n8n-nodes-base.set',
+            typeVersion: 3,
+            position: [100, 200],
+            parameters: {},
+            onError: 'continueRegularOutput',
+            // Server-managed fields echoed by GET but rejected on PUT/PATCH:
+            issues: { parameters: { missing: true } },
+            runIndex: 0,
+          } as any,
+          {
+            id: 'n2',
+            name: 'Webhook',
+            type: 'n8n-nodes-base.webhook',
+            typeVersion: 1,
+            position: [300, 200],
+            parameters: {},
+            webhookId: 'existing-wh-id',
+            // Extra echo field
+            data: { some: 'thing' },
+          } as any,
+        ]);
+
+        const cleaned = cleanWorkflowForUpdate(workflow as any);
+        const setNode = cleaned.nodes![0];
+        const webhookNode2 = cleaned.nodes![1];
+
+        // Allowed fields survive
+        expect(setNode.id).toBe('n1');
+        expect(setNode.name).toBe('Set');
+        expect(setNode.type).toBe('n8n-nodes-base.set');
+        expect(setNode.typeVersion).toBe(3);
+        expect(setNode.position).toEqual([100, 200]);
+        expect(setNode.onError).toBe('continueRegularOutput');
+
+        // Unknown echo fields are stripped
+        expect(setNode).not.toHaveProperty('issues');
+        expect(setNode).not.toHaveProperty('runIndex');
+        expect(webhookNode2).not.toHaveProperty('data');
+
+        // webhookId survives (it's in the allowlist)
+        expect(webhookNode2.webhookId).toBe('existing-wh-id');
+      });
+    });
+
+    describe('cleanNodeForApi', () => {
+      it('should keep all known node properties', () => {
+        const node: WorkflowNode = {
+          id: 'n1',
+          name: 'Test',
+          type: 'n8n-nodes-base.set',
+          typeVersion: 3,
+          position: [0, 0],
+          parameters: { key: 'val' },
+          credentials: { api: 'cred' },
+          disabled: false,
+          notes: 'note',
+          notesInFlow: true,
+          continueOnFail: true,
+          onError: 'stopWorkflow',
+          retryOnFail: true,
+          maxTries: 3,
+          waitBetweenTries: 1000,
+          alwaysOutputData: true,
+          executeOnce: false,
+          webhookId: 'wh-id',
+        };
+        const cleaned = cleanNodeForApi(node);
+        expect(cleaned).toEqual(node);
+      });
+
+      it('should strip unknown properties', () => {
+        const node = {
+          id: 'n1',
+          name: 'Test',
+          type: 'n8n-nodes-base.set',
+          typeVersion: 3,
+          position: [0, 0],
+          parameters: {},
+          issues: { error: true },
+          runIndex: 0,
+          data: { extra: true },
+        } as unknown as WorkflowNode;
+        const cleaned = cleanNodeForApi(node);
+        expect(cleaned).not.toHaveProperty('issues');
+        expect(cleaned).not.toHaveProperty('runIndex');
+        expect(cleaned).not.toHaveProperty('data');
+        expect(cleaned.id).toBe('n1');
       });
     });
   });


### PR DESCRIPTION
   ## Summary

   `n8n_update_partial_workflow` (and full workflow updates) fail with `request/body/nodes/X must NOT have additional properties` when the workflow payload contains node properties that n8n's GET API
   returns but its PUT/PATCH schema rejects.

   ## Problem

   n8n's GET `/workflows/{id}` returns node properties that are server-managed or read-only — e.g. `issues`, `runIndex`, `data`, and even legitimate fields like `onError` and `webhookId` that were missing
   from the local MCP schema. When the MCP tool reconstructs the payload for a partial or full update, these extra properties leak into the request body and n8n rejects it.

## Changes

   - **Added `onError` and `webhookId` to `workflowNodeSchema`** (`src/services/n8n-validation.ts`) so they are recognised as valid instead of being silently dropped.
   - **Introduced `cleanNodeForApi()`** that filters each node through an allow-list of API-safe properties, stripping anything unknown (server-managed echo fields, future additions).
   - **Applied filtering** in both `cleanWorkflowForCreate` and `cleanWorkflowForUpdate`.
   - **Added 4 unit tests** covering the stripping behaviour and the new function.

   ## Verification

   - `npm run typecheck` passes
   - `npm run build` passes
   - `npm test -- tests/unit/services/n8n-validation.test.ts` → 115 tests pass

   Tested with n8n local instance.