### PR TITLE
fix: remove synthetic 'drain' emission from the stdio Docker flush patch (v2.70.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.70.2] - 2026-08-18
+
+### Fixed
+
+- **The stdio transport no longer emits a synthetic `'drain'` event after every stdout write.** A Docker workaround from June 2025 wrapped `process.stdout.write` and fired `emit('drain')` after each call, claiming to force a flush — which `'drain'` cannot do: it is the signal that the buffer has emptied, not a command to empty it. The emit was not merely useless. The MCP SDK's `send()` resolves on `'drain'` whenever a write reports backpressure, so under concurrent writes the synthetic event resolved an *earlier* send's promise while its bytes were still buffered — a caller could believe a response was written when it was not, and a process exiting at that moment could drop it. The wrapper is removed outright; the timeout the patch originally chased was fixed at the time by the initialize-request handler and the entrypoint's stdout-pollution cleanup, both of which remain. A guard test now fails if a stdout override or synthetic drain is reintroduced into `server.ts`. (#999)
+
 ## [2.70.1] - 2026-08-18
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.70.1",
+  "version": "2.70.2",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4790,20 +4790,7 @@ Full documentation is being prepared. For now, use get_node_essentials for confi
     };
 
     await this.server.connect(transport);
-    
-    // Force flush stdout for Docker environments
-    // Docker uses block buffering which can delay MCP responses
-    if (!process.stdout.isTTY || process.env.IS_DOCKER) {
-      // Override write to auto-flush
-      const originalWrite = process.stdout.write.bind(process.stdout);
-      process.stdout.write = function(chunk: any, encoding?: any, callback?: any) {
-        const result = originalWrite(chunk, encoding, callback);
-        // Force immediate flush
-        process.stdout.emit('drain');
-        return result;
-      };
-    }
-    
+
     logger.info('n8n Documentation MCP Server running on stdio transport');
     
     // Keep the process alive and listening

--- a/tests/unit/mcp/stdio-flush.test.ts
+++ b/tests/unit/mcp/stdio-flush.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Issue #999: connectStdio() used to patch process.stdout.write for Docker /
+ * non-TTY environments so that every write was followed by
+ * process.stdout.emit('drain'), intending to "force a flush". 'drain' is the
+ * signal that the buffer emptied, not a command to empty it, so the patch
+ * flushed nothing. It did have an effect, and a harmful one: the MCP SDK's
+ * StdioServerTransport.send() waits on once('drain') whenever write() reports
+ * backpressure, so a synthetic drain emitted by one write resolves an earlier
+ * send whose bytes are still sitting in the stream buffer.
+ *
+ * This guard fails if a stdout override or synthetic drain emission is ever
+ * reintroduced into server.ts. (The legitimate stdout wrapper lives in
+ * src/utils/stdio-guard.ts and never touches 'drain'.)
+ */
+describe('stdio drain contract (issue #999)', () => {
+  it('keeps the synthetic-drain patch out of server.ts', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../../src/mcp/server.ts'),
+      'utf-8'
+    );
+
+    expect(source).not.toMatch(/process\.stdout\.write\s*=/);
+    expect(source).not.toMatch(/emit\(\s*['"]drain['"]/);
+  });
+});

--- a/tests/unit/mcp/stdio-flush.test.ts
+++ b/tests/unit/mcp/stdio-flush.test.ts
@@ -24,6 +24,6 @@ describe('stdio drain contract (issue #999)', () => {
     );
 
     expect(source).not.toMatch(/process\.stdout\.write\s*=/);
-    expect(source).not.toMatch(/emit\(\s*['"]drain['"]/);
+    expect(source).not.toMatch(/process\.stdout\.emit\s*\(\s*['"]drain['"]/);
   });
 });


### PR DESCRIPTION
Fixes #999.

## What

Removes the Docker "force flush" wrapper in `connectStdio()` that overrode `process.stdout.write` and emitted a synthetic `'drain'` event after every write.

## Why

Two defects, both analyzed in #999:

1. **The patch never did what it claimed.** `emit('drain')` moves no bytes — `'drain'` is the notification that the buffer emptied, not a command to empty it. Node's `process.stdout` on a pipe hands writes to the OS directly; there was no block buffering for the patch to defeat.
2. **It corrupted the SDK's completion signal.** `StdioServerTransport.send()` resolves on `once('drain')` whenever `write()` reports backpressure. The synthetic emit fires inside `write()` — too early to wake its own send, but exactly in time to wake an *earlier* send still waiting on real backpressure. That send's promise resolved with its bytes still buffered (reproduced in #999: a send resolving at 0ms with zero chunks flushed). The realistic exposure was a large response under backpressure followed by process exit.

The Docker/Claude Desktop timeout the patch was added for (June 2025, a688ad3d) was fixed at the time by the `InitializeRequestSchema` handler and the docker-entrypoint stdout-pollution cleanup, both of which remain in place. The `stdio-guard` wrapper is a separate, legitimate layer and is untouched.

## Changes

- `src/mcp/server.ts` — delete the 14-line override block; nothing replaces it.
- `tests/unit/mcp/stdio-flush.test.ts` — a guard test that fails if a `process.stdout.write` override or synthetic `'drain'` emission is reintroduced into `server.ts`.
- Version 2.70.2, changelog entry.

## Verification

- `npm run typecheck` clean.
- `npx vitest run tests/unit/mcp/` — 836 tests pass, no new failures.
- Reviewed by code-simplifier, code-reviewer, and Codex; all sign-offs, no open findings.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)