### PR TITLE
feat: detect the publish routes from the instance, not from a version (v2.70.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.70.1] - 2026-08-18
+
+### Changed
+
+- **Workflow activation now learns from the instance which route names it serves, instead of asking for a version it will not give.** v2.70.0 preferred n8n 2.33's `/publish` and `/unpublish` routes only when the detected version confirmed them — and the version is never detected (see below), so every instance stayed on the deprecated `/activate` and `/deactivate`. n8n sets an RFC 9745 `Deprecation` header on those legacy routes, from a middleware that runs ahead of the permission checks; only an instance that has the replacement sends it, so its presence is proof the modern route is there. A fallback to the modern route that succeeds is the same proof. Either one latches the choice for the rest of the client's life, so the switch costs no extra requests. The signal is read one way only: the header's absence proves nothing, since an older n8n does not send it and a proxy may strip it, and nothing clears the latch. A detected version is still honoured when one is somehow available.
+- **The version probe no longer runs on every workflow write.** `getVersion()` reads n8n's internal `/rest/settings` route, which has answered API-key clients from a fixed allowlist carrying no version field since n8n 1.119.0 — only a browser session gets the full settings, and the Public API exposes no version anywhere. Detection therefore fails on every current instance, and because only successful probes were cached, each workflow update and activation paid an extra HTTP round trip to fail the same way, and logged a warning for it. A probe that reaches the instance and finds no version is now cached like a successful one, for the same five-minute TTL. A probe that never reached the instance — a timeout, a refused connection — is still not cached, since it says nothing about what the instance would report.
+- **`n8n_health_check` says why the n8n version is missing rather than reporting it as unknown.** An absent version is the expected answer from every current n8n, not a lookup that failed, and "unknown" invites a retry that cannot succeed. The response carries `n8nVersionNote` explaining it when `n8nVersion` is absent.
+
 ## [2.70.0] - 2026-08-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.70.0",
+  "version": "2.70.1",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.70.0",
+  "version": "2.70.1",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -22,7 +22,7 @@ import {
   getWebhookUrl
 } from '../services/n8n-validation';
 import { nodeGroupsField, parseNodeGroupsInput } from '../services/node-groups';
