### PR TITLE
fix: mark timeSavedMode as derived to prevent 400 on workflow writes (n8n >= 2.33)

### DIFF
--- a/src/constants/workflow-settings.ts
+++ b/src/constants/workflow-settings.ts
@@ -67,7 +67,7 @@ export const WORKFLOW_SETTINGS_PROPERTIES: Record<string, WorkflowSettingPropert
 
   // n8n 2.33.0
   binaryMode: { since: v(2, 33, 0), derived: true },
-  timeSavedMode: { since: v(2, 33, 0) },
+  timeSavedMode: { since: v(2, 33, 0), derived: true },
   credentialResolverId: { since: v(2, 33, 0), derived: true },
 };
 


### PR DESCRIPTION
## Problem

On n8n instances >= 2.33.0, **every write operation** (`n8n_update_partial_workflow`, `n8n_update_full_workflow`) fails with:

```
400 Invalid request: request/body/settings must NOT have additional properties
```

## Root cause

n8n 2.33.0 added `timeSavedMode` to the `workflowSettings` DB column and echoes it back on `GET /workflows/{id}`. However, the **public API PUT schema** (`additionalProperties: false`) does not list `timeSavedMode` as an accepted property — so it rejects it on write.

`binaryMode` and `credentialResolverId`, introduced in the same release, already carry `derived: true` in `WORKFLOW_SETTINGS_PROPERTIES` and are correctly stripped by `stripDerivedSettings()` before every PUT. `timeSavedMode` was missing the flag by oversight.

## Fix

One-word change in `src/constants/workflow-settings.ts`:

```ts
// before
timeSavedMode: { since: v(2, 33, 0) },

// after
timeSavedMode: { since: v(2, 33, 0), derived: true },
```

`stripDerivedSettings()` runs unconditionally before every write, so this is enough — no other code needs to change.

## Verification

Confirmed on a live n8n 2.33+ instance (Railway-hosted):

| PUT body | Result |
|---|---|
| settings includes `timeSavedMode` | `400 request/body/settings must NOT have additional properties` |
| settings without `timeSavedMode` | `200 OK` |

The live instance's `GET /api/v1/openapi.yml` also confirms `timeSavedMode` is absent from `components.schemas.workflowSettings`.

## Note

`timeSavedMode` is derived server-side (n8n sets it from internal defaults, not from the PUT body), so stripping it loses nothing — identical to the existing treatment of `binaryMode`.