### PR TITLE
fix: re-export probeOfficialMcp from the package root (v2.75.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.75.1] - 2026-08-28
+
+### Fixed
+
+- `probeOfficialMcp` (and the `OfficialMcpCapabilities` / `OfficialMcpErrorCode` types) are now re-exported from the package root. They were exported from `mcp-engine` only, but the package's `exports` map publishes just `.`, so `import { probeOfficialMcp } from 'n8n-mcp'` failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` and embedders had to resolve the compiled file by path.
+
 ## [2.75.0] - 2026-08-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.75.0",
+  "version": "2.75.1",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.75.0",
+  "version": "2.75.1",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@
 
 // Engine exports for service integration
 export { N8NMCPEngine, EngineHealth, EngineOptions } from './mcp-engine';
+// Probe n8n's instance-level MCP server (same codes as n8n_health_check's officialMcp block);
+// the package's exports map publishes only ".", so embedders need it re-exported here.
+export { probeOfficialMcp } from './services/n8n-official-mcp-client';
+export type { OfficialMcpCapabilities, OfficialMcpErrorCode } from './services/n8n-official-mcp-client';
 export { SingleSessionHTTPServer } from './http-server-single-session';
 export { ConsoleManager } from './utils/console-manager';
 export { N8NDocumentationMCPServer } from './mcp/server';

--- a/tests/unit/package-root-exports.test.ts
+++ b/tests/unit/package-root-exports.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import * as root from '@/index';
+
+describe('package root exports', () => {
+  it('re-exports the official MCP probe for embedders', () => {
+    expect(typeof root.probeOfficialMcp).toBe('function');
+    expect(typeof root.N8NMCPEngine).toBe('function');
+  });
+});


### PR DESCRIPTION
`probeOfficialMcp` was exported from `mcp-engine` only, but the package's `exports` map publishes just `.`, so `import { probeOfficialMcp } from 'n8n-mcp'` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` and embedders have to `require.resolve` the compiled file by path.

This re-exports `probeOfficialMcp` and the `OfficialMcpCapabilities` / `OfficialMcpErrorCode` types from `src/index.ts`, adds a root-export test, and bumps the version to 2.75.1.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5E2LQVUpMQDBDueBzieGp