-import { versionAtLeast } from '../services/n8n-version';
+import { versionAtLeast, N8N_VERSION_UNAVAILABLE_NOTE } from '../services/n8n-version';
 import {
   N8nApiError,
   N8nNotFoundError,
@@ -70,6 +70,8 @@ interface HealthCheckResponseData {
   status: string;
   instanceId?: string;
   n8nVersion?: string;
+  /** Present only when the instance did not report a version - see N8N_VERSION_UNAVAILABLE_NOTE. */
+  n8nVersionNote?: string;
   features?: Record<string, unknown>;
   apiUrl?: string;
   mcpVersion: string;
@@ -2317,6 +2319,7 @@ export async function handleHealthCheck(context?: InstanceContext): Promise<McpT
       status: health.status,
       instanceId: health.instanceId,
       n8nVersion: health.n8nVersion,
+      ...(health.n8nVersion ? {} : { n8nVersionNote: N8N_VERSION_UNAVAILABLE_NOTE }),
       features: health.features,
       apiUrl: resolveN8nApiConfigForResponse(context)?.baseUrl,
       mcpVersion,
@@ -2615,7 +2618,7 @@ export async function handleDiagnostic(request: any, context?: InstanceContext):
     try {
       const health = await apiClient.healthCheck();
       apiStatus.connected = true;
-      apiStatus.version = health.n8nVersion || 'unknown';
+      apiStatus.version = health.n8nVersion || N8N_VERSION_UNAVAILABLE_NOTE;
     } catch (error) {
       apiStatus.error = error instanceof Error ? error.message : 'Unknown error';
     }

--- a/src/mcp/tool-docs/system/n8n-health-check.ts
+++ b/src/mcp/tool-docs/system/n8n-health-check.ts
@@ -48,7 +48,8 @@ Health checks are crucial for:
     },
     returns: `Health status object containing:
 - status: Overall health status ('healthy', 'degraded', 'error')
-- n8nVersion: n8n instance version information
+- n8nVersion: n8n instance version, when the instance reports one. n8n stopped exposing its version to API clients in 1.119.0, so this is usually absent; n8nVersionNote then says so. Neither an error nor worth retrying - check capabilities by calling the API, not by comparing versions
+- n8nVersionNote: Present only when n8nVersion is absent, explaining why
 - instanceId: Unique identifier for the n8n instance
 - features: Object listing available features and their status
 - mcpVersion: Current n8n-mcp version

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -102,6 +102,25 @@ function failureStatus(error: unknown): number | undefined {
   return (error as any)?.response?.status;
 }
 
+/**
+ * Whether a response carries an RFC 9745 `Deprecation` header.
+ *
+ * n8n sets one on the legacy activate/deactivate routes (`Deprecation: @<epoch>`), from a
+ * middleware that runs before the permission checks. Its presence proves the instance knows those
+ * routes are superseded, and therefore serves the routes that replaced them. The value is not
+ * parsed: a deprecation date tells us nothing we act on, only the header's presence does.
+ *
+ * Absence proves nothing - an older n8n has no header, and a proxy may drop it - so this is only
+ * ever read as a positive signal.
+ */
+function hasDeprecationHeader(headers: unknown): boolean {
+  if (!headers || typeof headers !== 'object') return false;
+  // Axios lowercases response header names, but a mock or a raw response may not.
+  return Object.entries(headers as Record<string, unknown>).some(
+    ([name, value]) => name.toLowerCase() === 'deprecation' && value !== undefined && value !== ''
+  );
+}
+
 /** The same write payload without `nodeGroups`, for instances whose schema has no such field. */
 function withoutNodeGroups(payload: Record<string, unknown>): Record<string, unknown> {
   const { nodeGroups, ...rest } = payload;
@@ -138,6 +157,12 @@ export class N8nApiClient {
    * group would permanently disable groups for the instance. Per-client, which is per-instance.
    */
   private groupSupport = { groups: true, descriptions: true };
+  /**
+   * Whether this instance is known to serve the modern publish/unpublish routes. Positive-only,
+   * and per-client, which is per-instance: it is set when the instance proves the routes exist
+   * and never cleared, because no response proves the opposite. See postPublishRoute.
+   */
+  private modernPublishRoute = false;
 
   constructor(config: N8nApiClientConfig) {
     const { baseUrl, apiKey, timeout = 30000, maxRetries = 3, cfClientId, cfClientSecret } = config;
@@ -250,6 +275,16 @@ export class N8nApiClient {
   /**
    * Get the n8n version, fetching it if not already cached.
    * Uses promise-based locking to prevent concurrent requests.
+   *
+   * **Returns null against every n8n from 1.119.0 onward**, which in practice means every
+   * instance: the version is only reachable through an internal editor route that answers
+   * Public API clients without it, and the Public API exposes no version of its own. See
+   * {@link fetchN8nVersion}.
+   *
+   * So do not gate behaviour on this. Null means "unknown", never "old", and a feature gated on
+   * a minimum version here is a feature that is off for everyone. Probe the instance instead -
+   * `groupSupport` and {@link postPublishRoute} read what the API actually answers - and keep the
+   * unprobed path the one that works on every version.
    */
   async getVersion(): Promise<N8nVersionInfo | null> {
     // If we already have version info, return it
@@ -637,8 +672,9 @@ export class N8nApiClient {
           versionInfo
         );
       } else {
-        logger.warn('Could not determine n8n version, sending all known settings properties');
-        // Without version info, we send all known properties (might fail on old n8n)
+        // The normal case since n8n 1.119.0 (see getVersion). Settings are forwarded untouched;
+        // n8n rejects anything it does not accept, which reads better than dropping it silently.
+        logger.debug('n8n version unknown, forwarding workflow settings unfiltered');
       }
 
       const safeId = encodeApiPathSegment(id, 'workflowId');
@@ -686,12 +722,17 @@ export class N8nApiClient {
    * which keeps the semantics identical to `/activate`.
    *
    * The new route is used only when the instance is *confirmed* to have it. The legacy pair
-   * works on every supported version - on 2.33+ they are the same handler - so an instance
-   * whose version could not be read is served by the legacy route rather than probed. That
-   * matters because detection fails on real instances: `/rest/settings` does not always carry
-   * `n8nVersion`, and probing a pre-2.33 instance then wastes a request on every call.
+   * works on every supported version - on 2.33+ they are the same handler - so an unconfirmed
+   * instance is served by the legacy route rather than probed, which would waste a request per
+   * call on every pre-2.33 instance.
    *
-   * The fallback runs in both directions on a 404 or 405. A router with no route may report
+   * Confirmation comes from the instance, not from a version number, because version detection
+   * returns null on every n8n from 1.119.0 (see {@link getVersion}). Two things confirm it, both
+   * one-way: a `Deprecation` header on a legacy response, which only an n8n that has the
+   * replacement sends, and a fallback to the modern route that succeeds. A version reading is
+   * still honoured when one is somehow available.
+   *
+   * The fallback runs in both directions on a 404, 405 or 410. A router with no route may report
    * either, depending on whether it matches the path prefix before the method; n8n answers 405
    * here, so keying on 404 alone left the fallback dead in practice. Symmetry matters because
    * the legacy routes are deprecated (2026-07-23, no sunset announced): when n8n eventually
@@ -699,7 +740,9 @@ export class N8nApiClient {
    * entirely, rather than moving to the route that replaced it.
    *
    * The cost is one extra request on a workflow id that does not exist, since n8n answers 404
-   * for an absent workflow and an absent route alike. Both attempts end in the same error.
+   * for an absent workflow and an absent route alike. Both attempts end in the same error. That
+   * also costs the confirmation: the response interceptor keeps a failure's status but not its
+   * headers, so only a legacy call that succeeds can carry the deprecation signal.
    */
   private async postPublishRoute(
     id: string,
@@ -707,13 +750,23 @@ export class N8nApiClient {
     legacyPath: 'activate' | 'deactivate'
   ): Promise<Workflow> {
     const safeId = encodeApiPathSegment(id, 'workflowId');
-    const version = await this.getVersion();
-    const preferModern = version !== null && versionAtLeast(version, 2, 33, 0);
+    let preferModern = this.modernPublishRoute;
+    if (!preferModern) {
+      // Only read while the routes are unconfirmed: once they are, no version could change the
+      // choice, and asking costs a request every time the version cache has expired.
+      const version = await this.getVersion();
+      preferModern = version !== null && versionAtLeast(version, 2, 33, 0);
+    }
     const [primaryPath, fallbackPath] = preferModern
       ? [modernPath, legacyPath]
       : [legacyPath, modernPath];
-    const post = async (path: string): Promise<Workflow> =>
-      (await this.client.post(`/workflows/${safeId}/${path}`, {})).data;
+    const post = async (path: string): Promise<Workflow> => {
+      const response = await this.client.post(`/workflows/${safeId}/${path}`, {});
+      if (path === legacyPath && hasDeprecationHeader(response.headers)) {
+        this.confirmModernPublishRoute(`/${legacyPath} answered with a Deprecation header`);
+      }
+      return response.data;
+    };
     let status: number | undefined;
 
     let primaryError: unknown;
@@ -735,7 +788,11 @@ export class N8nApiClient {
         '(this n8n does not serve that route, or the workflow does not exist)'
     );
     try {
-      return await post(fallbackPath);
+      const workflow = await post(fallbackPath);
+      if (fallbackPath === modernPath) {
+        this.confirmModernPublishRoute(`/${legacyPath} is absent and /${modernPath} answered`);
+      }
+      return workflow;
     } catch (fallbackError) {
       // When the fallback fails the same way, neither route exists and the first attempt is the
       // more faithful account - a missing workflow should read as a missing workflow rather than
@@ -746,6 +803,21 @@ export class N8nApiClient {
         ROUTE_ABSENT_STATUSES.has(fallbackStatus as number) ? primaryError : fallbackError
       );
     }
+  }
+
+  /**
+   * Latch that this instance serves the modern publish routes, so later calls go there first.
+   * Only ever called from evidence that the routes exist; nothing clears it.
+   *
+   * Nothing clears it because no response proves the routes are absent - a 404 is equally a
+   * missing workflow. If some intermediary ever produced the evidence spuriously (a proxy that
+   * adds a Deprecation header while blocking `/publish`), the cost is one wasted request per
+   * call, not a failure: the fallback still lands on the legacy route.
+   */
+  private confirmModernPublishRoute(evidence: string): void {
+    if (this.modernPublishRoute) return;
+    this.modernPublishRoute = true;
+    logger.debug(`Using the publish/unpublish routes for this instance: ${evidence}`);
   }
 
   async activateWorkflow(id: string): Promise<Workflow> {

--- a/src/services/n8n-version.ts
+++ b/src/services/n8n-version.ts
@@ -164,8 +164,10 @@ export async function fetchN8nVersion(
         : `no version in the response from ${settingsUrl}`
     );
   } catch (error) {
-    // Deliberately not cached: a timeout or a refused connection says nothing about whether the
-    // instance reports its version, and caching it would suppress detection for the whole TTL.
+    // Everything that produced no usable response lands here: a timeout, a refused connection,
+    // and any status at or above 500, which `validateStatus` rejects. None of them says what the
+    // instance reports when it is healthy, so none is cached - that would suppress detection for
+    // the whole TTL over a blip.
     logger.debug(`Failed to fetch n8n version: ${error instanceof Error ? error.message : 'Unknown error'}`);
     return null;
   }

--- a/src/services/n8n-version.ts
+++ b/src/services/n8n-version.ts
@@ -23,9 +23,18 @@ import {
   type SettingsVersion,
 } from '../constants/workflow-settings';
 
+/**
+ * What to tell a caller who asked for the instance version and got nothing. Reported instead of
+ * "unknown", which reads as a lookup that failed and invites a retry: no retry can succeed.
+ */
+export const N8N_VERSION_UNAVAILABLE_NOTE =
+  'Not reported. n8n stopped exposing its version to API clients in 1.119.0, so this is expected ' +
+  'and is not an error. Feature availability is detected from API responses instead.';
+
 // Cache version info per base URL with TTL to handle server upgrades
 interface CachedVersion {
-  info: N8nVersionInfo;
+  /** null when the instance answered but reported no version - see rememberProbe. */
+  info: N8nVersionInfo | null;
   fetchedAt: number;
 }
 
@@ -91,11 +100,18 @@ export function getSupportedSettingsProperties(version: N8nVersionInfo): Set<str
 }
 
 /**
- * Fetch n8n version from /rest/settings endpoint
+ * Fetch the n8n version from the instance's `/rest/settings` endpoint.
  *
- * This endpoint is available on all n8n instances and doesn't require authentication.
- * Note: There's a security concern about this being unauthenticated (see n8n community),
- * but it's the only reliable way to get version info.
+ * **This returns null against every n8n from 1.119.0 onward.** That endpoint is n8n's internal
+ * editor route, and since 1.119.0 it answers unauthenticated callers from a fixed allowlist that
+ * carries no version field; only a browser session gets the full settings. We authenticate with a
+ * Public API key, so the version is never in the response. The Public API itself exposes no
+ * version anywhere, so there is no route to switch to.
+ *
+ * Callers must treat null as "unknown", never as "old" - and new behaviour should be gated on
+ * what the API actually answers, not on a version number. A probe that reaches the instance and
+ * finds no version is cached like a successful one, so the request happens at most once per TTL
+ * rather than on every write.
  */
 export async function fetchN8nVersion(
   baseUrl: string,
@@ -106,7 +122,7 @@ export async function fetchN8nVersion(
   // because it is about to blame the instance version for a failure.
   const cached = forceRefresh ? undefined : versionCache.get(baseUrl);
   if (cached && Date.now() - cached.fetchedAt < VERSION_CACHE_TTL_MS) {
-    logger.debug(`Using cached n8n version for ${baseUrl}: ${cached.info.version}`);
+    logger.debug(`Using cached n8n version for ${baseUrl}: ${cached.info?.version ?? 'none reported'}`);
     return cached.info;
   }
 
@@ -127,38 +143,48 @@ export async function fetchN8nVersion(
       httpsAgent: pinnedAgents?.httpsAgent,
     });
 
-    if (response.status === 200 && response.data) {
-      // n8n wraps the settings in a "data" property
-      const settings = response.data.data;
-      if (!settings) {
-        logger.warn('No data in settings response');
-        return null;
-      }
+    // n8n wraps the settings in a "data" property
+    const settings = response.status === 200 ? response.data?.data : undefined;
 
-      // n8n can return version in different fields - validate type
-      const versionString = typeof settings.n8nVersion === 'string'
-        ? settings.n8nVersion
-        : typeof settings.versionCli === 'string'
-          ? settings.versionCli
-          : null;
+    // n8n can return version in different fields - validate type
+    const versionString = typeof settings?.n8nVersion === 'string'
+      ? settings.n8nVersion
+      : typeof settings?.versionCli === 'string'
+        ? settings.versionCli
+        : null;
+    const versionInfo = versionString ? parseVersion(versionString) : null;
 
-      if (versionString) {
-        const versionInfo = parseVersion(versionString);
-        if (versionInfo) {
-          // Cache the result with timestamp
-          versionCache.set(baseUrl, { info: versionInfo, fetchedAt: Date.now() });
-          logger.debug(`Detected n8n version: ${versionInfo.version}`);
-          return versionInfo;
-        }
-      }
-    }
-
-    logger.warn(`Could not determine n8n version from ${settingsUrl}`);
-    return null;
+    // A missing version is expected against any n8n >= 1.119.0, so it is not a warning - see the
+    // doc comment.
+    return rememberProbe(
+      baseUrl,
+      versionInfo,
+      versionInfo
+        ? `detected n8n version ${versionInfo.version}`
+        : `no version in the response from ${settingsUrl}`
+    );
   } catch (error) {
-    logger.warn(`Failed to fetch n8n version: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    // Deliberately not cached: a timeout or a refused connection says nothing about whether the
+    // instance reports its version, and caching it would suppress detection for the whole TTL.
+    logger.debug(`Failed to fetch n8n version: ${error instanceof Error ? error.message : 'Unknown error'}`);
     return null;
   }
