### PR TITLE
fix: gate the sync SSRF IPv4 denylist on isIPv4(hostname) (v2.70.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.70.4] - 2026-08-18
+
+### Fixed
+
+- **The synchronous SSRF pre-filter no longer refuses DNS hostnames whose first label looks like a blocked IPv4 octet.** `validateUrlSync` tested its IPv4 range regexes against the raw hostname, so ordinary DNS names like `247.example.com` or `10.example.com` were refused as "Private IP addresses not allowed" — long-standing behavior whose collision surface v2.69.0 widened from five first-octet values to the whole 224–255 range plus the CGNAT prefixes. The range check is now gated on `net.isIPv4(hostname)`, mirroring the existing `isIPv6` gate on the IPv6 path. This is a deliberate loosening of the sync pre-filter only: what such a name actually resolves to is still validated by the async DNS-resolving validator, and the transport is pinned to the address that validation approved. The WHATWG URL parser canonicalizes every numeric host form (hex, octal, integer, short) to dotted-quad before the gate, so no literal the regexes used to catch escapes it — now pinned by tests, along with the resolve-to-private safety net. Cloud-metadata hostname blocking is unchanged. (#984)
+
 ## [2.70.3] - 2026-08-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.70.3",
+  "version": "2.70.4",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/ssrf-protection.ts
+++ b/src/utils/ssrf-protection.ts
@@ -1,6 +1,6 @@
 import { URL } from 'url';
 import { lookup } from 'dns/promises';
-import { isIPv6 } from 'net';
+import { isIPv4, isIPv6 } from 'net';
 import http from 'http';
 import https from 'https';
 import ipaddr from 'ipaddr.js';
@@ -490,7 +490,11 @@ export class SSRFProtection {
       return { valid: false, reason: 'Localhost access is blocked in strict mode' };
     }
 
-    if (PRIVATE_IP_RANGES.some(regex => regex.test(hostname))) {
+    // SECURITY (#984): PRIVATE_IP_RANGES are prefix regexes, so gate them on
+    // isIPv4 — otherwise a DNS name like `247.example.com` is misread as an
+    // IPv4 literal and wrongly refused. What a name resolves to is still
+    // checked by the async validateWebhookUrl and the DNS-pinned agents.
+    if (isIPv4(hostname) && PRIVATE_IP_RANGES.some(regex => regex.test(hostname))) {
       return {
         valid: false,
         reason: mode === 'strict'

--- a/tests/unit/utils/ssrf-protection.test.ts
+++ b/tests/unit/utils/ssrf-protection.test.ts
@@ -589,12 +589,62 @@ describe('SSRFProtection', () => {
         'http://192.168.1.1',
         'http://172.16.0.1',
         'http://172.31.255.255',
+        'http://224.0.0.1',    // multicast
+        'http://100.64.1.1',   // RFC 6598 CGNAT
       ];
       for (const url of privateUrls) {
         const result = SSRFProtection.validateUrlSync(url);
         expect(result.valid, `url=${url}`).toBe(false);
         expect(result.reason).toContain('Private IP');
       }
+    });
+
+    it('should not treat DNS hostnames with leading digits as IPv4 literals (#984)', () => {
+      // PRIVATE_IP_RANGES are prefix regexes over the raw hostname, so without
+      // the isIPv4 gate a DNS name whose first label matches a blocked first
+      // octet (`247.` hits the 224-255 reserved-range regexes) is refused.
+      delete process.env.WEBHOOK_SECURITY_MODE; // strict default
+      const dnsHostnameUrls = [
+        'http://247.example.com',
+        'http://224.foo.com',
+        'http://10.example.com',
+        'http://100.64.evil.example',
+      ];
+      for (const url of dnsHostnameUrls) {
+        const result = SSRFProtection.validateUrlSync(url);
+        expect(result.valid, `url=${url}`).toBe(true);
+        expect(result.reason).toBeUndefined();
+      }
+    });
+
+    it('rejects non-canonical IPv4 forms via WHATWG URL normalization (#984)', () => {
+      // The isIPv4 gate relies on the URL parser canonicalizing every
+      // numeric host form to dotted-quad before validateUrlSync sees it.
+      delete process.env.WEBHOOK_SECURITY_MODE; // strict default
+      const nonCanonicalPrivate = [
+        'http://0x7f.0.0.1',   // hex -> 127.0.0.1
+        'http://0177.0.0.1',   // octal -> 127.0.0.1
+        'http://2130706433',   // integer -> 127.0.0.1
+        'http://127.1',        // short form -> 127.0.0.1
+        'http://0xa.0.0.1',    // hex -> 10.0.0.1
+      ];
+      for (const url of nonCanonicalPrivate) {
+        const result = SSRFProtection.validateUrlSync(url);
+        expect(result.valid, `url=${url}`).toBe(false);
+      }
+    });
+
+    it('still blocks a digit-labelled hostname at DNS resolution when it resolves privately (#984)', async () => {
+      // The async validator is the real control behind the loosened sync
+      // pre-filter: `10.example.com` passes validateUrlSync but must be
+      // rejected once DNS shows it resolves to a private address.
+      delete process.env.WEBHOOK_SECURITY_MODE; // strict default
+      expect(SSRFProtection.validateUrlSync('http://10.example.com').valid).toBe(true);
+
+      vi.mocked(dns.lookup).mockResolvedValue({ address: '10.0.0.1', family: 4 } as any);
+      const result = await SSRFProtection.validateWebhookUrl('http://10.example.com');
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain('Private IP');
     });
 
     it('should reject private IPv4 literals in moderate mode', () => {


### PR DESCRIPTION
Fixes #984.

## What

`validateUrlSync` tested the `PRIVATE_IP_RANGES` regexes against the raw hostname string, so a DNS label that happens to look like a blocked first octet was refused: `http://247.example.com` and `http://224.foo.com` → "Private IP addresses not allowed". Long-standing for `10.`/`127.`-style labels; v2.69.0 widened the collision surface to 224–255 and the CGNAT prefixes.

The IPv4 range check is now gated on `net.isIPv4(hostname)`, mirroring how `isPrivateOrMappedIpv6` already gates on `isIPv6`. Cloud-metadata hostname blocking is untouched.

## Why this loosening is safe

As stated in the issue, this is a deliberate behavior change: the sync validator is a pre-filter, and the async validator plus DNS-pinned transport remain the real control. The review gauntlet (code-reviewer + Codex, both adversarial) confirmed:

- **No literal escapes the gate.** The WHATWG URL parser canonicalizes every numeric host form — hex (`0x7f.0.0.1`), octal (`0177.0.0.1`), integer (`2130706433`), short (`127.1`) — to dotted-quad before `validateUrlSync` sees it, where `isIPv4` is true; numeric-last-label hosts that fail IPv4 parsing throw in `new URL()` and are rejected fail-closed. Now pinned by a test.
- **No sole-gate path.** The only production caller of `validateUrlSync` is config pre-validation (`instance-context.ts`); every outbound request goes through the async `validateWebhookUrl` + pinned agents. The resolve-to-private safety net (`10.example.com` → resolves `10.0.0.1` → blocked) is now covered by a test.
- A parser-differential Codex found (`0127.0.0.1`: URL says `87.0.0.1`, raw `dns.lookup` says `127.0.0.1`) is neutralized because the async path resolves and pins the *normalized* hostname.

## Tests

147/147 in `tests/unit/utils/ssrf-protection.test.ts` — all pre-existing tests unchanged (they are the contract per #985), plus: digit-labelled hostnames accepted by the sync filter, multicast/CGNAT literals still refused, non-canonical IPv4 normalization forms refused, and the async safety net.

Related: #985 (registry-table rewrite) remains open; this fix keeps the current shape per the issue's own scoping.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)