### PR TITLE
fix: forward workflow settings outside the typed create schema (v2.74.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.74.1] - 2026-08-27
+
+### Fixed
+
+- **`n8n_create_workflow` silently dropped workflow settings outside its own list** (#1026). The create input schema was a closed object with eight settings keys, so `availableInMCP`, `callerPolicy`, `callerIds`, `timeSavedPerExecution`, `customTelemetryTags`, `redactionPolicy` and `timeSavedMode` were stripped before the payload reached the API client. A workflow created with `settings.availableInMCP: true` therefore never appeared in n8n's instance-level MCP server, while the same key set through `updateSettings` worked. The typed keys are still validated; every other key is now forwarded, as on the update path; the create cleaner still drops the derived properties n8n ignores on write. The tool schema and documentation now mention `availableInMCP`.
+
 ## [2.74.0] - 2026-08-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.74.0",
+  "version": "2.74.1",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.74.0",
+  "version": "2.74.1",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -443,6 +443,9 @@ const createWorkflowSchema = z.object({
   // Two-arg z.record(keySchema, valueSchema) — see services/n8n-validation.ts for the
   // Zod 3/4 compatibility rationale (#744).
   connections: z.preprocess(normalizeMcpWorkflowConnections, z.record(z.string(), z.any())),
+  // The typed keys are validated; every other key is forwarded, as on the update path.
+  // A closed object here silently dropped `availableInMCP`, `callerPolicy` and the other
+  // settings added since n8n 1.119 before they reached the cleaner (issue #1026).
   settings: z.preprocess(normalizeMcpJsonValue, z.object({
     executionOrder: z.enum(['v0', 'v1']).optional(),
     timezone: z.string().optional(),
@@ -452,7 +455,7 @@ const createWorkflowSchema = z.object({
     saveExecutionProgress: z.boolean().optional(),
     executionTimeout: z.number().optional(),
     errorWorkflow: z.string().optional(),
-  })).optional(),
+  }).passthrough()).optional(),
   // Validated by parseNodeGroupsInput() — see services/node-groups.ts
   nodeGroups: z.any().optional(),
   projectId: z.string().optional(),

--- a/src/mcp/tool-docs/workflow_management/n8n-create-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-create-workflow.ts
@@ -21,7 +21,7 @@ export const n8nCreateWorkflowDoc: ToolDocumentation = {
       name: { type: 'string', required: true, description: 'Workflow name' },
       nodes: { type: 'array', required: true, description: 'Array of nodes with id, name, type, typeVersion, position, parameters' },
       connections: { type: 'object', required: true, description: 'Node connections. Keys are source node names (not IDs)' },
-      settings: { type: 'object', description: 'Optional workflow settings (timezone, error handling, etc.)' },
+      settings: { type: 'object', description: 'Optional workflow settings (timezone, error handling, etc.). Every key the n8n Public API accepts is forwarded, including availableInMCP, which exposes the workflow to n8n\'s instance-level MCP server.' },
       nodeGroups: { type: 'array', description: 'Optional canvas groups (n8n 2.28+): [{name, nodeIds, description?}]. Members are node IDs from nodes[] and must form a connected run with no trigger among them. Dropped with a warning on n8n older than 2.28.' },
       projectId: { type: 'string', description: 'Optional project to create the workflow in (enterprise feature). Defaults to the personal project.' },
       parentFolderId: { type: 'string', description: 'Optional folder to place the workflow in (n8n 2.32+; rejected with a 400 on older instances). Omit for the project root. Manage folders with n8n_manage_folders.' }
@@ -72,7 +72,8 @@ n8n_create_workflow({
     timezone: "America/New_York",
     errorWorkflow: "error_handler_workflow_id",
     saveDataSuccessExecution: "all",
-    saveDataErrorExecution: "all"
+    saveDataErrorExecution: "all",
+    availableInMCP: true  // expose to n8n's instance-level MCP server
   }
 })`
     ],

--- a/src/mcp/tool-docs/workflow_management/n8n-update-partial-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-update-partial-workflow.ts
@@ -50,7 +50,7 @@ export const n8nUpdatePartialWorkflowDoc: ToolDocumentation = {
 - **replaceConnections**: Replace entire connections object
 
 ### Metadata Operations (5 types):
-- **updateSettings**: Modify workflow settings
+- **updateSettings**: Modify workflow settings (merged over the current ones). Any key the n8n Public API accepts is forwarded, e.g. \`availableInMCP: true\` exposes the workflow to n8n's instance-level MCP server.
 - **updateName**: Rename the workflow
 - **setNodeGroups**: Replace the workflow's canvas groups (n8n 2.28+). Full replacement — pass every group to keep, or \`[]\` to ungroup everything. Each group takes \`name\` plus either \`nodeNames\` or \`nodeIds\`, and an optional \`description\` (max 155 chars, n8n 2.32+; dropped automatically on older instances). Group members must form a connected run with no trigger among them; n8n validates that on save and its message is returned unchanged if a group you asked for is rejected.
 - **addTag**: Add a workflow tag

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -52,7 +52,7 @@ export const n8nManagementTools: ToolDefinition[] = [
         },
         settings: {
           type: 'object',
-          description: 'Optional workflow settings (execution order, timezone, error handling)',
+          description: 'Optional workflow settings (execution order, timezone, error handling). Any other key the n8n Public API accepts is forwarded as well, e.g. availableInMCP (expose the workflow to n8n\'s instance-level MCP server), callerPolicy, callerIds.',
           properties: {
             executionOrder: { type: 'string', enum: ['v0', 'v1'] },
             timezone: { type: 'string' },
@@ -61,7 +61,8 @@ export const n8nManagementTools: ToolDefinition[] = [
             saveManualExecutions: { type: 'boolean' },
             saveExecutionProgress: { type: 'boolean' },
             executionTimeout: { type: 'number' },
-            errorWorkflow: { type: 'string' }
+            errorWorkflow: { type: 'string' },
+            availableInMCP: { type: 'boolean', description: 'Expose the workflow to n8n\'s instance-level MCP server (n8n 1.119+)' }
           }
         },
         nodeGroups: {

--- a/tests/integration/ai-validation/ai-agent-validation.test.ts
+++ b/tests/integration/ai-validation/ai-agent-validation.test.ts
@@ -317,6 +317,7 @@ describe('Integration: AI Agent Validation', () => {
     });
 
     const memory2 = createMemoryNode({
+      id: 'memory-2', // the helper defaults to 'memory-1'; n8n 2.36 rejects duplicate node ids
       name: 'Memory 2'
     });
 

--- a/tests/unit/mcp/handlers-n8n-manager.test.ts
+++ b/tests/unit/mcp/handlers-n8n-manager.test.ts
@@ -308,6 +308,45 @@ describe('handlers-n8n-manager', () => {
       expect(n8nValidation.validateWorkflowStructure).toHaveBeenCalledWith(input);
     });
 
+    it('should forward settings keys outside the typed schema, such as availableInMCP (issue #1026)', async () => {
+      // Regression: the create schema was a closed z.object, so Zod stripped every settings key
+      // it did not list before the payload reached the API client. The update path forwards them.
+      const testWorkflow = createTestWorkflow();
+      const input = {
+        name: 'Test Workflow',
+        nodes: testWorkflow.nodes,
+        connections: testWorkflow.connections,
+        settings: {
+          executionOrder: 'v1',
+          availableInMCP: true,
+          callerPolicy: 'workflowsFromSameOwner',
+          timeSavedPerExecution: 5,
+        },
+      };
+
+      mockApiClient.createWorkflow.mockResolvedValue(testWorkflow);
+
+      const result = await handlers.handleCreateWorkflow(input);
+
+      expect(result.success).toBe(true);
+      const sentWorkflow = mockApiClient.createWorkflow.mock.calls[0][0];
+      expect(sentWorkflow.settings).toEqual(input.settings);
+    });
+
+    it('should still reject invalid values for the typed settings keys', async () => {
+      const testWorkflow = createTestWorkflow();
+      const result = await handlers.handleCreateWorkflow({
+        name: 'Test Workflow',
+        nodes: testWorkflow.nodes,
+        connections: testWorkflow.connections,
+        settings: { executionOrder: 'v2', availableInMCP: true },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid input');
+      expect(mockApiClient.createWorkflow).not.toHaveBeenCalled();
+    });
+
     it('forwards parentFolderId to the create payload (folder placement, n8n 2.32+)', async () => {
       const testWorkflow = createTestWorkflow();
       const input = {


### PR DESCRIPTION
Fixes #1026.

## Problem

`n8n_create_workflow` declared `settings` as a closed `z.object` with eight keys. Zod strips unknown keys by default, so `availableInMCP`, `callerPolicy`, `callerIds`, `timeSavedPerExecution`, `customTelemetryTags`, `redactionPolicy` and `timeSavedMode` were removed before the payload reached the API client. A workflow created with `settings.availableInMCP: true` was stored with `{ executionOrder: 'v1' }` only and never appeared in n8n's instance-level MCP server. The update path (`updateSettings`, `n8n_update_full_workflow`) uses `z.any()` and forwarded the same keys correctly.

## Change

- `createWorkflowSchema.settings` gets `.passthrough()`: the eight typed keys are still validated (`executionOrder: 'v2'` is still rejected), every other key is forwarded. `cleanWorkflowForCreate` keeps stripping the derived properties (`binaryMode`, `credentialResolverId`).
- Tool input schema and tool docs for `n8n_create_workflow` and `updateSettings` mention `availableInMCP`.
- Two regression tests: extra settings keys reach `client.createWorkflow` unchanged; invalid typed values are still rejected.
- Version 2.74.1, CHANGELOG entry.

## Verification

- `npm run typecheck`, `npm run build`, `tests/unit/mcp/handlers-n8n-manager.test.ts` (147 tests), `parameter-validation`, `workflow-creation-node-type-format`, `n8n-validation` suites pass.
- Live against n8n 2.36.7: created a workflow through the built handler with `settings: { executionOrder: 'v1', availableInMCP: true, callerPolicy: 'workflowsFromSameOwner' }`; GET returned all three keys; workflow deleted afterwards.

## Unrelated CI fix, separate commit

`tests/integration/ai-validation/ai-agent-validation.test.ts` ("should validate memory connections") has failed on `main` since the n8n 2.36 update: the fixture built two memory nodes with the helper's default id `memory-1`, and n8n 2.36 rejects duplicate node ids. The second node now gets `memory-2`. Test-only change, no CHANGELOG entry.

Note on older instances: n8n's Public API rejects unknown settings keys (`additionalProperties: false`), so a key an older instance does not know now fails the create with n8n's own error instead of being dropped silently. That matches the update path, where the version-aware filter passes everything through because the instance version is not detectable since n8n 1.119.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5E2LQVUpMQDBDueBzieGp
