### PR TITLE
test: assert insert scaling instead of wall-clock in the bulk operations test

### DIFF
--- a/tests/integration/database-integration.test.ts
+++ b/tests/integration/database-integration.test.ts
@@ -261,34 +261,78 @@ describe('Database Integration Tests', () => {
   });
   
   describe('Performance Testing', () => {
-    it('should handle bulk operations efficiently', async () => {
-      const bulkNodes = Array.from({ length: 1000 }, (_, i) => ({
-        nodeType: `nodes-base.bulk${i}`,
-        displayName: `Bulk Node ${i}`,
-        category: i % 2 === 0 ? 'Category A' : 'Category B',
-        isAITool: i % 10 === 0
-      }));
-      
-      const insertDuration = await measureDatabaseOperation('Bulk Insert 1000 nodes', async () => {
-        await seedTestNodes(nodeRepo, bulkNodes);
-      });
-      
-      // Should complete reasonably quickly
-      expect(insertDuration).toBeLessThan(5000); // 5 seconds max
-      
-      // Test query performance
+    // Scaling is asserted, not wall-clock. An absolute millisecond budget here measures the
+    // machine, not the code: this test ran in ~450ms locally while failing at 6.8s, 10.1s and
+    // 10.9s on shared CI runners, none of which involved a change to the insert path. What the
+    // test is actually worth catching is a regression from batched inserts to per-row work,
+    // which shows up as a rising per-node cost regardless of how fast the host is.
+    it('should keep per-node insert cost flat as the batch grows', async () => {
+      const makeNodes = (count: number, prefix: string, category: string) =>
+        Array.from({ length: count }, (_, i) => ({
+          nodeType: `nodes-base.${prefix}${i}`,
+          displayName: `${prefix} Node ${i}`,
+          category,
+          isAITool: i % 10 === 0
+        }));
+
+      // Baseline on the same host, in the same run, so both measurements share its conditions
+      const baselineCount = 100;
+      const baselineDuration = await measureDatabaseOperation(
+        `Baseline insert ${baselineCount} nodes`,
+        async () => {
+          await seedTestNodes(nodeRepo, makeNodes(baselineCount, 'baseline', 'Category Baseline'));
+        }
+      );
+
+      const bulkCount = 1000;
+      const bulkNodes = [
+        ...makeNodes(bulkCount / 2, 'bulkA', 'Category A'),
+        ...makeNodes(bulkCount / 2, 'bulkB', 'Category B')
+      ];
+      const insertDuration = await measureDatabaseOperation(
+        `Bulk insert ${bulkCount} nodes`,
+        async () => {
+          await seedTestNodes(nodeRepo, bulkNodes);
+        }
+      );
+
+      // Every row must actually be there - a fast insert that lost rows is not a pass
+      const inserted = testDb.adapter
+        .prepare("SELECT COUNT(*) as count FROM nodes WHERE node_type LIKE 'nodes-base.bulk%'")
+        .get() as { count: number };
+      expect(inserted.count).toBe(bulkCount);
+
+      // Per-node cost must not grow with batch size. Batched inserts make the larger batch
+      // cheaper per node, since fixed overhead is amortised; the ceiling is deliberately loose
+      // because it only needs to separate "flat" from "degrading", not to police small drift.
+      // A sub-millisecond baseline is too small to divide by, so scaling is only asserted when
+      // the baseline is large enough to be a meaningful denominator.
+      const baselinePerNode = baselineDuration / baselineCount;
+      const bulkPerNode = insertDuration / bulkCount;
+      if (baselineDuration >= 5) {
+        expect(bulkPerNode).toBeLessThan(baselinePerNode * 4);
+      }
+
+      // Backstop for an outright hang or an accidental O(n^2) path, generous enough that a
+      // loaded runner cannot trip it
+      expect(insertDuration).toBeLessThan(60_000);
+
+      // An indexed lookup is compared against the insert it follows rather than a fixed budget
       const queryDuration = await measureDatabaseOperation('Query Category A nodes', async () => {
         const categoryA = testDb.adapter
           .prepare('SELECT COUNT(*) as count FROM nodes WHERE category = ?')
           .get('Category A') as { count: number };
-        
-        expect(categoryA.count).toBe(500);
+
+        expect(categoryA.count).toBe(bulkCount / 2);
       });
-      
-      expect(queryDuration).toBeLessThan(100); // Queries should be very fast
-      
-      // Cleanup bulk data
-      dbHelpers.executeSql(testDb.adapter, "DELETE FROM nodes WHERE node_type LIKE 'nodes-base.bulk%'");
+
+      expect(queryDuration).toBeLessThanOrEqual(insertDuration);
+
+      // Cleanup both data sets
+      dbHelpers.executeSql(
+        testDb.adapter,
+        "DELETE FROM nodes WHERE node_type LIKE 'nodes-base.bulk%' OR node_type LIKE 'nodes-base.baseline%'"
+      );
     });
   });
 });

