### PR TITLE
fix: pin the SSRF transport to every validated address and retry connection failures (v2.71.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [Unreleased]
-
 ## [2.71.0] - 2026-08-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [Unreleased]
+
+## [2.71.0] - 2026-08-18
+
+### Fixed
+
+- **The SSRF-pinned transport now fails over across every validated address instead of hard-failing on the first DNS answer.** The DNS-pinning protection (GHSA-cmrh-wvq6-wm9r) resolved the API hostname with a single-answer lookup and pinned all connections to that one address for the life of the process. Two real-world casualties: on macOS, `localhost` answers `::1` first, so an n8n listening only on IPv4 loopback (the Docker Desktop default) failed every management tool with an unexplained `NO_RESPONSE` even though `curl` worked; and a CDN-fronted instance (Cloudflare) stayed nailed to whichever single edge answered first at startup, so one bad edge meant every call failed until the process restarted. The validator now resolves the full record set, validates **every** address against the SSRF policy — failing closed if any record is disallowed, which also closes the mixed-record variant of DNS rebinding and, deliberately, now applies to metadata addresses in any record position even in permissive mode — and the transport pins the whole validated set, letting the socket layer try each candidate in turn. The pinned agents are also re-resolved after a 60-second TTL and after any connection failure, so a rotated edge or moved instance heals on the next call. (#978, #989, #990)
+- **`N8N_API_MAX_RETRIES` does something now.** It was validated, documented, stored — and never read: no retry logic existed on the n8n API client at all. Connection-level failures are now retried up to that count with exponential backoff and a fresh DNS resolution per attempt. Failures that occur before the connection is established (refused, unreachable, DNS) retry for any method; failures that may have interrupted an in-flight request (reset, timeout) retry only for reads, so a create is never double-executed. DNS-resolution failures inside URL validation still fail fast — the cache resets, so the next call re-resolves.
+- **`NO_RESPONSE` errors say which address failed.** `Unable to connect to n8n…` now carries the failing code and address, e.g. `(ECONNREFUSED 127.0.0.1:5678, ECONNREFUSED [::1]:5678)`, naming each attempted candidate — the difference between a two-minute diagnosis and a dead end where n8n looks healthy and the MCP looks broken.
+
 ## [2.70.4] - 2026-08-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.70.4",
+  "version": "2.71.0",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -149,6 +149,11 @@ export class N8nApiClient {
   private personalProjectId: string | null = null;
   // SECURITY (GHSA-cmrh-wvq6-wm9r): cached pinned transport agents.
   private pinnedAgentsPromise: Promise<PinnedAgents> | null = null;
+  // #978/#989/#990: when the cached agents were last (re-)resolved, so a
+  // long-lived client periodically re-validates DNS instead of pinning to
+  // one address (possibly a stale CDN/Cloudflare edge) for its whole life.
+  private pinnedAgentsResolvedAt = 0;
+  private static readonly PINNED_AGENTS_TTL_MS = 60_000;
   private cfClientId?: string;
   private cfClientSecret?: string;
   /**
@@ -230,14 +235,30 @@ export class N8nApiClient {
       }
     );
 
-    // Response interceptor for logging
+    // Response interceptor for logging + connection-failure retry
     this.client.interceptors.response.use(
       (response: any) => {
         logger.debug(`n8n API Response: ${response.status} ${response.config.url}`);
         return response;
       },
-      (error: unknown) => {
+      async (error: unknown) => {
+        // #978/#989/#990: retry connection-level failures (no response at
+        // all) before mapping to N8nApiError. Re-issuing goes back through
+        // this same interceptor pipeline, so a further failure is retried
+        // again automatically until maxRetries is exhausted.
+        const retryAttempt = this.tryRetry(error);
+        if (retryAttempt) {
+          return retryAttempt;
+        }
+
         const n8nError = handleN8nApiError(error);
+        if (n8nError.code === 'NO_RESPONSE') {
+          // SECURITY (GHSA-cmrh-wvq6-wm9r resilience): the pinned IP may be
+          // dead (CDN edge rotated, instance moved) - clear the cache so the
+          // *next* request re-resolves DNS instead of retrying the same bad
+          // address forever.
+          this.pinnedAgentsPromise = null;
+        }
         logN8nError(n8nError, 'n8n API Response');
         return Promise.reject(n8nError);
       }
@@ -245,13 +266,103 @@ export class N8nApiClient {
   }
 
   /**
+   * Retry a connection-level axios failure (no response received) when it
+   * looks safe to retry and attempts remain. Returns a promise for the
+   * retried request when a retry is attempted, or `undefined` when the
+   * caller should fall through to normal error mapping.
+   *
+   * @security GHSA-cmrh-wvq6-wm9r follow-up (#978/#989/#990) - the failure
+   * may mean the pinned IP has gone stale, so the pinned-agent cache is
+   * cleared before each retry to force fresh DNS resolution.
+   */
+  private tryRetry(error: unknown): Promise<any> | undefined {
+    const axiosError = error as any;
+    const config = axiosError?.config;
+    const noResponse = !!(axiosError && axiosError.request && !axiosError.response);
+    if (!noResponse || !config) {
+      return undefined;
+    }
+
+    const retryCount = (config as any).__retryCount || 0;
+    if (retryCount >= this.maxRetries) {
+      return undefined;
+    }
+
+    // Default to a non-idempotent classification when the method is missing:
+    // only pre-connection failures are then eligible for retry.
+    const method = String(config.method || '');
+    if (!this.isRetryableConnectionError(axiosError, method)) {
+      return undefined;
+    }
+
+    (config as any).__retryCount = retryCount + 1;
+    // Force fresh DNS on the retried attempt.
+    this.pinnedAgentsPromise = null;
+
+    const backoffMs = 250 * Math.pow(2, retryCount);
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        this.client.request(config).then(resolve, reject);
+      }, backoffMs);
+    });
+  }
+
+  /**
+   * Whether a connection-level axios error is safe to retry for the given
+   * HTTP method. Errors that occurred before any bytes reached the wire
+   * (connection refused/unreachable/DNS failure) are safe to retry
+   * regardless of method - the server never saw the request. Errors that may
+   * have interrupted an in-flight request (reset, timeout) are only retried
+   * for idempotent methods.
+   */
+  private isRetryableConnectionError(axiosError: any, method: string): boolean {
+    const codes = this.extractErrorCodes(axiosError);
+    if (codes.length === 0) return false;
+
+    const isIdempotent = method.toUpperCase() === 'GET' || method.toUpperCase() === 'HEAD';
+    const anyMethodCodes = new Set(['ECONNREFUSED', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND', 'EAI_AGAIN']);
+    const idempotentOnlyCodes = new Set(['ECONNRESET', 'ETIMEDOUT', 'ECONNABORTED']);
+
+    return codes.some(code => anyMethodCodes.has(code) || (isIdempotent && idempotentOnlyCodes.has(code)));
+  }
+
+  /**
+   * Collect every error `code` relevant to the retry decision: the error's
+   * own code, plus each member's code when the error is an AggregateError
+   * (e.g. from `autoSelectFamily` trying multiple pinned addresses).
+   */
+  private extractErrorCodes(error: any): string[] {
+    const codes: string[] = [];
+    if (error?.code) codes.push(error.code);
+
+    const aggregateMembers = error?.errors ?? error?.cause?.errors;
+    if (Array.isArray(aggregateMembers)) {
+      for (const member of aggregateMembers) {
+        if (member?.code) codes.push(member.code);
+      }
+    }
+    return codes;
+  }
+
+  /**
    * Resolve the configured baseUrl once and return HTTP/HTTPS agents that
-   * pin every connection to the validated IP.
+   * pin every connection to the validated address(es). Re-resolved when the
+   * cache is empty, has expired (TTL), or was invalidated after a
+   * connection failure — see {@link tryRetry} and the NO_RESPONSE branch of
+   * the response interceptor.
    *
    * @security GHSA-cmrh-wvq6-wm9r — without this, axios performs an
    * independent DNS lookup on every request, opening a TOCTOU window.
    */
   private getPinnedAgents(): Promise<PinnedAgents> {
+    const isExpired = this.pinnedAgentsPromise !== null &&
+      Date.now() - this.pinnedAgentsResolvedAt > N8nApiClient.PINNED_AGENTS_TTL_MS;
+    if (isExpired) {
+      // #978/#989/#990: don't stay pinned to a possibly-stale address (e.g.
+      // a rotated CDN/Cloudflare edge) for the whole process lifetime.
+      this.pinnedAgentsPromise = null;
+    }
+
     if (!this.pinnedAgentsPromise) {
       const promise = (async () => {
         const { SSRFProtection } = await import('../utils/ssrf-protection');
@@ -259,8 +370,21 @@ export class N8nApiClient {
         if (!validation.valid || !validation.address || !validation.family) {
           throw new Error(`SSRF protection: ${validation.reason || 'baseUrl rejected'}`);
         }
-        return SSRFProtection.createPinnedAgents(validation.address, validation.family);
+        return SSRFProtection.createPinnedAgents(
+          validation.addresses ?? [{ address: validation.address, family: validation.family }]
+        );
       })();
+      // Stamp at dispatch so concurrent callers during an in-flight
+      // re-resolution see a fresh TTL and don't each kick off their own
+      // lookup; refresh on fulfillment (only while still the current
+      // promise) so the window restarts from when the addresses actually
+      // became valid.
+      this.pinnedAgentsResolvedAt = Date.now();
+      promise.then(() => {
+        if (this.pinnedAgentsPromise === promise) {
+          this.pinnedAgentsResolvedAt = Date.now();
+        }
+      }, () => {});
       // Reset on rejection so transient DNS failures don't brick the client.
       promise.catch(() => {
         if (this.pinnedAgentsPromise === promise) {
@@ -1037,7 +1161,9 @@ export class N8nApiClient {
 
       // SECURITY (GHSA-cmrh-wvq6-wm9r): pin transport to validated IP.
       const pinned = validation.address && validation.family
-        ? SSRFProtection.createPinnedAgents(validation.address, validation.family)
+        ? SSRFProtection.createPinnedAgents(
+            validation.addresses ?? [{ address: validation.address, family: validation.family }]
+          )
         : undefined;
 
       // Create a new axios instance for webhook requests to avoid API interceptors

--- a/src/triggers/handlers/chat-handler.ts
+++ b/src/triggers/handlers/chat-handler.ts
@@ -91,7 +91,9 @@ export class ChatHandler extends BaseTriggerHandler<ChatTriggerInput> {
 
       // SECURITY (GHSA-cmrh-wvq6-wm9r): pin transport to validated IP.
       const pinned = validation.address && validation.family
-        ? SSRFProtection.createPinnedAgents(validation.address, validation.family)
+        ? SSRFProtection.createPinnedAgents(
+            validation.addresses ?? [{ address: validation.address, family: validation.family }]
+          )
         : undefined;
 
       // Generate or use provided session ID
@@ -139,7 +141,16 @@ export class ChatHandler extends BaseTriggerHandler<ChatTriggerInput> {
         },
       });
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      let errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      if (!errorMessage) {
+        // An AggregateError from a multi-address connection failure
+        // (autoSelectFamily across the pinned set) has an empty message;
+        // summarize its members instead of reporting nothing.
+        const members = (error as any)?.errors ?? (error as any)?.cause?.errors;
+        errorMessage = (Array.isArray(members)
+          ? members.map((m: any) => m?.code || m?.message).filter(Boolean).join(', ')
+          : '') || 'Connection failed';
+      }
 
       // Try to extract execution ID from error if available
       const errorDetails = (error as any)?.response?.data;

--- a/src/triggers/handlers/form-handler.ts
+++ b/src/triggers/handlers/form-handler.ts
@@ -269,7 +269,9 @@ export class FormHandler extends BaseTriggerHandler<FormTriggerInput> {
 
       // SECURITY (GHSA-cmrh-wvq6-wm9r): pin transport to validated IP.
       const pinned = validation.address && validation.family
-        ? SSRFProtection.createPinnedAgents(validation.address, validation.family)
+        ? SSRFProtection.createPinnedAgents(
+            validation.addresses ?? [{ address: validation.address, family: validation.family }]
+          )
         : undefined;
 
       // Build multipart/form-data (required by n8n form triggers)
@@ -443,7 +445,16 @@ export class FormHandler extends BaseTriggerHandler<FormTriggerInput> {
 
       return result;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      let errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      if (!errorMessage) {
+        // An AggregateError from a multi-address connection failure
+        // (autoSelectFamily across the pinned set) has an empty message;
+        // summarize its members instead of reporting nothing.
+        const members = (error as any)?.errors ?? (error as any)?.cause?.errors;
+        errorMessage = (Array.isArray(members)
+          ? members.map((m: any) => m?.code || m?.message).filter(Boolean).join(', ')
+          : '') || 'Connection failed';
+      }
 
       // Try to extract execution ID from error if available
       const errorDetails = (error as any)?.response?.data;

--- a/src/utils/n8n-errors.ts
+++ b/src/utils/n8n-errors.ts
@@ -85,8 +85,13 @@ export function handleN8nApiError(error: unknown): N8nApiError {
           return new N8nApiError(message, status, 'API_ERROR', data);
       }
     } else if (axiosError.request) {
-      // Request was made but no response received
-      return new N8nApiError('No response from n8n server', undefined, 'NO_RESPONSE');
+      // Request was made but no response received. Name which address(es)
+      // failed so "no response" is diagnosable instead of opaque (#978/#989/#990).
+      const detail = describeConnectionFailure(axiosError);
+      const message = detail
+        ? `No response from n8n server (${detail})`
+        : 'No response from n8n server';
+      return new N8nApiError(message, undefined, 'NO_RESPONSE');
     } else {
       // Something happened in setting up the request
       return new N8nApiError(axiosError.message, undefined, 'REQUEST_ERROR');
@@ -135,6 +140,49 @@ function folderPlacementHint(error: N8nApiError): string {
   return ' Note: workflow folder placement (parentFolderId) requires n8n 2.32 or later - retry without parentFolderId, or upgrade the instance.';
 }
 
+/**
+ * Build a short "CODE address:port" detail string from a connection-level
+ * axios error, for the NO_RESPONSE message (#978/#989/#990). When the
+ * underlying failure is an AggregateError (`autoSelectFamily` trying
+ * multiple pinned addresses), lists each member deduped so a multi-address
+ * failure reads as e.g. "ECONNREFUSED 127.0.0.1:5678, ECONNREFUSED
+ * [::1]:5678" instead of the generic top-level message alone. Returns ''
+ * when no code-bearing detail is available.
+ */
+function describeConnectionFailure(axiosError: any): string {
+  const parts: string[] = [];
+  const seen = new Set<string>();
+
+  const addPart = (source: any) => {
+    if (!source || !source.code) return;
+    let part = String(source.code);
+    if (source.address) {
+      const host = String(source.address).includes(':') ? `[${source.address}]` : source.address;
+      part += source.port !== undefined ? ` ${host}:${source.port}` : ` ${host}`;
+    }
+    if (!seen.has(part)) {
+      seen.add(part);
+      parts.push(part);
+    }
+  };
+
+  const aggregateMembers = axiosError?.errors ?? axiosError?.cause?.errors;
+  if (Array.isArray(aggregateMembers) && aggregateMembers.length > 0) {
+    aggregateMembers.forEach(addPart);
+  }
+  // Fall back to the wrapper, then its cause: axios copies `code` onto the
+  // AxiosError but the syscall address/port may live only on the underlying
+  // error, and aggregate members without codes contribute nothing above.
+  if (parts.length === 0) {
+    addPart(axiosError);
+  }
+  if (parts.length === 0) {
+    addPart(axiosError?.cause);
+  }
+
+  return parts.join(', ');
+}
+
 function safeStringify(value: unknown): string {
   try {
     return JSON.stringify(value) ?? '';
@@ -154,8 +202,14 @@ export function getUserFriendlyErrorMessage(error: N8nApiError): string {
       return `Invalid request: ${error.message}${folderPlacementHint(error)}`;
     case 'RATE_LIMIT_ERROR':
       return 'Too many requests. Please wait a moment and try again.';
-    case 'NO_RESPONSE':
-      return 'Unable to connect to n8n. Please check the server URL and ensure n8n is running.';
+    case 'NO_RESPONSE': {
+      // #978/#989/#990: append the connection detail from the enriched
+      // message (e.g. "(ECONNREFUSED 127.0.0.1:5678)") when present, so the
+      // generic sentence doesn't hide which address actually failed.
+      const generic = 'Unable to connect to n8n. Please check the server URL and ensure n8n is running.';
+      const detailMatch = error.message.match(/\(([^)]+)\)\s*$/);
+      return detailMatch ? `${generic} (${detailMatch[1]})` : generic;
+    }
     case 'SERVER_ERROR':
       // For server errors, we should not show generic message
       // Callers should check for execution context and use formatExecutionError instead

--- a/src/utils/n8n-errors.ts
+++ b/src/utils/n8n-errors.ts
@@ -207,8 +207,16 @@ export function getUserFriendlyErrorMessage(error: N8nApiError): string {
       // message (e.g. "(ECONNREFUSED 127.0.0.1:5678)") when present, so the
       // generic sentence doesn't hide which address actually failed.
       const generic = 'Unable to connect to n8n. Please check the server URL and ensure n8n is running.';
-      const detailMatch = error.message.match(/\(([^)]+)\)\s*$/);
-      return detailMatch ? `${generic} (${detailMatch[1]})` : generic;
+      // Plain string scan instead of a trailing-group regex (CodeQL
+      // js/polynomial-redos): take a non-empty parenthesized suffix that
+      // contains no nested parens, which is the only shape
+      // describeConnectionFailure produces.
+      const message = error.message.trimEnd();
+      const open = message.lastIndexOf('(');
+      const detail = message.endsWith(')') && open !== -1
+        ? message.slice(open + 1, -1)
+        : '';
+      return detail && !detail.includes(')') ? `${generic} (${detail})` : generic;
     }
     case 'SERVER_ERROR':
       // For server errors, we should not show generic message

--- a/src/utils/ssrf-protection.ts
+++ b/src/utils/ssrf-protection.ts
@@ -1,6 +1,6 @@
 import { URL } from 'url';
 import { lookup } from 'dns/promises';
-import { isIPv4, isIPv6 } from 'net';
+import net, { isIPv4, isIPv6 } from 'net';
 import http from 'http';
 import https from 'https';
 import ipaddr from 'ipaddr.js';
@@ -14,9 +14,24 @@ export interface PinnedAgents {
 export interface WebhookUrlValidationResult {
   valid: boolean;
   reason?: string;
+  /** First validated address, kept for backward compat. See {@link addresses} for the full set. */
   address?: string;
   family?: 4 | 6;
+  /**
+   * Every address the hostname resolved to, in DNS-answer order, each of
+   * which passed the SSRF policy. Pass this to {@link SSRFProtection.createPinnedAgents}
+   * so the transport can fail over across all validated candidates (e.g.
+   * `localhost` resolving to `::1` first on a host where the server only
+   * listens on IPv4) instead of being pinned to a single answer forever.
+   */
+  addresses?: Array<{ address: string; family: 4 | 6 }>;
 }
+
+// SECURITY (#978/#989/#990 resilience follow-up to GHSA-cmrh-wvq6-wm9r):
+// `autoSelectFamily`/`autoSelectFamilyAttemptTimeout` were added in Node 18.13
+// and are stable by 20.x. Guard for older runtimes; computed once at module
+// scope rather than probed per-socket.
+const supportsAutoSelectFamily = typeof (net as any).getDefaultAutoSelectFamily === 'function';
 
 /**
  * SSRF Protection Utility with Configurable Security Modes
@@ -285,16 +300,29 @@ export class SSRFProtection {
         return { valid: false, reason: 'Cloud metadata endpoint blocked' };
       }
 
-      // Step 3: Resolve DNS to get actual IP address
-      // This prevents DNS rebinding attacks where hostname resolves to different IPs
-      let resolvedIP: string;
-      let resolvedFamily: 4 | 6;
+      // Step 3: Resolve DNS to get every address this hostname answers with.
+      // Validating the full record set (not just the first answer) prevents
+      // a mixed-record DNS-rebinding attack where a public address ships
+      // alongside a private/metadata one and only the public one is checked.
+      let resolved: Array<{ address: string; family: 4 | 6 }>;
       try {
-        const { address, family } = await lookup(hostname);
-        resolvedIP = address;
-        resolvedFamily = family === 6 ? 6 : 4;
+        const raw = await lookup(hostname, { all: true }) as any;
+        // Real Node with { all: true } always returns an array; normalize
+        // defensively in case a caller/mock returns a single record.
+        const list: any[] = Array.isArray(raw) ? raw : [raw];
+        if (list.length === 0) {
+          throw new Error('DNS lookup returned no addresses');
+        }
+        resolved = list.map((entry) => ({
+          address: entry.address,
+          family: entry.family === 6 ? 6 : 4,
+        }));
 
-        logger.debug('DNS resolved for SSRF check', { hostname, resolvedIP, mode });
+        logger.debug('DNS resolved for SSRF check', {
+          hostname,
+          resolvedIPs: resolved.map(r => r.address),
+          mode
+        });
       } catch (error) {
         logger.warn('DNS resolution failed for webhook URL', {
           hostname,
@@ -303,110 +331,152 @@ export class SSRFProtection {
         return { valid: false, reason: 'DNS resolution failed' };
       }
 
-      // Step 4: ALWAYS block cloud metadata IPs (all modes)
-      if (CLOUD_METADATA.has(resolvedIP)) {
-        logger.warn('SSRF blocked: Hostname resolves to cloud metadata IP', {
-          hostname,
-          resolvedIP,
-          mode
-        });
-        return { valid: false, reason: 'Hostname resolves to cloud metadata endpoint' };
+      // Steps 4-7: validate every resolved address. FAIL CLOSED — if any
+      // address in the record set is disallowed, reject the whole hostname
+      // instead of only checking the first.
+      for (const { address } of resolved) {
+        const check = SSRFProtection.validateResolvedAddress(hostname, address, mode);
+        if (!check.valid) {
+          return { valid: false, reason: check.reason };
+        }
       }
 
-      // Step 4b: All-mode IPv6 tunneling gate — runs before the permissive
-      // early-return. Rejects (a) tunneled cloud-metadata (any mode) and
-      // (b) non-canonical tunneling prefixes (the fail-safe promise must
-      // hold in permissive too, not just strict/moderate).
-      const tunneledReason = SSRFProtection.tunneledIPv6BlockReason(resolvedIP);
-      if (tunneledReason !== null) {
-        logger.warn('SSRF blocked: IPv6 tunneling rejection (all-mode gate)', {
-          hostname,
-          resolvedIP,
-          mode,
-          reason: tunneledReason
-        });
-        return { valid: false, reason: tunneledReason };
-      }
-
-      // Step 5: Mode-specific validation
-
-      // MODE: permissive - Allow everything except cloud metadata
       if (mode === 'permissive') {
         logger.warn('SSRF protection in permissive mode (localhost and private IPs allowed)', {
           hostname,
-          resolvedIP
+          resolvedIPs: resolved.map(r => r.address)
         });
-        return { valid: true, address: resolvedIP, family: resolvedFamily };
       }
 
-      // Check if target is localhost
-      const isLocalhost = LOCALHOST_PATTERNS.has(hostname) ||
-                        resolvedIP === '::1' ||
-                        resolvedIP.startsWith('127.');
-
-      // MODE: strict - Block localhost and private IPs
-      if (mode === 'strict' && isLocalhost) {
-        logger.warn('SSRF blocked: Localhost not allowed in strict mode', {
-          hostname,
-          resolvedIP
-        });
-        return { valid: false, reason: 'Localhost access is blocked in strict mode' };
-      }
-
-      // MODE: moderate - Allow localhost, block private IPs
-      if (mode === 'moderate' && isLocalhost) {
-        logger.info('Localhost webhook allowed (moderate mode)', { hostname, resolvedIP });
-        return { valid: true, address: resolvedIP, family: resolvedFamily };
-      }
-
-      // Step 6: Check private IPv4 ranges (strict & moderate modes)
-      if (PRIVATE_IP_RANGES.some(regex => regex.test(resolvedIP))) {
-        logger.warn('SSRF blocked: Private IP address', { hostname, resolvedIP, mode });
-        return {
-          valid: false,
-          reason: mode === 'strict'
-            ? 'Private IP addresses not allowed'
-            : 'Private IP addresses not allowed (use WEBHOOK_SECURITY_MODE=permissive if needed)'
-        };
-      }
-
-      // Step 7: IPv6 private address check (strict & moderate modes)
-      if (SSRFProtection.isPrivateOrMappedIpv6(resolvedIP)) {
-        logger.warn('SSRF blocked: IPv6 private address', {
-          hostname,
-          resolvedIP,
-          mode
-        });
-        return { valid: false, reason: 'IPv6 private address not allowed' };
-      }
-
-      return { valid: true, address: resolvedIP, family: resolvedFamily };
+      const [first] = resolved;
+      return { valid: true, address: first.address, family: first.family, addresses: resolved };
     } catch (error) {
       return { valid: false, reason: 'Invalid URL format' };
     }
   }
 
   /**
+   * Validate a single resolved address against the cloud-metadata, IPv6
+   * tunneling, and mode-specific (localhost / private-range) policy. Shared
+   * by {@link validateWebhookUrl}'s loop over every DNS answer, so a
+   * hostname with a mixed record set is checked address-by-address instead
+   * of only on the first answer.
+   */
+  private static validateResolvedAddress(
+    hostname: string,
+    resolvedIP: string,
+    mode: SecurityMode
+  ): { valid: boolean; reason?: string } {
+    // Step 4: ALWAYS block cloud metadata IPs (all modes)
+    if (CLOUD_METADATA.has(resolvedIP)) {
+      logger.warn('SSRF blocked: Hostname resolves to cloud metadata IP', {
+        hostname,
+        resolvedIP,
+        mode
+      });
+      return { valid: false, reason: 'Hostname resolves to cloud metadata endpoint' };
+    }
+
+    // Step 4b: All-mode IPv6 tunneling gate — runs before the permissive
+    // early-return. Rejects (a) tunneled cloud-metadata (any mode) and
+    // (b) non-canonical tunneling prefixes (the fail-safe promise must
+    // hold in permissive too, not just strict/moderate).
+    const tunneledReason = SSRFProtection.tunneledIPv6BlockReason(resolvedIP);
+    if (tunneledReason !== null) {
+      logger.warn('SSRF blocked: IPv6 tunneling rejection (all-mode gate)', {
+        hostname,
+        resolvedIP,
+        mode,
+        reason: tunneledReason
+      });
+      return { valid: false, reason: tunneledReason };
+    }
+
+    // Step 5: Mode-specific validation
+
+    // MODE: permissive - Allow everything except cloud metadata
+    if (mode === 'permissive') {
+      return { valid: true };
+    }
+
+    // Check if target is localhost
+    const isLocalhost = LOCALHOST_PATTERNS.has(hostname) ||
+                      resolvedIP === '::1' ||
+                      resolvedIP.startsWith('127.');
+
+    // MODE: strict - Block localhost and private IPs
+    if (mode === 'strict' && isLocalhost) {
+      logger.warn('SSRF blocked: Localhost not allowed in strict mode', {
+        hostname,
+        resolvedIP
+      });
+      return { valid: false, reason: 'Localhost access is blocked in strict mode' };
+    }
+
+    // MODE: moderate - Allow localhost, block private IPs
+    if (mode === 'moderate' && isLocalhost) {
+      logger.info('Localhost webhook allowed (moderate mode)', { hostname, resolvedIP });
+      return { valid: true };
+    }
+
+    // Step 6: Check private IPv4 ranges (strict & moderate modes)
+    if (PRIVATE_IP_RANGES.some(regex => regex.test(resolvedIP))) {
+      logger.warn('SSRF blocked: Private IP address', { hostname, resolvedIP, mode });
+      return {
+        valid: false,
+        reason: mode === 'strict'
+          ? 'Private IP addresses not allowed'
+          : 'Private IP addresses not allowed (use WEBHOOK_SECURITY_MODE=permissive if needed)'
+      };
+    }
+
+    // Step 7: IPv6 private address check (strict & moderate modes)
+    if (SSRFProtection.isPrivateOrMappedIpv6(resolvedIP)) {
+      logger.warn('SSRF blocked: IPv6 private address', {
+        hostname,
+        resolvedIP,
+        mode
+      });
+      return { valid: false, reason: 'IPv6 private address not allowed' };
+    }
+
+    return { valid: true };
+  }
+
+  /**
    * Build a pair of HTTP/HTTPS agents that resolve every hostname to a fixed
-   * IP via a custom dns lookup callback. Pair with {@link validateWebhookUrl}
-   * so the transport connects to the IP that was just validated, regardless
-   * of what subsequent DNS queries would return.
+   * set of validated addresses via a custom dns lookup callback. Pair with
+   * {@link validateWebhookUrl} so the transport only ever connects to
+   * addresses that were just validated, regardless of what subsequent DNS
+   * queries would return.
+   *
+   * `addresses` should be the full, ordered set from
+   * {@link WebhookUrlValidationResult.addresses}, not just the first answer.
+   * Passing every validated candidate lets `net.connect`'s Happy-Eyeballs
+   * fallback (`autoSelectFamily`) try each one in turn — e.g. when `localhost`
+   * resolves to `::1` first but the server only listens on IPv4 — instead of
+   * hard-failing on a single pinned address (#978/#989/#990).
    *
    * @security GHSA-cmrh-wvq6-wm9r
    */
-  static createPinnedAgents(address: string, family: 4 | 6): PinnedAgents {
+  static createPinnedAgents(addresses: Array<{ address: string; family: 4 | 6 }>): PinnedAgents {
+    if (!addresses || addresses.length === 0) {
+      throw new Error('createPinnedAgents requires at least one validated address');
+    }
+
     const pinnedLookup = (
       _hostname: string,
       options: any,
       callback: any
     ): void => {
       // Node's lookup contract: when options.all is true, callback receives
-      // an array of {address, family}; otherwise (address, family).
-      // validateWebhookUrl resolved a single IP — return that for both shapes.
+      // an array of {address, family}; otherwise (address, family) for the
+      // first candidate. validateWebhookUrl resolved and validated the full
+      // set — return all of it for `all`, and the first for the scalar shape.
       if (options && options.all) {
-        callback(null, [{ address, family }]);
+        callback(null, addresses.map(a => ({ address: a.address, family: a.family })));
       } else {
-        callback(null, address, family);
+        callback(null, addresses[0].address, addresses[0].family);
       }
     };
 
@@ -420,7 +490,16 @@ export class SSRFProtection {
       const proto = Object.getPrototypeOf(agent);
       const original = proto.createConnection;
       (agent as any).createConnection = function (options: any, cb: any) {
-        return original.call(this, { ...options, lookup: pinnedLookup }, cb);
+        const connectOptions: any = { ...options, lookup: pinnedLookup };
+        // Try every pinned candidate (Happy-Eyeballs) instead of hard-failing
+        // on the first — all candidates already passed SSRF validation, so
+        // this doesn't weaken the pinning guarantee. Guarded for Node
+        // runtimes that predate autoSelectFamily.
+        if (supportsAutoSelectFamily) {
+          connectOptions.autoSelectFamily = true;
+          connectOptions.autoSelectFamilyAttemptTimeout = 250;
+        }
+        return original.call(this, connectOptions, cb);
       };
       // Expose for tests; not load-bearing at runtime.
       (agent as any).options = { ...((agent as any).options || {}), lookup: pinnedLookup };

--- a/tests/unit/services/n8n-api-client.test.ts
+++ b/tests/unit/services/n8n-api-client.test.ts
@@ -2680,6 +2680,197 @@ badRequest('request/body/nodeGroups/0 must NOT have additional properties')
     });
   });
 
+  // #978/#989/#990 — pinned-agent resilience follow-up to GHSA-cmrh-wvq6-wm9r:
+  // TTL expiry, invalidate-on-failure, and real connection-level retries.
+  describe('pinned agent resilience', () => {
+    let requestInterceptor: any;
+    let responseErrorInterceptor: any;
+
+    beforeEach(() => {
+      vi.mocked(mockAxiosInstance.interceptors.request.use).mockImplementation((onFulfilled: any) => {
+        requestInterceptor = onFulfilled;
+        return 0;
+      });
+      vi.mocked(mockAxiosInstance.interceptors.response.use).mockImplementation((onFulfilled: any, onRejected: any) => {
+        responseErrorInterceptor = onRejected;
+        return 0;
+      });
+      client = new N8nApiClient(defaultConfig);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // Real n8n api client `config` objects carry `.method` and mutate
+    // `__retryCount` across retries; helper mirrors that shape.
+    const makeConnectionError = (code: string, config: any) => {
+      const error: any = new Error(code);
+      error.isAxiosError = true;
+      error.code = code;
+      error.request = {};
+      error.config = config;
+      return error;
+    };
+
+    it('caches pinned agents across requests within the TTL', async () => {
+      await requestInterceptor({ method: 'get', url: '/workflows' });
+      await requestInterceptor({ method: 'get', url: '/workflows' });
+
+      expect(vi.mocked(dns.lookup)).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-resolves pinned agents after the TTL expires', async () => {
+      vi.useFakeTimers();
+
+      await requestInterceptor({ method: 'get', url: '/workflows' });
+      expect(vi.mocked(dns.lookup)).toHaveBeenCalledTimes(1);
+
+      // Still within the 60s TTL: cache is reused.
+      await requestInterceptor({ method: 'get', url: '/workflows' });
+      expect(vi.mocked(dns.lookup)).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(60_001);
+
+      await requestInterceptor({ method: 'get', url: '/workflows' });
+      expect(vi.mocked(dns.lookup)).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidates the pinned agent cache after a NO_RESPONSE error', async () => {
+      await requestInterceptor({ method: 'get', url: '/workflows' });
+      expect(vi.mocked(dns.lookup)).toHaveBeenCalledTimes(1);
+
+      // No `.code` on the error: retry is ineligible, isolating the
+      // cache-invalidation behavior of the terminal NO_RESPONSE mapping.
+      const error: any = new Error('Network error');
+      error.isAxiosError = true;
+      error.request = {};
+      error.config = {};
+      await expect(responseErrorInterceptor(error)).rejects.toThrow();
+
+      await requestInterceptor({ method: 'get', url: '/workflows' });
+      expect(vi.mocked(dns.lookup)).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not stampede re-resolution when concurrent requests hit an expired TTL', async () => {
+      vi.useFakeTimers();
+
+      await requestInterceptor({ method: 'get', url: '/workflows' });
+      expect(vi.mocked(dns.lookup)).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(60_001);
+
+      // Both requests observe the expired cache; only the first may kick off
+      // a new resolution — the second must reuse the in-flight promise.
+      await Promise.all([
+        requestInterceptor({ method: 'get', url: '/workflows' }),
+        requestInterceptor({ method: 'get', url: '/workflows' }),
+      ]);
+      expect(vi.mocked(dns.lookup)).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-resolves DNS on the retried attempt after a connection failure', async () => {
+      vi.useFakeTimers();
+      const config: any = { method: 'get', url: '/workflows' };
+
+      // Populate the pinned-agent cache the way a real first attempt would.
+      await requestInterceptor(config);
+      expect(vi.mocked(dns.lookup)).toHaveBeenCalledTimes(1);
+
+      // Mimic real axios: a re-issued request runs the request interceptor
+      // (which attaches agents, resolving DNS if the cache was cleared)
+      // before hitting the (now healthy) adapter.
+      mockAxiosInstance.request.mockImplementation(async (cfg: any) => {
+        await requestInterceptor(cfg);
+        return { data: { ok: true }, headers: {} };
+      });
+
+      const resultPromise = responseErrorInterceptor(makeConnectionError('ECONNREFUSED', config));
+      const assertion = expect(resultPromise).resolves.toEqual({ data: { ok: true }, headers: {} });
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      // tryRetry cleared the cache, so the retried attempt resolved afresh.
+      expect(vi.mocked(dns.lookup)).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries a GET on ETIMEDOUT up to maxRetries then rejects with NO_RESPONSE', async () => {
+      vi.useFakeTimers();
+      const config: any = { method: 'get', url: '/workflows' };
+
+      // Mimics real axios: re-issuing via client.request() re-enters the
+      // same response error interceptor, so retries recurse exactly as they
+      // do against a real client.
+      mockAxiosInstance.request.mockImplementation(async () =>
+        responseErrorInterceptor(makeConnectionError('ETIMEDOUT', config))
+      );
+
+      const resultPromise = responseErrorInterceptor(makeConnectionError('ETIMEDOUT', config));
+      const assertion = expect(resultPromise).rejects.toMatchObject({ code: 'NO_RESPONSE' });
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      expect(mockAxiosInstance.request).toHaveBeenCalledTimes(defaultConfig.maxRetries!);
+    });
+
+    it('retries a POST on ECONNREFUSED and resolves on success', async () => {
+      vi.useFakeTimers();
+      const config: any = { method: 'post', url: '/workflows' };
+
+      mockAxiosInstance.request.mockResolvedValue({ data: { id: '123' }, headers: {} });
+
+      const resultPromise = responseErrorInterceptor(makeConnectionError('ECONNREFUSED', config));
+      const assertion = expect(resultPromise).resolves.toEqual({ data: { id: '123' }, headers: {} });
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      expect(mockAxiosInstance.request).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry a POST on ECONNRESET (not idempotent-safe)', async () => {
+      const config: any = { method: 'post', url: '/workflows' };
+
+      await expect(
+        responseErrorInterceptor(makeConnectionError('ECONNRESET', config))
+      ).rejects.toMatchObject({ code: 'NO_RESPONSE' });
+
+      expect(mockAxiosInstance.request).not.toHaveBeenCalled();
+    });
+
+    it('does retry a GET on ECONNRESET (idempotent-safe)', async () => {
+      vi.useFakeTimers();
+      const config: any = { method: 'get', url: '/workflows' };
+
+      mockAxiosInstance.request.mockResolvedValue({ data: [], headers: {} });
+
+      const resultPromise = responseErrorInterceptor(makeConnectionError('ECONNRESET', config));
+      const assertion = expect(resultPromise).resolves.toEqual({ data: [], headers: {} });
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      expect(mockAxiosInstance.request).toHaveBeenCalledTimes(1);
+    });
+
+    it('respects a custom maxRetries', async () => {
+      vi.useFakeTimers();
+      // Constructing a second client re-registers interceptors on the mock;
+      // `responseErrorInterceptor` now points at this client's handler.
+      new N8nApiClient({ ...defaultConfig, maxRetries: 1 });
+      const config: any = { method: 'get', url: '/workflows' };
+
+      mockAxiosInstance.request.mockImplementation(async () =>
+        responseErrorInterceptor(makeConnectionError('ETIMEDOUT', config))
+      );
+
+      const resultPromise = responseErrorInterceptor(makeConnectionError('ETIMEDOUT', config));
+      const assertion = expect(resultPromise).rejects.toMatchObject({ code: 'NO_RESPONSE' });
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      expect(mockAxiosInstance.request).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // GHSA-4ggg-h7ph-26qr — defense-in-depth URL normalization in the constructor.
   describe('constructor URL normalization', () => {
     const getLastAxiosBaseURL = (): string => {

--- a/tests/unit/utils/n8n-errors.test.ts
+++ b/tests/unit/utils/n8n-errors.test.ts
@@ -3,6 +3,7 @@ import {
   formatExecutionError,
   formatNoExecutionError,
   getUserFriendlyErrorMessage,
+  handleN8nApiError,
   N8nApiError,
   N8nAuthenticationError,
   N8nNotFoundError,
@@ -179,6 +180,97 @@ describe('getUserFriendlyErrorMessage', () => {
       // Circular details cannot be stringified - the hint just doesn't fire from details
       expect(() => getUserFriendlyErrorMessage(error)).not.toThrow();
     });
+  });
+});
+
+// #978/#989/#990 — say which address failed instead of an opaque "no response".
+describe('NO_RESPONSE connection detail', () => {
+  it('enriches the message with code and address:port from a plain connection error', () => {
+    const axiosError: any = new Error('connect ECONNREFUSED 127.0.0.1:5678');
+    axiosError.isAxiosError = true;
+    axiosError.code = 'ECONNREFUSED';
+    axiosError.address = '127.0.0.1';
+    axiosError.port = 5678;
+    axiosError.request = {};
+
+    const error = handleN8nApiError(axiosError);
+    expect(error.code).toBe('NO_RESPONSE');
+    expect(error.message).toBe('No response from n8n server (ECONNREFUSED 127.0.0.1:5678)');
+  });
+
+  it('brackets an IPv6 address in the detail', () => {
+    const axiosError: any = new Error('connect ECONNREFUSED ::1:5678');
+    axiosError.isAxiosError = true;
+    axiosError.code = 'ECONNREFUSED';
+    axiosError.address = '::1';
+    axiosError.port = 5678;
+    axiosError.request = {};
+
+    const error = handleN8nApiError(axiosError);
+    expect(error.message).toBe('No response from n8n server (ECONNREFUSED [::1]:5678)');
+  });
+
+  it('lists each deduped member of an AggregateError (autoSelectFamily)', () => {
+    const axiosError: any = new Error('connect failed');
+    axiosError.isAxiosError = true;
+    axiosError.request = {};
+    axiosError.errors = [
+      Object.assign(new Error('a'), { code: 'ECONNREFUSED', address: '127.0.0.1', port: 5678 }),
+      Object.assign(new Error('b'), { code: 'ECONNREFUSED', address: '::1', port: 5678 }),
+      Object.assign(new Error('c'), { code: 'ECONNREFUSED', address: '127.0.0.1', port: 5678 }),
+    ];
+
+    const error = handleN8nApiError(axiosError);
+    expect(error.message).toBe(
+      'No response from n8n server (ECONNREFUSED 127.0.0.1:5678, ECONNREFUSED [::1]:5678)'
+    );
+  });
+
+  it('reads the detail from error.cause when the wrapper carries only the code', () => {
+    // Real axios copies `code` onto the AxiosError but the syscall
+    // address/port can live only on the underlying cause.
+    const axiosError: any = new Error('connect ECONNREFUSED 127.0.0.1:5678');
+    axiosError.isAxiosError = true;
+    axiosError.request = {};
+    axiosError.cause = Object.assign(new Error('raw'), {
+      code: 'ECONNREFUSED',
+      address: '127.0.0.1',
+      port: 5678,
+    });
+
+    const error = handleN8nApiError(axiosError);
+    expect(error.message).toBe('No response from n8n server (ECONNREFUSED 127.0.0.1:5678)');
+  });
+
+  it('falls back to the top-level code when aggregate members carry none', () => {
+    const axiosError: any = new Error('connect failed');
+    axiosError.isAxiosError = true;
+    axiosError.code = 'ECONNREFUSED';
+    axiosError.request = {};
+    axiosError.errors = [new Error('memberless'), new Error('another')];
+
+    const error = handleN8nApiError(axiosError);
+    expect(error.message).toBe('No response from n8n server (ECONNREFUSED)');
+  });
+
+  it('falls back to the generic message when no code-bearing detail is available', () => {
+    const axiosError: any = new Error('Network error');
+    axiosError.isAxiosError = true;
+    axiosError.request = {};
+
+    const error = handleN8nApiError(axiosError);
+    expect(error.message).toBe('No response from n8n server');
+  });
+
+  it('getUserFriendlyErrorMessage appends the detail to the generic sentence', () => {
+    const error = new N8nApiError(
+      'No response from n8n server (ECONNREFUSED 127.0.0.1:5678)',
+      undefined,
+      'NO_RESPONSE'
+    );
+    expect(getUserFriendlyErrorMessage(error)).toBe(
+      'Unable to connect to n8n. Please check the server URL and ensure n8n is running. (ECONNREFUSED 127.0.0.1:5678)'
+    );
   });
 });
 

--- a/tests/unit/utils/ssrf-protection.test.ts
+++ b/tests/unit/utils/ssrf-protection.test.ts
@@ -5,6 +5,7 @@ vi.mock('dns/promises', () => ({
   lookup: vi.fn(),
 }));
 
+import http from 'http';
 import { SSRFProtection } from '../../../src/utils/ssrf-protection';
 import * as dns from 'dns/promises';
 
@@ -1035,6 +1036,7 @@ describe('SSRFProtection', () => {
       expect(result.valid).toBe(true);
       expect(result.address).toBe('93.184.216.34');
       expect(result.family).toBe(4);
+      expect(result.addresses).toEqual([{ address: '93.184.216.34', family: 4 }]);
     });
 
     it('should return IPv6 family when hostname resolves to v6', async () => {
@@ -1043,10 +1045,82 @@ describe('SSRFProtection', () => {
       expect(result.valid).toBe(true);
       expect(result.address).toBe('2606:4700:4700::1111');
       expect(result.family).toBe(6);
+      expect(result.addresses).toEqual([{ address: '2606:4700:4700::1111', family: 6 }]);
     });
 
-    it('createPinnedAgents lookup returns the pinned IP regardless of hostname', () => {
-      const { httpAgent, httpsAgent } = SSRFProtection.createPinnedAgents('93.184.216.34', 4);
+    it('validateWebhookUrl with a multi-address DNS answer returns every validated address', async () => {
+      vi.mocked(dns.lookup).mockResolvedValue([
+        { address: '93.184.216.34', family: 4 },
+        { address: '2606:4700:4700::1111', family: 6 },
+      ] as any);
+
+      const result = await SSRFProtection.validateWebhookUrl('https://multi.example.com');
+      expect(result.valid).toBe(true);
+      expect(result.address).toBe('93.184.216.34');
+      expect(result.family).toBe(4);
+      expect(result.addresses).toEqual([
+        { address: '93.184.216.34', family: 4 },
+        { address: '2606:4700:4700::1111', family: 6 },
+      ]);
+    });
+
+    it('fails closed when any address in a mixed-record answer is disallowed', async () => {
+      // One legitimate public IP alongside a cloud-metadata IP: the whole
+      // hostname must be rejected, not just have the bad address ignored.
+      vi.mocked(dns.lookup).mockResolvedValue([
+        { address: '93.184.216.34', family: 4 },
+        { address: '169.254.169.254', family: 4 },
+      ] as any);
+
+      const result = await SSRFProtection.validateWebhookUrl('https://mixed-record.example.com');
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('Hostname resolves to cloud metadata endpoint');
+      expect(result.address).toBeUndefined();
+      expect(result.addresses).toBeUndefined();
+    });
+
+    it('wrapped createConnection pins the lookup and enables autoSelectFamily fallback', () => {
+      const proto = http.Agent.prototype as any;
+      const original = proto.createConnection;
+      let seenOptions: any;
+      proto.createConnection = function (options: any) {
+        seenOptions = options;
+        // Minimal socket stand-in; the agent only needs an object back.
+        return { on: () => {}, once: () => {}, setNoDelay: () => {}, destroy: () => {} };
+      };
+      try {
+        const { httpAgent } = SSRFProtection.createPinnedAgents([
+          { address: '203.0.113.10', family: 4 },
+          { address: '2001:db8::1', family: 6 },
+        ]);
+        (httpAgent as any).createConnection({ host: 'pinned.example.test', port: 80 }, () => {});
+      } finally {
+        proto.createConnection = original;
+      }
+
+      expect(typeof seenOptions.lookup).toBe('function');
+      // Every currently supported Node exposes autoSelectFamily; the option
+      // is what lets net.connect fall back across the pinned set (#978).
+      expect(seenOptions.autoSelectFamily).toBe(true);
+      expect(seenOptions.autoSelectFamilyAttemptTimeout).toBe(250);
+    });
+
+    it('fails closed on a metadata address in any record position even in permissive mode', async () => {
+      process.env.WEBHOOK_SECURITY_MODE = 'permissive';
+      vi.mocked(dns.lookup).mockResolvedValue([
+        { address: '93.184.216.34', family: 4 },
+        { address: '169.254.169.254', family: 4 },
+      ] as any);
+
+      const result = await SSRFProtection.validateWebhookUrl('https://mixed-permissive.example.com');
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe('Hostname resolves to cloud metadata endpoint');
+    });
+
+    it('createPinnedAgents lookup returns the first pinned address for the scalar shape', () => {
+      const { httpAgent, httpsAgent } = SSRFProtection.createPinnedAgents([
+        { address: '93.184.216.34', family: 4 },
+      ]);
       const httpLookup = (httpAgent as any).options.lookup;
       const httpsLookup = (httpsAgent as any).options.lookup;
       expect(typeof httpLookup).toBe('function');
@@ -1066,6 +1140,30 @@ describe('SSRFProtection', () => {
       ]);
     });
 
+    it('createPinnedAgents lookup returns the full pinned set for options.all', () => {
+      const addresses = [
+        { address: '93.184.216.34', family: 4 as const },
+        { address: '2606:4700:4700::1111', family: 6 as const },
+      ];
+      const { httpAgent } = SSRFProtection.createPinnedAgents(addresses);
+      const lookup = (httpAgent as any).options.lookup as Function;
+
+      let allResult: any;
+      lookup('rebind.example.test', { all: true }, (_err: any, result: any) => {
+        allResult = result;
+      });
+      expect(allResult).toEqual(addresses);
+
+      let firstAddress: string | undefined;
+      let firstFamily: number | undefined;
+      lookup('rebind.example.test', {}, (_err: any, address: string, family: number) => {
+        firstAddress = address;
+        firstFamily = family;
+      });
+      expect(firstAddress).toBe('93.184.216.34');
+      expect(firstFamily).toBe(4);
+    });
+
     it('pinned lookup ignores subsequent dns.lookup answers', async () => {
       // Validator DNS answer (the "good" IP). Subsequent dns.lookup calls
       // simulate an attacker-controlled resolver flipping to a private IP —
@@ -1082,10 +1180,7 @@ describe('SSRFProtection', () => {
       expect(validation.valid).toBe(true);
       expect(validation.address).toBe('1.1.1.1');
 
-      const { httpAgent } = SSRFProtection.createPinnedAgents(
-        validation.address!,
-        validation.family!
-      );
+      const { httpAgent } = SSRFProtection.createPinnedAgents(validation.addresses!);
 
       const transportCalls: Array<{ address: string; family: number }> = [];
       const lookup = (httpAgent as any).options.lookup as Function;
@@ -1107,17 +1202,24 @@ describe('SSRFProtection', () => {
     });
 
     it('agents disable keep-alive so connections do not leak across hosts', () => {
-      const { httpAgent, httpsAgent } = SSRFProtection.createPinnedAgents('1.2.3.4', 4);
+      const { httpAgent, httpsAgent } = SSRFProtection.createPinnedAgents([
+        { address: '1.2.3.4', family: 4 },
+      ]);
       expect((httpAgent as any).keepAlive).toBe(false);
       expect((httpsAgent as any).keepAlive).toBe(false);
     });
 
-    it('does not return address/family on rejection', async () => {
+    it('createPinnedAgents throws on an empty address list', () => {
+      expect(() => SSRFProtection.createPinnedAgents([])).toThrow();
+    });
+
+    it('does not return address/family/addresses on rejection', async () => {
       vi.mocked(dns.lookup).mockResolvedValue({ address: '169.254.169.254', family: 4 } as any);
       const result = await SSRFProtection.validateWebhookUrl('http://attacker.example');
       expect(result.valid).toBe(false);
       expect(result.address).toBeUndefined();
       expect(result.family).toBeUndefined();
+      expect(result.addresses).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Fixes #978. Fixes #989. Fixes #990.

Thanks to @ConnorCloze (#978) and @Boulevard-Dreams (#989/#990) for unusually precise root-cause analyses — both traced the installed package to the exact lines, and both were confirmed verbatim against `main`.

## The problem

The DNS-pinning SSRF protection (GHSA-cmrh-wvq6-wm9r) resolved the API hostname with a single-answer `dns.lookup()`, pinned every connection to that one address, cached it for the life of the process, and had no retry path (`N8N_API_MAX_RETRIES` was stored and never read). Consequences:

- **#978** — macOS resolves `localhost` to `::1` first; an n8n listening only on IPv4 loopback (Docker Desktop's `-p 127.0.0.1:5678:5678`) fails every management tool with an opaque `NO_RESPONSE` while `curl` works.
- **#989/#990** (duplicates) — a Cloudflare-fronted instance stays nailed to whichever edge answered first at startup; one bad edge means every call fails until the MCP process restarts.

## The fix

**`ssrf-protection.ts`** — `validateWebhookUrl` resolves `{all: true}` and validates **every** record via a shared per-address policy helper, failing closed if any record is disallowed. This also closes the mixed-record variant of DNS rebinding, and deliberately applies to cloud-metadata addresses in any record position **in permissive mode too** (previously only the first answer was ever checked). `createPinnedAgents` pins the full validated set: the custom lookup hands back all candidates, and `autoSelectFamily` (guarded for old Node) lets `net.connect` try each in turn — every candidate has already passed validation, so the pinning guarantee is unchanged.

**`n8n-api-client.ts`** — the cached pinned agents get a 60s TTL (stamped at dispatch to prevent a re-resolution stampede, refreshed on fulfillment only while still current) and are invalidated after any terminal `NO_RESPONSE`. `maxRetries` now drives a real retry path in the response interceptor: pre-connection failures (`ECONNREFUSED`/`EHOSTUNREACH`/`ENETUNREACH`/`ENOTFOUND`/`EAI_AGAIN`, including AggregateError members) retry any method; `ECONNRESET`/`ETIMEDOUT`/`ECONNABORTED` retry only GET/HEAD, so a non-idempotent request that may have reached the server is never re-executed. Each retry clears the pinned cache first, so the retried attempt resolves fresh DNS — this is what heals the rotated-CDN-edge case mid-session.

**`n8n-errors.ts`** — `NO_RESPONSE` now names what failed: `No response from n8n server (ECONNREFUSED 127.0.0.1:5678, ECONNREFUSED [::1]:5678)`, reading detail from the error, its `cause`, or each AggregateError member; the user-facing message carries it through. The trigger handlers also summarize AggregateError members instead of surfacing an empty message.

## Review notes

Gauntlet: code-reviewer + Codex (adversarial), both confirmed the core invariant — no connection can reach an address that did not pass validation — and both verified the axios re-issue mechanics against the installed axios 1.18.1 (`__retryCount` survives `mergeConfig`; serialized bodies aren't double-transformed; recursion bounded). Applied from review: the TTL stampede fix, the `cause` fallback in error details, non-idempotent default for a missing method, AggregateError messages in trigger handlers, and coverage for autoSelectFamily wiring, permissive-mode fail-close, concurrent-expiry, and fresh-DNS-on-retry. Declined: retrying DNS-resolution failures inside URL validation (fail-fast is intentional; the cache resets so the next call re-resolves).

Behavior changes to be aware of: a hostname whose record set mixes allowed and disallowed addresses now fails closed even when the allowed one comes first (stricter; previously only the first answer was checked), and permissive mode now rejects tunneled/metadata records in any position.

## Verification

- `npm run typecheck` clean.
- Full unit suite in the worktree: 170 files, 5762 passed, 35 skipped (baseline), 0 failures.
- New coverage: multi-address validation, fail-closed mixed records (strict + permissive), pinned-set lookup shapes, autoSelectFamily on `createConnection`, TTL expiry + concurrent-expiry single-flight, cache invalidation on `NO_RESPONSE`, retry matrix (GET/POST × refused/reset/timeout), fresh DNS on retried attempts, enriched error details incl. `cause` and code-less aggregates.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)