### PR TITLE
docs: clarify officialMcp.toolCount and refresh stale tool names in the setup guides

### DIFF
--- a/docs/ANTIGRAVITY_SETUP.md
+++ b/docs/ANTIGRAVITY_SETUP.md
@@ -130,10 +130,10 @@ ALWAYS explicitly configure ALL parameters that control node behavior.
    - Fix ALL issues before deployment
 
 8. **Deployment** (if n8n API configured)
-   - `n8n_create_workflow(workflow)` - Deploy
+   - `n8n_create_workflow({name, nodes, connections})` - Deploy
    - `n8n_validate_workflow({id})` - Post-deployment check
    - `n8n_update_partial_workflow({id, operations: [...]})` - Batch updates
-   - `n8n_test_workflow()` - Test/trigger the workflow (webhook, form, chat)
+   - `n8n_test_workflow({workflowId})` - Test/trigger the workflow (webhook, form, chat)
 
 ## Critical Warnings
 
@@ -201,8 +201,8 @@ Use `n8n_update_partial_workflow` with multiple operations in a single call:
 n8n_update_partial_workflow({
   id: "wf-123",
   operations: [
-    {type: "updateNode", nodeId: "slack-1", changes: {...}},
-    {type: "updateNode", nodeId: "http-1", changes: {...}},
+    {type: "updateNode", nodeId: "slack-1", updates: {...}},
+    {type: "updateNode", nodeId: "http-1", updates: {...}},
     {type: "cleanStaleConnections"}
   ]
 })
@@ -244,8 +244,8 @@ The `addConnection` operation requires **four separate string parameters**. Comm
   "type": "addConnection",
   "source": "node-id-string",
   "target": "target-node-id-string",
-  "sourcePort": "main",
-  "targetPort": "main"
+  "sourceOutput": "main",
+  "targetInput": "main"
 }
 ```
 
@@ -261,8 +261,8 @@ IF nodes have **two outputs** (TRUE and FALSE). Use the **`branch` parameter** t
   "type": "addConnection",
   "source": "if-node-id",
   "target": "success-handler-id",
-  "sourcePort": "main",
-  "targetPort": "main",
+  "sourceOutput": "main",
+  "targetInput": "main",
   "branch": "true"
 }
 ```
@@ -273,8 +273,8 @@ IF nodes have **two outputs** (TRUE and FALSE). Use the **`branch` parameter** t
   "type": "addConnection",
   "source": "if-node-id",
   "target": "failure-handler-id",
-  "sourcePort": "main",
-  "targetPort": "main",
+  "sourceOutput": "main",
+  "targetInput": "main",
   "branch": "false"
 }
 ```
@@ -284,8 +284,8 @@ IF nodes have **two outputs** (TRUE and FALSE). Use the **`branch` parameter** t
 n8n_update_partial_workflow({
   id: "workflow-id",
   operations: [
-    {type: "addConnection", source: "If Node", target: "True Handler", sourcePort: "main", targetPort: "main", branch: "true"},
-    {type: "addConnection", source: "If Node", target: "False Handler", sourcePort: "main", targetPort: "main", branch: "false"}
+    {type: "addConnection", source: "If Node", target: "True Handler", sourceOutput: "main", targetInput: "main", branch: "true"},
+    {type: "addConnection", source: "If Node", target: "False Handler", sourceOutput: "main", targetInput: "main", branch: "false"}
   ]
 })
 ```
@@ -300,8 +300,8 @@ Use the same four-parameter format:
   "type": "removeConnection",
   "source": "source-node-id",
   "target": "target-node-id",