--- a/tests/integration/database-integration.test.ts
+++ b/tests/integration/database-integration.test.ts
@@ -275,6 +275,16 @@ describe('Database Integration Tests', () => {
           isAITool: i % 10 === 0
         }));
 
+      // This suite runs against a persistent file-backed database at a fixed path, so a run
+      // interrupted before the cleanup below leaves rows behind. Clear them first: otherwise
+      // the row-count assertion fails for reasons that have nothing to do with performance.
+      const clearFixtureRows = () =>
+        dbHelpers.executeSql(
+          testDb.adapter,
+          "DELETE FROM nodes WHERE node_type LIKE 'nodes-base.bulk%' OR node_type LIKE 'nodes-base.baseline%'"
+        );
+      clearFixtureRows();
+
       // Baseline on the same host, in the same run, so both measurements share its conditions
       const baselineCount = 100;
       const baselineDuration = await measureDatabaseOperation(
@@ -328,11 +338,7 @@ describe('Database Integration Tests', () => {
 
       expect(queryDuration).toBeLessThanOrEqual(insertDuration);
 
-      // Cleanup both data sets
-      dbHelpers.executeSql(
-        testDb.adapter,
-        "DELETE FROM nodes WHERE node_type LIKE 'nodes-base.bulk%' OR node_type LIKE 'nodes-base.baseline%'"
-      );
+      clearFixtureRows();
     });
   });
 });


### PR DESCRIPTION
`Database Integration Tests > Performance Testing > should handle bulk operations efficiently` asserted a hardcoded wall clock:

```ts
expect(insertDuration).toBeLessThan(5000);  // 1000-node insert
expect(queryDuration).toBeLessThan(100);    // indexed COUNT
```

That measures the runner, not the code. Recent evidence, all on branches that never touched the insert path:

| Where | Duration |
|---|---|
| Local | ~450ms |
| CI (three consecutive runs) | 6831ms, 10107ms, 10891ms |

It has also failed this way on an unrelated Dependabot branch. On a shared runner the second half of that job is I/O-contended — the same runs show `metadata-operations` at 18107ms against 1787ms on another run of the identical job — and a fixed millisecond budget converts that contention into a red build on whichever PR happens to draw a slow runner. Each occurrence costs an investigation to prove the PR innocent.

## What replaces it

The regression actually worth catching is batched inserts degrading into per-row work. That shows up as a **rising per-node cost**, which is independent of host speed:

- A 100-node baseline batch is timed in the same run, on the same machine, immediately before the 1000-node batch.
- The larger batch's per-node cost must stay under 4× the baseline's. With batching it is normally *lower*, since fixed overhead is amortised; the ceiling only needs to separate "flat" from "degrading".
- Scaling is only asserted when the baseline is ≥5ms, so a sub-millisecond denominator can't produce a meaningless ratio.
- Row count is asserted — a fast insert that lost rows is not a pass. This was not checked before.
- A 60s absolute backstop remains, for an outright hang or an accidental O(n²) path, set far beyond anything runner contention can reach.
- The query assertion is now relative to the insert it follows rather than a fixed 100ms.

## Verified in both directions

Replacing the batched insert with a per-row loop — the exact regression this guards — fails the assertion:

```
AssertionError: expected 2.336802875 to be less than 1.51086
```

and the batched implementation passes (489ms). So the test was confirmed against the defect, not merely against itself.

Full offline integration suite: **34 files, 507 tests passing**.

## Note

Roughly a dozen other integration tests use the same absolute-millisecond pattern (`tests/integration/ci/database-population.test.ts`, `database/node-repository.test.ts`, `templates/metadata-operations.test.ts` among them). They have not fired yet, so they are left alone here rather than bundled into an unrelated change — but they carry the same fragility and are worth the same treatment if they start failing.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)