### PR TITLE
fix: count settings.errorWorkflow as error handling in the instance audit (v2.70.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.70.3] - 2026-08-18
+
+### Fixed
+
+- **`n8n_audit_instance` no longer reports "No error handling" for workflows that route failures through `settings.errorWorkflow`.** The error-handling check looked only at node-level signals — `continueOnFail`, a non-default `onError`, an Error Trigger node — and never at the workflow-level error workflow assignment, n8n's first-class mechanism for exactly this. On instances that standardize on a shared error handler, that made the check's output almost entirely false positives (a reported production case: 105 workflows flagged where ground truth was 10). A workflow with a non-blank `settings.errorWorkflow` now counts as having error handling, and the finding's text names the missing signal and recommends the error-workflow route first, since `continueOnFail`/`onError: continueRegularOutput` swallow errors rather than surface them. Reported with root cause and fix by @johngluch. (#992)
+
 ## [2.70.2] - 2026-08-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.70.2",
+  "version": "2.70.3",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/services/audit-report-builder.ts
+++ b/src/services/audit-report-builder.ts
@@ -307,7 +307,7 @@ function renderRemediationPlaybook(
 
     if (byCat['error_handling']?.length) {
       const wfCount = uniqueWorkflows(byCat['error_handling']);
-      lines.push(`**Error handling gaps** (${wfCount} workflow${wfCount !== 1 ? 's' : ''}): Add Error Trigger nodes or set continueOnFail on critical nodes.`);
+      lines.push(`**Error handling gaps** (${wfCount} workflow${wfCount !== 1 ? 's' : ''}): Assign a shared error workflow via settings.errorWorkflow, add Error Trigger nodes, or set continueOnFail on critical nodes.`);
     }
 
     if (piiFindings.length > 0) {

--- a/src/services/workflow-security-scanner.ts
+++ b/src/services/workflow-security-scanner.ts
@@ -216,7 +216,10 @@ function checkErrorHandlingGaps(workflow: WorkflowInput): AuditFinding[] {
     (node) => (node.type ?? '').toLowerCase() === 'n8n-nodes-base.errortrigger',
   );
 
-  if (hasContinueOnFail || hasOnErrorHandling || hasErrorTrigger) {
+  const errorWorkflow = workflow.settings?.errorWorkflow;
+  const hasErrorWorkflow = typeof errorWorkflow === 'string' && errorWorkflow.trim().length > 0;
+
+  if (hasContinueOnFail || hasOnErrorHandling || hasErrorTrigger || hasErrorWorkflow) {
     return [];
   }
 
@@ -226,8 +229,8 @@ function checkErrorHandlingGaps(workflow: WorkflowInput): AuditFinding[] {
       severity: 'medium',
       category: 'error_handling',
       title: `No error handling in workflow "${workflow.name}"`,
-      description: `Workflow "${workflow.name}" has ${workflow.nodes.length} nodes but no error handling configured. There are no nodes with continueOnFail enabled, no custom onError behavior, and no Error Trigger node.`,
-      recommendation: 'Add error handling to prevent silent failures. Consider adding an Error Trigger node for global error notifications, or set continueOnFail on critical nodes that should not block the workflow.',
+      description: `Workflow "${workflow.name}" has ${workflow.nodes.length} nodes but no error handling configured. There are no nodes with continueOnFail enabled, no custom onError behavior, no Error Trigger node, and no workflow-level settings.errorWorkflow assigned.`,
+      recommendation: 'Add error handling to prevent silent failures. Assign an error workflow via settings.errorWorkflow to route failures to a shared handler, or add an Error Trigger node (a workflow containing one handles its own failures by default). Setting continueOnFail or onError="continueRegularOutput" on critical nodes also counts, but those swallow errors rather than surfacing them.',
       remediationType: 'review_recommended',
       location: {
         workflowId: workflow.id ?? '',

--- a/tests/unit/services/workflow-security-scanner.test.ts
+++ b/tests/unit/services/workflow-security-scanner.test.ts
@@ -316,6 +316,40 @@ describe('workflow-security-scanner', () => {
       const report = scanOne(wf, ['error_handling']);
       expect(findingsOf(report, 'error_handling')).toHaveLength(1);
     });
+
+    it('should NOT flag a workflow with settings.errorWorkflow assigned', () => {
+      const wf = makeWorkflow({
+        nodes: [
+          { name: 'Trigger', type: 'n8n-nodes-base.manualTrigger', parameters: {} },
+          { name: 'Step 1', type: 'n8n-nodes-base.set', parameters: {} },
+          { name: 'Step 2', type: 'n8n-nodes-base.httpRequest', parameters: {} },
+        ],
+        settings: {
+          errorWorkflow: 'some-error-workflow-id',
+        },
+      });
+      const report = scanOne(wf, ['error_handling']);
+      expect(findingsOf(report, 'error_handling')).toHaveLength(0);
+    });
+
+    it.each([
+      ['an empty string', ''],
+      ['a whitespace-only string', '   '],
+      ['a non-string value', 123],
+    ])('should still flag a workflow whose settings.errorWorkflow is %s', (_label, value) => {
+      const wf = makeWorkflow({
+        nodes: [
+          { name: 'Trigger', type: 'n8n-nodes-base.manualTrigger', parameters: {} },
+          { name: 'Step 1', type: 'n8n-nodes-base.set', parameters: {} },
+          { name: 'Step 2', type: 'n8n-nodes-base.httpRequest', parameters: {} },
+        ],
+        settings: {
+          errorWorkflow: value,
+        },
+      });
+      const report = scanOne(wf, ['error_handling']);
+      expect(findingsOf(report, 'error_handling')).toHaveLength(1);
+    });
   });
 
   // ===========================================================================


### PR DESCRIPTION
Fixes #992. Reported with root cause and proposed fix by @johngluch — thank you for the precise analysis and the production ground-truth numbers.

## What

`checkErrorHandlingGaps` in the workflow security scanner only inspected node-level signals (`continueOnFail`, non-default `onError`, an Error Trigger node) and never consulted `workflow.settings.errorWorkflow` — n8n's first-class mechanism for routing a workflow's failures to a dedicated error workflow. On instances that standardize on a shared error handler this made the `error_handling` audit results almost entirely false positives (#992's production case: 105 flagged, 10 real).

## Changes

- A non-blank `settings.errorWorkflow` (string, non-whitespace) now counts as error handling. Whitespace-only, empty-string, and non-string values still flag — the whitespace case was caught in review as a symmetric false-negative gap.
- The finding's description now names the missing signal, and the recommendation leads with `settings.errorWorkflow` since `continueOnFail`/`onError: "continueRegularOutput"` swallow errors rather than surface them.
- Tests: positive case (assigned error workflow → no finding) and an `it.each` negative table (`''`, `'   '`, `123` → still flagged).

## Out of scope (noted during review, pre-existing)

Review surfaced three adjacent gaps in the same check that predate this fix and are left for a follow-up: disabled nodes still count toward the node-level signals; `onError: "continueErrorOutput"` counts even when the error output is unwired (the workflow validator has a stricter check); `retryOnFail` is not counted although the workflow validator recognizes it.

## Verification

- `npm run typecheck` clean; `vitest run tests/unit/services/workflow-security-scanner.test.ts` — 31/31.
- Reviewed by code-simplifier, code-reviewer, and Codex; all applied or dispositioned above.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)