+}
+
+/**
+ * Cache the outcome of a probe that reached the instance, and return it.
+ *
+ * A null outcome is cached too: it is the normal answer from every current n8n, and re-probing on
+ * every workflow write would cost a round trip per write to learn the same thing.
+ */
+function rememberProbe(
+  baseUrl: string,
+  info: N8nVersionInfo | null,
+  reason: string
+): N8nVersionInfo | null {
+  versionCache.set(baseUrl, { info, fetchedAt: Date.now() });
+  logger.debug(`n8n version probe for ${baseUrl}: ${reason}`);
+  return info;
 }
 
 /**
@@ -169,7 +195,8 @@ export function clearVersionCache(): void {
 }
 
 /**
- * Get cached version for a base URL (or null if not cached or expired)
+ * Get cached version for a base URL. Null when nothing is cached, the entry expired, or the
+ * instance was probed and reported no version.
  */
 export function getCachedVersion(baseUrl: string): N8nVersionInfo | null {
   const cached = versionCache.get(baseUrl);

--- a/tests/integration/n8n-api/system/health-check.test.ts
+++ b/tests/integration/n8n-api/system/health-check.test.ts
@@ -90,10 +90,11 @@ describe('Integration: handleHealthCheck', () => {
         expect(typeof data.supportedN8nVersion).toBe('string');
       }
 
-      // Should include version note for AI agents
-      if (data.versionNote) {
-        expect(typeof data.versionNote).toBe('string');
-        expect(data.versionNote).toContain('version');
+      // One of the two is always there: n8n has withheld its version from API clients since
+      // 1.119.0, and an instance that does not report one says so rather than staying silent.
+      expect(data.n8nVersion === undefined).toBe(data.n8nVersionNote !== undefined);
+      if (data.n8nVersionNote) {
+        expect(data.n8nVersionNote).toContain('version');
       }
     });
   });