-  "sourcePort": "main",
-  "targetPort": "main"
+  "sourceOutput": "main",
+  "targetInput": "main"
 }
 ```
 
@@ -369,8 +369,8 @@ Validation: ✅ Passed"
 n8n_update_partial_workflow({
   id: "wf-123",
   operations: [
-    {type: "updateNode", nodeId: "slack-1", changes: {position: [100, 200]}},
-    {type: "updateNode", nodeId: "http-1", changes: {position: [300, 200]}},
+    {type: "updateNode", nodeId: "slack-1", updates: {position: [100, 200]}},
+    {type: "updateNode", nodeId: "http-1", updates: {position: [300, 200]}},
     {type: "cleanStaleConnections"}
   ]
 })

--- a/docs/ANTIGRAVITY_SETUP.md
+++ b/docs/ANTIGRAVITY_SETUP.md
@@ -74,7 +74,7 @@ When operations are independent, execute them in parallel for maximum performanc
 ALWAYS check templates before building from scratch (2,709 available).
 
 ### 4. Multi-Level Validation
-Use validate_node(mode='minimal') → validate_node(mode='full') → validate_workflow pattern.
+Use validate_node({..., mode: 'minimal'}) → validate_node({..., mode: 'full'}) → validate_workflow({workflow}) pattern.
 
 ### 5. Never Trust Defaults
 ⚠️ CRITICAL: Default parameter values are the #1 source of runtime failures.
@@ -111,12 +111,12 @@ ALWAYS explicitly configure ALL parameters that control node behavior.
    - Show workflow architecture to user for approval before proceeding
 
 5. **Validation Phase** (parallel for multiple nodes)
-   - `validate_node({nodeType, config, mode: 'minimal'})` - Quick required fields check
-   - `validate_node({nodeType, config, mode: 'full', profile: 'runtime'})` - Full validation with fixes
+   - `validate_node({nodeType, config, mode: 'minimal'})` - Quick required fields check only
+   - `validate_node({nodeType, config, mode: 'full', profile: 'runtime'})` - Full validation (default mode) with errors/warnings/suggestions
    - Fix ALL errors before proceeding
 
 6. **Building Phase**
-   - If using template: `get_template(templateId, {mode: "full"})`
+   - If using template: `get_template({templateId, mode: 'full'})`
    - **MANDATORY ATTRIBUTION**: "Based on template by **[author.name]** (@[username]). View at: [url]"
    - Build from validated configurations
    - ⚠️ EXPLICITLY set ALL parameters - never rely on defaults
@@ -126,7 +126,7 @@ ALWAYS explicitly configure ALL parameters that control node behavior.
    - Build in artifact (unless deploying to n8n instance)
 
 7. **Workflow Validation** (before deployment)
-   - `validate_workflow(workflow)` - Complete validation: structure, connections, expressions, AI tools
+   - `validate_workflow({workflow})` - Complete validation: structure, connections, expressions, AI tools
    - Fix ALL issues before deployment
 
 8. **Deployment** (if n8n API configured)
@@ -158,10 +158,10 @@ Default values cause runtime failures. Example:
 `validate_node({nodeType, config, mode: 'minimal'})` - Required fields only (<100ms)
 
 ### Level 2 - Comprehensive (before building)
-`validate_node({nodeType, config, mode: 'full', profile: 'runtime'})` - Full validation with fixes
+`validate_node({nodeType, config, mode: 'full', profile: 'runtime'})` - Full validation (default mode) with fixes
 
 ### Level 3 - Complete (after building)
-`validate_workflow(workflow)` - Connections, expressions, AI tools
+`validate_workflow({workflow})` - Connections, expressions, AI tools
 
 ### Level 4 - Post-Deployment
 1. `n8n_validate_workflow({id})` - Validate deployed workflow
@@ -321,8 +321,8 @@ search_templates({
 search_templates({searchMode: 'by_task', task: 'slack_integration'})
 
 // STEP 2: Use template
-get_template(templateId, {mode: 'full'})
-validate_workflow(workflow)
+get_template({templateId, mode: 'full'})
+validate_workflow({workflow})
 
 // Response after all tools complete:
 "Found template by **David Ashby** (@cfomodz).
@@ -355,7 +355,7 @@ validate_node({nodeType: 'n8n-nodes-base.slack', config: fullConfig, mode: 'full
 
 // STEP 5: Validate
 [Silent execution]
-validate_workflow(workflowJson)
+validate_workflow({workflow: workflowJson})
 
 // Response after all tools complete:
 "Created workflow: Webhook → Slack

--- a/docs/ANTIGRAVITY_SETUP.md
+++ b/docs/ANTIGRAVITY_SETUP.md
@@ -158,7 +158,7 @@ Default values cause runtime failures. Example:
 `validate_node({nodeType, config, mode: 'minimal'})` - Required fields only (<100ms)
 
 ### Level 2 - Comprehensive (before building)
-`validate_node({nodeType, config, mode: 'full', profile: 'runtime'})` - Full validation (default mode) with fixes
+`validate_node({nodeType, config, mode: 'full', profile: 'runtime'})` - Full validation (default mode); returns errors, warnings and suggestions — it does not change the config
 
 ### Level 3 - Complete (after building)
 `validate_workflow({workflow})` - Connections, expressions, AI tools
@@ -294,14 +294,12 @@ n8n_update_partial_workflow({
 
 ### removeConnection Syntax
 
-Use the same four-parameter format:
+`removeConnection` takes the same fields; `sourceOutput` and `targetInput` are optional and default to `"main"`:
 ```json
 {
   "type": "removeConnection",
   "source": "source-node-id",
-  "target": "target-node-id",
-  "sourceOutput": "main",
-  "targetInput": "main"
+  "target": "target-node-id"
 }
 ```
 

--- a/docs/ANTIGRAVITY_SETUP.md
+++ b/docs/ANTIGRAVITY_SETUP.md
@@ -216,7 +216,7 @@ n8n_update_partial_workflow({id: "wf-123", operations: [{...}]})
 
 ###   CRITICAL: addConnection Syntax
 
-The `addConnection` operation takes `source` and `target` as **separate string parameters** (node names); `sourceOutput` and `targetInput` are optional and default to `"main"`. Common mistakes cause misleading errors.
+The `addConnection` operation takes `source` and `target` as **separate string parameters** (node names or node ids). `sourceOutput` is optional (default `"main"`); `targetInput` is optional and defaults to the value of `sourceOutput`, so AI connection types such as `ai_tool` match on both ends. Common mistakes cause misleading errors.
 
 ❌ WRONG - Object format (fails with "Expected string, received object"):
 ```json

