### PR TITLE
README: add an independent maintenance badge (StillShipping, maintained · 100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Tests](https://img.shields.io/badge/tests-5418%20passing-brightgreen.svg)](https://github.com/czlonkowski/n8n-mcp/actions)
 [![n8n version](https://img.shields.io/badge/n8n-2.32.7-orange.svg)](https://github.com/n8n-io/n8n)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io%2Fczlonkowski%2Fn8n--mcp-green.svg)](https://github.com/czlonkowski/n8n-mcp/pkgs/container/n8n-mcp)
+[![Maintenance: maintained](https://toolproof.kynth.studio/badge/stillshipping/czlonkowski/n8n-mcp.svg)](https://stillshipping.kynth.studio/tool/n8n-mcp)
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/n8n-mcp?referralCode=n8n-mcp)
 
 A Model Context Protocol (MCP) server that provides AI assistants with comprehensive access to n8n node documentation, properties, and operations. Deploy in minutes to give Claude and other AI assistants deep knowledge about n8n's 2,412 workflow automation nodes (829 core + 1,583 community).


### PR DESCRIPTION
Adds one badge to the existing row:

[![Maintenance: maintained](https://toolproof.kynth.studio/badge/stillshipping/czlonkowski/n8n-mcp.svg)](https://stillshipping.kynth.studio/tool/n8n-mcp)

**What it is.** StillShipping tracks 333 agent tools and recomputes one of three verdicts — maintained, stale, dead — every night from the GitHub API: commit recency and volume, release cadence, issue response time, and how many people have committed in the last 90 days. n8n-MCP reads `maintained` at freshness 100/100. Every verdict ships with the list of facts that produced it, so a reader can interrogate it rather than take it on faith: https://stillshipping.kynth.studio/tool/n8n-mcp

**Why it might earn the slot.** The MCP server ecosystem has a real abandonment problem — a large share of what is listed in the directories has stopped moving, and the reliable early signal is silence rather than an announcement. A third party saying out loud that this one is alive is worth more to someone evaluating it than a star count, and it is not a claim you are making about yourself.

**Disclosure.** I maintain StillShipping, so I am proposing a badge that points at my own index. Judge it on whether it is useful to your readers and close it without ceremony if it is not — a badge nobody wanted is worse than no badge.

**The things that usually decide a badge PR:**

- **Free, no account, no key.** GET only.
- **It updates itself.** Recomputed nightly, so it changes when the project does and there is nothing to keep in sync. If n8n-MCP ever went quiet the badge would say so on its own — which is the only reason a maintenance badge means anything.
- **You cannot set the value and neither can I.** There is no `?message=` parameter and there will not be one.
- **No tracking.** The endpoint sets no cookie, reads no header it does not need to render an SVG, and keeps no per-reader log.
- **If you would rather not hotlink a domain you have not heard of** — a completely fair objection, and the reason nearly every badge in your row is shields — the same data is served in shields.io's endpoint schema, so shields renders the image and your readers never talk to my domain:

  ```
  [![maintenance](https://img.shields.io/endpoint?url=https%3A%2F%2Ftoolproof.kynth.studio%2Fapi%2Fv1%2Fbadge%2Fstillshipping%2Fczlonkowski%2Fn8n-mcp)](https://stillshipping.kynth.studio/tool/n8n-mcp)
  ```

  Say which you prefer and I will switch the PR.

**Context.** StillShipping is one of nine indexes under [Toolproof](https://toolproof.kynth.studio), a measurement layer for AI agent tooling published by Kynth Studios. Method: https://toolproof.kynth.studio/methodology · Everything as JSON, no key: https://toolproof.kynth.studio/api · Badge terms, and the two indexes that deliberately mint no badge because a badge there could only ever be used against its subject: https://toolproof.kynth.studio/badges

Every reading that exists for a repository, in one call:

```
curl https://toolproof.kynth.studio/api/v1/subjects/czlonkowski/n8n-mcp
```

Thanks either way — and if the verdict looks wrong to you, I would genuinely rather hear that than land the badge.