@@ -118,7 +119,7 @@ describe('Integration: handleHealthCheck', () => {
       });
 
       // Optional fields that may be present
-      const optionalFields = ['instanceId', 'n8nVersion', 'features', 'supportedN8nVersion', 'versionNote'];
+      const optionalFields = ['instanceId', 'n8nVersion', 'features', 'supportedN8nVersion', 'n8nVersionNote'];
       optionalFields.forEach(field => {
         if (data[field] !== undefined) {
           expect(data[field]).not.toBeNull();

--- a/tests/integration/n8n-api/utils/response-types.ts
+++ b/tests/integration/n8n-api/utils/response-types.ts
@@ -15,7 +15,7 @@ export interface HealthCheckResponse {
   apiUrl: string;
   mcpVersion: string;
   supportedN8nVersion?: string;
-  versionNote?: string;
+  n8nVersionNote?: string;
   [key: string]: any; // Allow dynamic property access for optional field checks
 }
 

--- a/tests/unit/mcp/handlers-n8n-manager.test.ts
+++ b/tests/unit/mcp/handlers-n8n-manager.test.ts
@@ -1634,6 +1634,26 @@ describe('handlers-n8n-manager', () => {
       });
     });
 
+    it('should explain a missing version rather than leaving it blank', async () => {
+      // Every n8n from 1.119.0 withholds its version from API clients, so an empty field here is
+      // the norm and not a lookup worth retrying.
+      mockApiClient.healthCheck.mockResolvedValue({ status: 'ok', features: [] });
+
+      const result = await handlers.handleHealthCheck();
+
+      expect(result.success).toBe(true);
+      expect((result.data as any).n8nVersion).toBeUndefined();
+      expect((result.data as any).n8nVersionNote).toMatch(/1\.119\.0/);
+    });
+
+    it('should not annotate a version the instance did report', async () => {
+      mockApiClient.healthCheck.mockResolvedValue({ status: 'ok', n8nVersion: '1.100.0' });
+
+      const result = await handlers.handleHealthCheck();
+
+      expect((result.data as any).n8nVersionNote).toBeUndefined();
+    });
+
     it('should handle API errors', async () => {
       const apiError = new N8nServerError('Service unavailable');
       mockApiClient.healthCheck.mockRejectedValue(apiError);

--- a/tests/unit/services/n8n-api-client.test.ts
+++ b/tests/unit/services/n8n-api-client.test.ts
@@ -108,7 +108,7 @@ describe('N8nApiClient', () => {
       let call = 0;
       mockAxiosInstance[method].mockImplementation(async () => {
         const outcome = outcomes[Math.min(call++, outcomes.length - 1)];
-        if (!outcome.error) return { data: outcome.data };
+        if (!outcome.error) return { data: outcome.data, headers: outcome.headers ?? {} };
         const axiosError = createAxiosError(outcome.error);
         try {
           return Promise.reject(
@@ -1070,6 +1070,66 @@ badRequest('request/body/nodeGroups/0 must NOT have additional properties')
 
       expect(mockAxiosInstance.post).toHaveBeenNthCalledWith(2, '/workflows/123/publish', {});
       expect(result).toEqual(activated);
+    });
+
+    it('should switch to /publish once a legacy response carries a Deprecation header', async () => {
+      // n8n sets `Deprecation: @<epoch>` on /activate from 2.33 on. Only an instance that has
+      // /publish sends it, so it is proof the modern route is there - without a version reading.
+      vi.spyOn(client, 'getVersion').mockResolvedValue(null);
+      mockAxiosInstance.simulateSequence('post', [
+        { data: { id: '123', active: true }, headers: { deprecation: '@1753228800' } },
+        { data: { id: '123', active: true } },
+      ]);
+
+      await client.activateWorkflow('123');
+      await client.activateWorkflow('123');
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledTimes(2);
+      expect(mockAxiosInstance.post).toHaveBeenNthCalledWith(1, '/workflows/123/activate', {});
+      expect(mockAxiosInstance.post).toHaveBeenNthCalledWith(2, '/workflows/123/publish', {});
+    });
+
+    it('should read the Deprecation header whatever its casing', async () => {
+      vi.spyOn(client, 'getVersion').mockResolvedValue(null);
+      mockAxiosInstance.simulateSequence('post', [
+        { data: { id: '123', active: true }, headers: { Deprecation: '@1753228800' } },
+        { data: { id: '123', active: true } },
+      ]);
+
+      await client.activateWorkflow('123');
+      await client.deactivateWorkflow('123');
+
+      expect(mockAxiosInstance.post).toHaveBeenNthCalledWith(2, '/workflows/123/unpublish', {});
+    });
+
+    it('should stay on the legacy route when no Deprecation header arrives', async () => {
+      // Absence proves nothing: an older n8n has no header, and a proxy may strip it. The legacy
+      // route works on every version, so an unconfirmed instance keeps using it.
+      vi.spyOn(client, 'getVersion').mockResolvedValue(null);
+      mockAxiosInstance.simulateSequence('post', [{ data: { id: '123', active: true } }]);
+
+      await client.activateWorkflow('123');
+      await client.activateWorkflow('123');
+
+      expect(mockAxiosInstance.post).toHaveBeenNthCalledWith(1, '/workflows/123/activate', {});
+      expect(mockAxiosInstance.post).toHaveBeenNthCalledWith(2, '/workflows/123/activate', {});
+    });
+
+    it('should switch to /publish once a fallback to it has succeeded', async () => {
+      // The legacy route being gone is the other proof that /publish is there. Latching it keeps
+      // the wasted probe to one request instead of one per call.
+      vi.spyOn(client, 'getVersion').mockResolvedValue(null);
+      mockAxiosInstance.simulateSequence('post', [
+        { error: { response: { status: 405, data: { message: 'POST method not allowed' } } } },
+        { data: { id: '123', active: true } },
+      ]);
+
+      await client.activateWorkflow('123');
+      expect(mockAxiosInstance.post).toHaveBeenCalledTimes(2);
+
+      await client.activateWorkflow('123');
+      expect(mockAxiosInstance.post).toHaveBeenCalledTimes(3);
+      expect(mockAxiosInstance.post).toHaveBeenNthCalledWith(3, '/workflows/123/publish', {});
     });
 
     it('should surface the fallback error when it is substantive, not a missing route', async () => {

--- a/tests/unit/services/n8n-version.test.ts
+++ b/tests/unit/services/n8n-version.test.ts
@@ -445,12 +445,16 @@ describe('n8n-version', () => {
       expect(axios.get).toHaveBeenCalledTimes(1);
     });
 
-    it('re-probes after a request that never reached the instance', async () => {
-      // A timeout says nothing about whether the instance reports its version, so caching it
-      // would suppress detection for the whole TTL.
+    it('re-probes after a probe that produced no usable response', async () => {
+      // Neither a timeout nor a 5xx - which validateStatus rejects - says anything about what the
+      // instance reports when healthy, so caching either would suppress detection over a blip.
       vi.mocked(axios.get).mockRejectedValueOnce(new Error('ETIMEDOUT'));
+      vi.mocked(axios.get).mockRejectedValueOnce(
+        Object.assign(new Error('Bad Gateway'), { response: { status: 502 } })
+      );
       vi.mocked(axios.get).mockResolvedValue(settingsResponse);
 
+      expect(await fetchN8nVersion(baseUrl)).toBeNull();
       expect(await fetchN8nVersion(baseUrl)).toBeNull();
       expect(await fetchN8nVersion(baseUrl)).toEqual({
         version: '1.119.0',
@@ -458,7 +462,7 @@ describe('n8n-version', () => {
         minor: 119,
         patch: 0,
       });
-      expect(axios.get).toHaveBeenCalledTimes(2);
+      expect(axios.get).toHaveBeenCalledTimes(3);
     });
 
     it('does not let a forced refresh keep reporting a version the instance stopped sending', async () => {

--- a/tests/unit/services/n8n-version.test.ts
+++ b/tests/unit/services/n8n-version.test.ts
@@ -433,6 +433,42 @@ describe('n8n-version', () => {
       expect(cached).toEqual({ version: '1.119.0', major: 1, minor: 119, patch: 0 });
       expect(axios.get).toHaveBeenCalledTimes(1);
     });
+
+    it('caches an instance that answers without a version', async () => {
+      // The normal answer from every n8n >= 1.119.0. Re-probing would cost a round trip per
+      // workflow write to learn the same thing.
+      vi.mocked(axios.get).mockResolvedValue({ status: 200, data: { data: { sso: {} } } });
+
+      expect(await fetchN8nVersion(baseUrl)).toBeNull();
+      expect(await fetchN8nVersion(baseUrl)).toBeNull();
+
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-probes after a request that never reached the instance', async () => {
+      // A timeout says nothing about whether the instance reports its version, so caching it
+      // would suppress detection for the whole TTL.
+      vi.mocked(axios.get).mockRejectedValueOnce(new Error('ETIMEDOUT'));
+      vi.mocked(axios.get).mockResolvedValue(settingsResponse);
+
+      expect(await fetchN8nVersion(baseUrl)).toBeNull();
+      expect(await fetchN8nVersion(baseUrl)).toEqual({
+        version: '1.119.0',
+        major: 1,
+        minor: 119,
+        patch: 0,
+      });
+      expect(axios.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not let a forced refresh keep reporting a version the instance stopped sending', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(settingsResponse);
+      expect(await fetchN8nVersion(baseUrl)).not.toBeNull();
+
+      vi.mocked(axios.get).mockResolvedValue({ status: 200, data: { data: {} } });
+      expect(await fetchN8nVersion(baseUrl, { forceRefresh: true })).toBeNull();
+      expect(await fetchN8nVersion(baseUrl)).toBeNull();
+    });
   });
 
   describe('VERSION_THRESHOLDS', () => {


### PR DESCRIPTION
## Why

v2.70.0 migrated workflow activation to n8n 2.33's `/publish` and `/unpublish` routes, but gated the choice on the detected instance version — and **the version is never detected**. `getVersion()` reads n8n's internal `/rest/settings` route, which since n8n **1.119.0** answers unauthenticated callers (which is what a Public API key client is, to that route) from a fixed allowlist carrying no version field. The Public API exposes no version anywhere. So every instance stayed on the deprecated legacy routes, and the migration was inert.

Verified in n8n 2.34.4's shipped code: `activateWorkflow`/`deactivateWorkflow` run through a `deprecated({ since })` middleware that sets `Deprecation: @<epoch>` (RFC 9745) before the permission checks.

## What changed

**1. Activation learns the route names from the instance, not from a version number.**
`modernPublishRoute` latches when the instance proves the modern routes exist, and the latch then makes them primary:
- a successful legacy response carrying a `Deprecation` header — only an n8n that *has* the replacement sends it;
- a fallback to the modern route that succeeds.

The signal is read one way only: the header's absence proves nothing (an older n8n does not send it; a proxy may strip it), so an unconfirmed instance keeps using the legacy route, which works on every supported version. A detected version is still honoured if one is ever available.

**2. The version probe no longer runs on every workflow write.**
Only successful probes were cached, so each `updateWorkflow` and each activation paid an extra HTTP round trip to `/rest/settings` to fail the same way — and logged a warning for it. A probe that reaches the instance and finds no version is now cached like a successful one for the same 5-minute TTL. A probe that never reached the instance (timeout, refused connection) is still not cached: it says nothing about what the instance would report.

**3. `n8n_health_check` explains an absent version instead of reporting "unknown".**
An absent version is the expected answer from every current n8n, not a lookup that failed. The response carries `n8nVersionNote` when `n8nVersion` is absent, and the tool docs say so.

`getVersion()` and `fetchN8nVersion()` now carry doc comments recording all of this, so the next feature is not gated on a value that is always null.

## Testing

- Full unit suite green.
- The four new activation tests and the two new cache tests were each verified to **fail** against the pre-change behaviour before being kept.
- Guard tests included: no header ⇒ stays on the legacy route; a thrown probe error ⇒ re-probes rather than caching.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en