--- a/docs/ANTIGRAVITY_SETUP.md
+++ b/docs/ANTIGRAVITY_SETUP.md
@@ -67,7 +67,7 @@ CRITICAL: Execute tools without commentary. Only respond AFTER all tools complet
 ### 2. Parallel Execution
 When operations are independent, execute them in parallel for maximum performance.
 
-✅ GOOD: Call search_nodes, list_nodes, and search_templates simultaneously
+✅ GOOD: Call search_nodes, get_node, and search_templates simultaneously
 ❌ BAD: Sequential tool calls (await each one before the next)
 
 ### 3. Templates First
@@ -126,16 +126,14 @@ ALWAYS explicitly configure ALL parameters that control node behavior.
    - Build in artifact (unless deploying to n8n instance)
 
 7. **Workflow Validation** (before deployment)
-   - `validate_workflow(workflow)` - Complete validation
-   - `validate_workflow_connections(workflow)` - Structure check
-   - `validate_workflow_expressions(workflow)` - Expression validation
+   - `validate_workflow(workflow)` - Complete validation: structure, connections, expressions, AI tools
    - Fix ALL issues before deployment
 
 8. **Deployment** (if n8n API configured)
    - `n8n_create_workflow(workflow)` - Deploy
    - `n8n_validate_workflow({id})` - Post-deployment check
    - `n8n_update_partial_workflow({id, operations: [...]})` - Batch updates
-   - `n8n_trigger_webhook_workflow()` - Test webhooks
+   - `n8n_test_workflow()` - Test/trigger the workflow (webhook, form, chat)
 
 ## Critical Warnings
 

--- a/docs/ANTIGRAVITY_SETUP.md
+++ b/docs/ANTIGRAVITY_SETUP.md
@@ -67,7 +67,7 @@ CRITICAL: Execute tools without commentary. Only respond AFTER all tools complet
 ### 2. Parallel Execution
 When operations are independent, execute them in parallel for maximum performance.
 
-✅ GOOD: Call search_nodes, get_node, and search_templates simultaneously
+✅ GOOD: Call search_nodes and search_templates simultaneously, then get_node for the node types you found (get_node needs a concrete nodeType)
 ❌ BAD: Sequential tool calls (await each one before the next)
 
 ### 3. Templates First

--- a/docs/ANTIGRAVITY_SETUP.md
+++ b/docs/ANTIGRAVITY_SETUP.md
@@ -294,7 +294,7 @@ n8n_update_partial_workflow({
 
 ### removeConnection Syntax
 
-`removeConnection` takes the same fields; `sourceOutput` and `targetInput` are optional and default to `"main"`:
+`removeConnection` takes `source` and `target`; `sourceOutput` is optional (default `"main"`) and selects which output's connections to the target are removed; `targetInput` is not used by this operation:
 ```json
 {
   "type": "removeConnection",

--- a/docs/ANTIGRAVITY_SETUP.md
+++ b/docs/ANTIGRAVITY_SETUP.md
@@ -216,7 +216,7 @@ n8n_update_partial_workflow({id: "wf-123", operations: [{...}]})
 
 ###   CRITICAL: addConnection Syntax
 
-The `addConnection` operation requires **four separate string parameters**. Common mistakes cause misleading errors.
+The `addConnection` operation takes `source` and `target` as **separate string parameters** (node names); `sourceOutput` and `targetInput` are optional and default to `"main"`. Common mistakes cause misleading errors.
 
 ❌ WRONG - Object format (fails with "Expected string, received object"):
 ```json

--- a/docs/OFFICIAL_MCP_SETUP.md
+++ b/docs/OFFICIAL_MCP_SETUP.md
@@ -136,7 +136,10 @@ Run `n8n_health_check` - the response includes an `officialMcp` block:
 
 - `officialMcp.configured` - `true` once `N8N_MCP_ACCESS_TOKEN` is set.
 - `officialMcp.reachable` - whether the last check reached n8n's MCP server.
-- `officialMcp.toolCount` - how many tools n8n's MCP server reported.
+- `officialMcp.toolCount` - how many tools n8n's own MCP server advertises. This is
+  n8n's list, not n8n-mcp's: it depends on the n8n version and the modules enabled
+  on the instance (for example, 54 on n8n 2.36 with the agents module, 39 without
+  it). n8n-mcp uses that list to decide which official tools it can route to.
 - `officialMcp.agentTools` - whether the agents module's tools are present (needs
   n8n 2.34+ with the agents module).
 

--- a/docs/README_CLAUDE_SETUP.md
+++ b/docs/README_CLAUDE_SETUP.md
@@ -120,7 +120,7 @@ After restarting Claude Desktop:
 ### Documentation & Validation Tools (offline, always available)
 - **`search_nodes`** - Search n8n nodes by keyword, with optional real-world configuration examples
 - **`get_node`** - Get node info with progressive detail levels (`detail`: `minimal`, `standard`, `full`) and modes (schema info, docs, property search, version comparison)
-- **`validate_node`** - Validate a node configuration against a profile (`minimal`, `runtime`, `ai-friendly`, `strict`)
+- **`validate_node`** - Validate a node configuration. `mode: 'minimal'` checks required fields only; `mode: 'full'` (default) runs full validation against a `profile` (`minimal`, `runtime`, `ai-friendly` (default), `strict`)
 - **`validate_workflow`** - Full workflow validation: structure, connections, expressions, AI tool connections
 - **`search_templates`** - Search workflow templates by keyword, by node type, by task, or by metadata
 - **`get_template`** - Get a complete workflow JSON by template ID, ready to import

--- a/docs/README_CLAUDE_SETUP.md
+++ b/docs/README_CLAUDE_SETUP.md
@@ -110,46 +110,28 @@ After restarting Claude Desktop:
 
 1. Look for "n8n-docker" or "n8n-documentation" in the MCP servers list
 2. Try asking Claude: "What n8n nodes are available for working with Slack?"
-3. Or use a tool directly: "Use the list_nodes tool to show me trigger nodes"
+3. Or use a tool directly: "Use the search_nodes tool to show me trigger nodes"
 
-## 🔧 Available Tools (v2.5.1)
+## 🔧 Available Tools
 
 ### Essential Tool - Start Here!
 - **`tools_documentation`** - Get documentation for any MCP tool (ALWAYS use this first!)
 
-### Core Tools
-- **`list_nodes`** - List all n8n nodes with filtering options
-- **`get_node_info`** - Get comprehensive information (now includes aiToolCapabilities)
-- **`get_node_essentials`** - Get only 10-20 essential properties (95% smaller!)
-- **`search_nodes`** - Full-text search across all node documentation
-- **`search_node_properties`** - Find specific properties within nodes
-- **`get_node_documentation`** - Get parsed documentation from n8n-docs
-- **`get_database_statistics`** - View database metrics and coverage
+### Documentation & Validation Tools (offline, always available)
+- **`search_nodes`** - Search n8n nodes by keyword, with optional real-world configuration examples
+- **`get_node`** - Get node info with progressive detail levels (`detail`: `minimal`, `standard`, `full`) and modes (schema info, docs, property search, version comparison)
+- **`validate_node`** - Validate a node configuration against a profile (`minimal`, `runtime`, `ai-friendly`, `strict`)
+- **`validate_workflow`** - Full workflow validation: structure, connections, expressions, AI tool connections
+- **`search_templates`** - Search workflow templates by keyword, by node type, by task, or by metadata
+- **`get_template`** - Get a complete workflow JSON by template ID, ready to import
 
-### AI Tools (Enhanced in v2.5.1)
-- **`list_ai_tools`** - List AI-capable nodes (ANY node can be used as AI tool!)
-- **`get_node_as_tool_info`** - Get guidance on using any node as an AI tool
-
-### Task & Template Tools
-- **`get_node_for_task`** - Pre-configured node settings for common tasks
-- **`list_tasks`** - Discover available task templates
-- **`list_node_templates`** - Find workflow templates using specific nodes
-- **`get_template`** - Get complete workflow JSON for import
-- **`search_templates`** - Search templates by keywords
-- **`get_templates_for_task`** - Get curated templates for common tasks
-
-### Validation Tools (Professional Grade)
-- **`validate_node_operation`** - Smart validation with operation awareness
-- **`validate_node_minimal`** - Quick validation for just required fields
-- **`validate_workflow`** - Complete workflow validation (validates AI tool connections)
-- **`validate_workflow_connections`** - Check workflow structure
-- **`validate_workflow_expressions`** - Validate n8n expressions including $fromAI()
-- **`get_property_dependencies`** - Analyze property visibility conditions
+### Management Tools (`n8n_*`, require n8n API configuration)
+See the [n8n Management Tools table](../README.md#n8n-management-tools-21-tools---requires-api-configuration) in the main README for the full list of 21 tools covering workflow CRUD, executions, folders, data tables, credentials, and instance auditing.
 
 ### Example Questions to Ask Claude:
 - "Show me all n8n nodes for working with databases"
 - "How do I use the HTTP Request node?"
-- "Get the essentials for Slack node" (uses get_node_essentials)
+- "Get the essential properties for the Slack node" (uses get_node with detail='standard')
 - "How can I use Google Sheets as an AI tool?"
 - "Validate my workflow before deployment"
 - "Find templates for webhook automation"

--- a/docs/VS_CODE_PROJECT_SETUP.md
+++ b/docs/VS_CODE_PROJECT_SETUP.md
@@ -90,10 +90,10 @@ You are an expert in n8n automation software using n8n-MCP tools. Your role is t
    - Fix any issues found before deployment
 
 7. **Deployment Phase** (if n8n API configured):
-   - `n8n_create_workflow(workflow)` - Deploy validated workflow
+   - `n8n_create_workflow({name, nodes, connections})` - Deploy validated workflow
    - `n8n_validate_workflow({id: 'workflow-id'})` - Post-deployment validation
-   - `n8n_update_partial_workflow()` - Make incremental updates using diffs
-   - `n8n_test_workflow()` - Test/trigger the workflow (webhook, form, chat)
+   - `n8n_update_partial_workflow({id, operations: [...]})` - Make incremental updates using diffs
+   - `n8n_test_workflow({workflowId})` - Test/trigger the workflow (webhook, form, chat)
 
 ## Key Insights
 
@@ -119,7 +119,7 @@ You are an expert in n8n automation software using n8n-MCP tools. Your role is t
 ### After Deployment:
 1. n8n_validate_workflow({id}) - Validate deployed workflow
 2. n8n_executions({action: 'list'}) - Monitor execution status
-3. n8n_update_partial_workflow() - Fix issues using diffs
+3. n8n_update_partial_workflow({id, operations: [...]}) - Fix issues using diffs
 
 ## Response Structure
 
@@ -148,12 +148,12 @@ validate_node({nodeType: 'n8n-nodes-base.slack', config: fullConfig, mode: 'full
 validate_workflow({workflow: workflowJson})
 
 ### 5. Deploy (if configured)
-n8n_create_workflow(validatedWorkflow)
+n8n_create_workflow({name: 'My Workflow', nodes: validatedWorkflow.nodes, connections: validatedWorkflow.connections})
 n8n_validate_workflow({id: createdWorkflowId})
 
 ### 6. Update Using Diffs
 n8n_update_partial_workflow({
-  workflowId: id,
+  id: createdWorkflowId,
   operations: [
     {type: 'updateNode', nodeId: 'slack1', updates: {position: [100, 200]}}
   ]

--- a/docs/VS_CODE_PROJECT_SETUP.md
+++ b/docs/VS_CODE_PROJECT_SETUP.md
@@ -64,19 +64,18 @@ You are an expert in n8n automation software using n8n-MCP tools. Your role is t
 2. **Discovery Phase** - Find the right nodes:
    - Think deeply about user request and the logic you are going to build to fulfill it. Ask follow-up questions to clarify the user's intent, if something is unclear. Then, proceed with the rest of your instructions.
    - `search_nodes({query: 'keyword'})` - Search by functionality
-   - `list_nodes({category: 'trigger'})` - Browse by category
-   - `list_ai_tools()` - See AI-capable nodes (remember: ANY node can be an AI tool!)
+   - `search_nodes({query: 'trigger'})` - Browse triggers
+   - `search_nodes({query: 'AI agent langchain'})` - Find AI-capable nodes (remember: ANY node can be an AI tool!)
 
 3. **Configuration Phase** - Get node details efficiently:
-   - `get_node_essentials(nodeType)` - Start here! Only 10-20 essential properties
-   - `search_node_properties(nodeType, 'auth')` - Find specific properties
-   - `get_node_for_task('send_email')` - Get pre-configured templates
-   - `get_node_documentation(nodeType)` - Human-readable docs when needed
+   - `get_node(nodeType, {detail: 'standard'})` - Start here! Only the essential properties
+   - `get_node(nodeType, {mode: 'search_properties', propertyQuery: 'auth'})` - Find specific properties
+   - `get_node(nodeType, {mode: 'docs'})` - Human-readable docs when needed
    - It is good common practice to show a visual representation of the workflow architecture to the user and asking for opinion, before moving forward. 
 
 4. **Pre-Validation Phase** - Validate BEFORE building:
-   - `validate_node_minimal(nodeType, config)` - Quick required fields check
-   - `validate_node_operation(nodeType, config, profile)` - Full operation-aware validation
+   - `validate_node(nodeType, config, {mode: 'minimal'})` - Quick required fields check
+   - `validate_node(nodeType, config, {mode: 'full', profile: 'runtime'})` - Full validation with errors/warnings/suggestions
    - Fix any validation errors before proceeding
 
 5. **Building Phase** - Create the workflow:
@@ -87,16 +86,14 @@ You are an expert in n8n automation software using n8n-MCP tools. Your role is t
    - Build the workflow in an artifact for easy editing downstream (unless the user asked to create in n8n instance)
 
 6. **Workflow Validation Phase** - Validate complete workflow:
-   - `validate_workflow(workflow)` - Complete validation including connections
-   - `validate_workflow_connections(workflow)` - Check structure and AI tool connections
-   - `validate_workflow_expressions(workflow)` - Validate all n8n expressions
+   - `validate_workflow(workflow)` - Complete validation including structure, connections, expressions, and AI tools
    - Fix any issues found before deployment
 
 7. **Deployment Phase** (if n8n API configured):
    - `n8n_create_workflow(workflow)` - Deploy validated workflow
    - `n8n_validate_workflow({id: 'workflow-id'})` - Post-deployment validation
    - `n8n_update_partial_workflow()` - Make incremental updates using diffs
-   - `n8n_trigger_webhook_workflow()` - Test webhook workflows
+   - `n8n_test_workflow()` - Test/trigger the workflow (webhook, form, chat)
 
 ## Key Insights
 
@@ -104,7 +101,7 @@ You are an expert in n8n automation software using n8n-MCP tools. Your role is t
 - **VALIDATE EARLY AND OFTEN** - Catch errors before they reach deployment
 - **USE DIFF UPDATES** - Use n8n_update_partial_workflow for 80-90% token savings
 - **ANY node can be an AI tool** - not just those with usableAsTool=true
-- **Pre-validate configurations** - Use validate_node_minimal before building
+- **Pre-validate configurations** - Use validate_node with mode='minimal' before building
 - **Post-validate workflows** - Always validate complete workflows before deployment
 - **Incremental updates** - Use diff operations for existing workflows
 - **Test thoroughly** - Validate both locally and after deployment to n8n
@@ -112,18 +109,16 @@ You are an expert in n8n automation software using n8n-MCP tools. Your role is t
 ## Validation Strategy
 
 ### Before Building:
-1. validate_node_minimal() - Check required fields
-2. validate_node_operation() - Full configuration validation
+1. validate_node(nodeType, config, {mode: 'minimal'}) - Check required fields
+2. validate_node(nodeType, config, {mode: 'full', profile: 'runtime'}) - Full configuration validation
 3. Fix all errors before proceeding
 
 ### After Building:
-1. validate_workflow() - Complete workflow validation
-2. validate_workflow_connections() - Structure validation
-3. validate_workflow_expressions() - Expression syntax check
+1. validate_workflow(workflow) - Complete workflow validation (structure, connections, expressions)
 
 ### After Deployment:
 1. n8n_validate_workflow({id}) - Validate deployed workflow
-2. n8n_list_executions() - Monitor execution status
+2. n8n_executions({action: 'list'}) - Monitor execution status
 3. n8n_update_partial_workflow() - Fix issues using diffs
 
 ## Response Structure
@@ -140,19 +135,17 @@ You are an expert in n8n automation software using n8n-MCP tools. Your role is t
 
 ### 1. Discovery & Configuration
 search_nodes({query: 'slack'})
-get_node_essentials('n8n-nodes-base.slack')
+get_node('n8n-nodes-base.slack', {detail: 'standard'})
 
 ### 2. Pre-Validation
-validate_node_minimal('n8n-nodes-base.slack', {resource:'message', operation:'send'})
-validate_node_operation('n8n-nodes-base.slack', fullConfig, 'runtime')
+validate_node('n8n-nodes-base.slack', {resource:'message', operation:'send'}, {mode: 'minimal'})
+validate_node('n8n-nodes-base.slack', fullConfig, {mode: 'full', profile: 'runtime'})
 
 ### 3. Build Workflow
 // Create workflow JSON with validated configs
 
 ### 4. Workflow Validation
 validate_workflow(workflowJson)
-validate_workflow_connections(workflowJson)
-validate_workflow_expressions(workflowJson)
 
 ### 5. Deploy (if configured)
 n8n_create_workflow(validatedWorkflow)

--- a/docs/VS_CODE_PROJECT_SETUP.md
+++ b/docs/VS_CODE_PROJECT_SETUP.md
@@ -68,14 +68,14 @@ You are an expert in n8n automation software using n8n-MCP tools. Your role is t
    - `search_nodes({query: 'AI agent langchain'})` - Find AI-capable nodes (remember: ANY node can be an AI tool!)
 
 3. **Configuration Phase** - Get node details efficiently:
-   - `get_node(nodeType, {detail: 'standard'})` - Start here! Only the essential properties
-   - `get_node(nodeType, {mode: 'search_properties', propertyQuery: 'auth'})` - Find specific properties
-   - `get_node(nodeType, {mode: 'docs'})` - Human-readable docs when needed
+   - `get_node({nodeType, detail: 'standard'})` - Start here! Only the essential properties
+   - `get_node({nodeType, mode: 'search_properties', propertyQuery: 'auth'})` - Find specific properties
+   - `get_node({nodeType, mode: 'docs'})` - Human-readable docs when needed
    - It is good common practice to show a visual representation of the workflow architecture to the user and asking for opinion, before moving forward. 
 
 4. **Pre-Validation Phase** - Validate BEFORE building:
-   - `validate_node(nodeType, config, {mode: 'minimal'})` - Quick required fields check
-   - `validate_node(nodeType, config, {mode: 'full', profile: 'runtime'})` - Full validation with errors/warnings/suggestions
+   - `validate_node({nodeType, config, mode: 'minimal'})` - Quick required fields check only (checks required fields are present)
+   - `validate_node({nodeType, config, mode: 'full', profile: 'runtime'})` - Full validation (default mode) with errors/warnings/suggestions; profile options are `minimal`, `runtime`, `ai-friendly` (default), `strict`
    - Fix any validation errors before proceeding
 
 5. **Building Phase** - Create the workflow:
@@ -86,7 +86,7 @@ You are an expert in n8n automation software using n8n-MCP tools. Your role is t
    - Build the workflow in an artifact for easy editing downstream (unless the user asked to create in n8n instance)
 
 6. **Workflow Validation Phase** - Validate complete workflow:
-   - `validate_workflow(workflow)` - Complete validation including structure, connections, expressions, and AI tools
+   - `validate_workflow({workflow})` - Complete validation including structure, connections, expressions, and AI tools
    - Fix any issues found before deployment
 
 7. **Deployment Phase** (if n8n API configured):
@@ -109,12 +109,12 @@ You are an expert in n8n automation software using n8n-MCP tools. Your role is t
 ## Validation Strategy
 
 ### Before Building:
-1. validate_node(nodeType, config, {mode: 'minimal'}) - Check required fields
-2. validate_node(nodeType, config, {mode: 'full', profile: 'runtime'}) - Full configuration validation
+1. validate_node({nodeType, config, mode: 'minimal'}) - Check required fields only
+2. validate_node({nodeType, config, mode: 'full', profile: 'runtime'}) - Full configuration validation (default mode)
 3. Fix all errors before proceeding
 
 ### After Building:
-1. validate_workflow(workflow) - Complete workflow validation (structure, connections, expressions)
+1. validate_workflow({workflow}) - Complete workflow validation (structure, connections, expressions)
 
 ### After Deployment:
 1. n8n_validate_workflow({id}) - Validate deployed workflow
@@ -135,17 +135,17 @@ You are an expert in n8n automation software using n8n-MCP tools. Your role is t
 
 ### 1. Discovery & Configuration
 search_nodes({query: 'slack'})
-get_node('n8n-nodes-base.slack', {detail: 'standard'})
+get_node({nodeType: 'n8n-nodes-base.slack', detail: 'standard'})
 
 ### 2. Pre-Validation
-validate_node('n8n-nodes-base.slack', {resource:'message', operation:'send'}, {mode: 'minimal'})
-validate_node('n8n-nodes-base.slack', fullConfig, {mode: 'full', profile: 'runtime'})
+validate_node({nodeType: 'n8n-nodes-base.slack', config: {resource:'message', operation:'send'}, mode: 'minimal'})
+validate_node({nodeType: 'n8n-nodes-base.slack', config: fullConfig, mode: 'full', profile: 'runtime'})
 
 ### 3. Build Workflow
 // Create workflow JSON with validated configs
 
 ### 4. Workflow Validation
-validate_workflow(workflowJson)
+validate_workflow({workflow: workflowJson})
 
 ### 5. Deploy (if configured)
 n8n_create_workflow(validatedWorkflow)


### PR DESCRIPTION
Documentation follow-ups after #1028.

- `docs/OFFICIAL_MCP_SETUP.md`: `officialMcp.toolCount` is n8n's own tool list (depends on the n8n version and enabled modules — 54 on 2.36 with the agents module, 39 without), not n8n-mcp's; n8n-mcp uses that list to decide which official tools it can route to.
- `docs/README_CLAUDE_SETUP.md`, `docs/VS_CODE_PROJECT_SETUP.md`, `docs/ANTIGRAVITY_SETUP.md`: the tool lists and examples still named v2.5-era tools (`list_nodes`, `get_node_info`, `get_node_essentials`, `validate_node_minimal`, …). Replaced with the current documentation tools (`search_nodes`, `get_node` with `detail`, `validate_node` with a profile, `validate_workflow`, templates, `tools_documentation`) and a pointer to the README table for the management tools.

Docs only; no code or version change.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5E2LQVUpMQDBDueBzieGp
