### PR TITLE
fix: strip settings.engineType so workflow updates survive n8n >= 2.36.0 (v2.76.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `npm run check:settings-drift` now also diffs n8n's workflow entity settings (`IWorkflowSettings` from the installed `n8n-workflow` package) against the Public API schema. A property n8n persists but the write schema rejects — the exact shape of #1043, invisible to the schema-only check — now fails the n8n dependency update until it is marked as stripped.
 
+## [2.76.0] - 2026-08-28
+
 ### Added
 
 - **`n8n_test_workflow` can run workflows that have no webhook, form or chat trigger**, through n8n's instance-level MCP server (`N8N_MCP_ACCESS_TOKEN`, n8n 2.34+). The new `method` parameter selects the path: `auto` (default) and `trigger` keep the existing HTTP behaviour, `prepare` lists the nodes that need pinned data, `pinned` runs the workflow with a `pinData` map you build from that list, and `direct` starts a run with optional inputs. Supporting parameters: `pinData`, `triggerNodeName`, `executionMode` (`manual` default, `production` only when passed), `timeoutMs` and `exposeToMcp`. Successful and routed responses state `method` and `backend`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.76.0] - 2026-08-28
+## [2.76.1] - 2026-08-31
+
+### Fixed
+
+- **Workflow updates no longer fail with `settings must NOT have additional properties` against n8n ≥ 2.36.0** ([#1043](https://github.com/czlonkowski/n8n-mcp/issues/1043)). n8n 2.36.0 added `engineType` to the workflow's persisted settings without adding it to the Public API write schema, so `n8n_update_partial_workflow` and `n8n_update_full_workflow` — which read the workflow, apply the change and write it back — echoed the property into a `PUT` the schema rejects. `engineType` is now stripped from every create and update payload, like `binaryMode` and `credentialResolverId` before it. Stripping does not change the setting on the instance: n8n keeps stored settings for keys the request omits.
+
+### Changed
+
+- `npm run check:settings-drift` now also diffs n8n's workflow entity settings (`IWorkflowSettings` from the installed `n8n-workflow` package) against the Public API schema. A property n8n persists but the write schema rejects — the exact shape of #1043, invisible to the schema-only check — now fails the n8n dependency update until it is marked as stripped.
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.76.0",
+  "version": "2.76.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.76.0",
+      "version": "2.76.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.76.0",
+  "version": "2.76.1",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.76.0",
+  "version": "2.76.1",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/scripts/check-settings-drift.ts
+++ b/scripts/check-settings-drift.ts
@@ -261,6 +261,15 @@ async function resolveSchemaRelease(
   return nodesBaseMatch ?? { version: nodesBase, pins: await fetchReleasePins(nodesBase) };
 }
 
+/** The version actually installed, which a stale node_modules can hold apart from the pin. */
+function installedNodesBaseVersion(): string | null {
+  try {
+    return (require('n8n-nodes-base/package.json') as { version?: string }).version ?? null;
+  } catch {
+    return null;
+  }
+}
+
 function installedEntityPackageVersion(): string | null {
   try {
     const pkgPath = join(dirname(require.resolve('n8n-workflow')), '..', '..', 'package.json');
@@ -372,9 +381,15 @@ async function main(): Promise<void> {
   let entityProperties: Set<string> | null = null;
   let releasePins: ReleasePins | null = null;
   const installedEntity = explicitVersion ? null : installedEntityPackageVersion();
+  const installedNodesBase = explicitVersion ? null : installedNodesBaseVersion();
   if (!explicitVersion) {
     entityProperties = parseEntitySettingsProperties(readEntityDeclarations());
-    ({ version, pins: releasePins } = await resolveSchemaRelease(version, installedEntity));
+    // Match on what is installed, not what is declared - a stale node_modules would otherwise
+    // pair this run's entity types with a schema neither of them belongs to.
+    ({ version, pins: releasePins } = await resolveSchemaRelease(
+      installedNodesBase ?? version,
+      installedEntity
+    ));
   }
 
   console.log(`🔍 Checking workflow settings against n8n ${version}\n`);
@@ -386,9 +401,10 @@ async function main(): Promise<void> {
     // n8n-workflow while shipping a different n8n-nodes-base (and so a different schema).
     // The axis still runs: it can only fail loudly (a human investigates at update time),
     // never silently pass what a matching set would fail.
-    const installedNodesBase = resolveVersion();
     const skews: string[] = [];
-    if (releasePins && releasePins.nodesBase !== installedNodesBase) {
+    if (!installedNodesBase) {
+      skews.push('installed n8n-nodes-base version could not be read');
+    } else if (releasePins && releasePins.nodesBase !== installedNodesBase) {
       skews.push(`n8n-nodes-base ${installedNodesBase} vs pin ${releasePins.nodesBase}`);
     }
     if (releasePins && installedEntity && releasePins.workflow !== installedEntity) {

--- a/scripts/check-settings-drift.ts
+++ b/scripts/check-settings-drift.ts
@@ -13,6 +13,8 @@
  *   npx tsx scripts/check-settings-drift.ts 2.34.4     # explicit n8n version
  */
 
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 import {
   WORKFLOW_SETTINGS_PROPERTIES,
   type SettingsVersion,
@@ -20,6 +22,7 @@ import {
 
 const SCHEMA_PATH = 'dist/public-api/v1/openapi.yml';
 const SCHEMA_NAME = 'workflowSettings';
+const ENTITY_INTERFACE = 'IWorkflowSettings';
 
 function resolveVersion(): string {
   const fromArgs = process.argv[2];
@@ -115,35 +118,192 @@ export function parseSchemaProperties(yaml: string): Set<string> {
   return names;
 }
 
-async function main(): Promise<void> {
-  const version = resolveVersion();
-  console.log(`🔍 Checking workflow settings against n8n ${version}\n`);
+/**
+ * Pull the property names out of n8n-workflow's `IWorkflowSettings` declaration - the workflow
+ * entity's settings type, which the Public API schema is supposed to mirror but has trailed
+ * (engineType, issue #1043). Same philosophy as the schema parser: anything this cannot find
+ * throws, because an empty result would read as "no entity-only properties".
+ */
+export function parseEntitySettingsProperties(dts: string): Set<string> {
+  const lines = dts.split('\n');
+  // Anchored at line start (allowing export/declare) so comment lines mentioning the name
+  // don't count as declarations.
+  const declaration = new RegExp(
+    `^\\s*(?:export\\s+)?(?:declare\\s+)?interface ${ENTITY_INTERFACE}\\b`
+  );
+  const declarationIndices = lines.flatMap((line, i) => (declaration.test(line) ? [i] : []));
+  if (declarationIndices.length === 0) {
+    throw new Error(
+      `No "${ENTITY_INTERFACE}" interface in n8n-workflow's declarations. ` +
+        'n8n may have renamed or moved it - check the package.'
+    );
+  }
+  // These two shapes would parse cleanly but return a silently incomplete set, which reads as
+  // "no entity-only properties" - the one failure mode this check must never have.
+  if (declarationIndices.length > 1) {
+    throw new Error(
+      `"${ENTITY_INTERFACE}" is declared ${declarationIndices.length} times - declaration ` +
+        'merging would hide properties from this parser. Teach it to merge the declarations.'
+    );
+  }
+  const startIndex = declarationIndices[0];
+  let header = '';
+  for (let i = startIndex; i < lines.length; i++) {
+    header += lines[i];
+    if (lines[i].includes('{')) break;
+  }
+  if (/\bextends\b/.test(header)) {
+    throw new Error(
+      `"${ENTITY_INTERFACE}" extends a base type - inherited properties would be missed. ` +
+        'Teach this parser about heritage clauses.'
+    );
+  }
 
-  const schemaProperties = parseSchemaProperties(await fetchSchemaFile(version));
+  const names = new Set<string>();
+  let depth = 0;
+  for (let i = startIndex; i < lines.length; i++) {
+    const line = lines[i];
+    // Depth 1 is the interface body; nested object types sit deeper and their keys are not
+    // settings properties. The check runs before this line's braces are counted, so a
+    // `foo?: {` line still registers foo while its members do not.
+    if (depth === 1) {
+      const match = line.trim().match(/^(?:readonly\s+)?([A-Za-z][A-Za-z0-9_]*)\??:/);
+      if (match) names.add(match[1]);
+    }
+    for (const char of line) {
+      if (char === '{') depth++;
+      else if (char === '}') depth--;
+    }
+    if (depth === 0 && i > startIndex) break;
+  }
+
+  if (names.size === 0) {
+    throw new Error(
+      `Parsed zero properties from "${ENTITY_INTERFACE}" - the declaration format changed`
+    );
+  }
+  return names;
+}
+
+function readEntityDeclarations(): string {
+  // Resolve from the installed n8n-workflow package (same release train as n8n and
+  // n8n-nodes-base) so hoisting and store layouts don't matter.
+  const dtsPath = join(dirname(require.resolve('n8n-workflow')), 'interfaces.d.ts');
+  try {
+    return readFileSync(dtsPath, 'utf8');
+  } catch (error) {
+    throw new Error(
+      `Could not read ${dtsPath} (${error instanceof Error ? error.message : error}). ` +
+        'If n8n-workflow moved its type declarations, update readEntityDeclarations in this script.'
+    );
+  }
+}
+
+export interface SettingsDrift {
+  /** In the schema, unknown to our table - a new setting we would silently drop. */
+  missing: string[];
+  /** In our table, gone from n8n entirely - stale entries to prune. */
+  removed: string[];
+  /** In our table from a later n8n than the target - expected while the pin trails. */
+  ahead: string[];
+  /** Derived properties confirmed (or assumed, without an entity set) as entity-only. */
+  entityOnly: string[];
+  /** On the entity, rejected by the write schema, and not marked derived - the #1043 shape. */
+  unhandledEntityOnly: string[];
+  /** Marked entityOnly in our table but now published in the schema - stripping is a choice again. */
+  publishedEntityOnly: string[];
+}
+
+/**
+ * Classify every property of the three sources. Pure so the gate itself is testable;
+ * `entityProperties` is null when the entity axis cannot run (see main).
+ */
+export function diffSettingsProperties(
+  schemaProperties: Set<string>,
+  entityProperties: Set<string> | null,
+  target: SettingsVersion
+): SettingsDrift {
   const ours = new Set(Object.keys(WORKFLOW_SETTINGS_PROPERTIES));
 
   const missing = [...schemaProperties].filter(name => !ours.has(name));
 
+  // The entity-vs-schema axis: a property n8n persists on the workflow entity but leaves out of
+  // the write schema comes back on GET and, echoed into a read-modify-write PUT, rejects the
+  // whole request (additionalProperties: false). Such a property must be marked derived so every
+  // write strips it. engineType (issue #1043) shipped exactly this way, and the schema-only diff
+  // stayed green because the property was absent from both sides of it.
+  const unhandledEntityOnly = entityProperties
+    ? [...entityProperties].filter(
+        name => !schemaProperties.has(name) && WORKFLOW_SETTINGS_PROPERTIES[name]?.derived !== true
+      )
+    : [];
+
+  // The reverse transition: n8n published a property we strip because its schema used to reject
+  // it. Stripping is no longer the only correct behaviour - callers might want to set it - so
+  // the flag has to be reconsidered rather than silently kept.
+  const publishedEntityOnly = [...schemaProperties].filter(
+    name => WORKFLOW_SETTINGS_PROPERTIES[name]?.entityOnly === true
+  );
+
   // A property we know but this version lacks is only drift when we claim it already existed:
   // one introduced in a later release is simply ahead of the pin, which is expected while the
-  // pinned version trails n8n's newest.
-  const target = parseVersion(version);
+  // pinned version trails n8n's newest. A derived property still on the entity is expected too -
+  // it is stripped from every write, so the schema not naming it cannot break anything.
   const removed: string[] = [];
   const ahead: string[] = [];
+  const entityOnly: string[] = [];
   for (const name of ours) {
     if (schemaProperties.has(name)) continue;
-    const introduced = WORKFLOW_SETTINGS_PROPERTIES[name].since;
-    (compareVersions(introduced, target) <= 0 ? removed : ahead).push(name);
+    const meta = WORKFLOW_SETTINGS_PROPERTIES[name];
+    if (meta.derived && (entityProperties === null || entityProperties.has(name))) {
+      entityOnly.push(name);
+      continue;
+    }
+    (compareVersions(meta.since, target) <= 0 ? removed : ahead).push(name);
   }
 
+  return { missing, removed, ahead, entityOnly, unhandledEntityOnly, publishedEntityOnly };
+}
+
+async function main(): Promise<void> {
+  const explicitVersion = process.argv[2];
+  const version = resolveVersion();
+  console.log(`🔍 Checking workflow settings against n8n ${version}\n`);
+
+  const schemaProperties = parseSchemaProperties(await fetchSchemaFile(version));
+
+  // The entity axis reads the INSTALLED n8n-workflow, which only describes the pinned dependency
+  // set. Compared against an explicitly requested other version it would manufacture skew
+  // findings (an old schema "missing" every newer entity property), so it runs in default mode
+  // only - which is the mode `npm run update:n8n` uses, right after installing the new set.
+  let entityProperties: Set<string> | null = null;
+  if (!explicitVersion) {
+    entityProperties = parseEntitySettingsProperties(readEntityDeclarations());
+  } else {
+    console.log('ℹ️  Entity axis skipped: the installed n8n-workflow may not match the requested version.\n');
+  }
+
+  const { missing, removed, ahead, entityOnly, unhandledEntityOnly, publishedEntityOnly } =
+    diffSettingsProperties(schemaProperties, entityProperties, parseVersion(version));
+  const ours = new Set(Object.keys(WORKFLOW_SETTINGS_PROPERTIES));
+
   console.log(`   n8n schema: ${schemaProperties.size} properties`);
+  if (entityProperties) console.log(`   n8n entity: ${entityProperties.size} properties`);
   console.log(`   ours:       ${ours.size} properties\n`);
 
   if (ahead.length > 0) {
     console.log(`ℹ️  ${ahead.length} known from a later n8n than the pin (expected): ${ahead.join(', ')}\n`);
   }
+  if (entityOnly.length > 0) {
+    console.log(`ℹ️  ${entityOnly.length} entity-only, stripped on write (expected): ${entityOnly.join(', ')}\n`);
+  }
 
-  if (missing.length === 0 && removed.length === 0) {
+  if (
+    missing.length === 0 &&
+    removed.length === 0 &&
+    unhandledEntityOnly.length === 0 &&
+    publishedEntityOnly.length === 0
+  ) {
     console.log('✅ No drift - src/constants/workflow-settings.ts matches n8n.');
     return;
   }
@@ -164,6 +324,34 @@ async function main(): Promise<void> {
     console.error(`\n❌ ${removed.length} property/properties in ours but not in n8n:`);
     for (const name of removed) console.error(`   - ${name}`);
     console.error('\n   n8n removed or renamed these. Remove them once no supported version has them.');
+  }
+
+  if (unhandledEntityOnly.length > 0) {
+    console.error(
+      `\n❌ ${unhandledEntityOnly.length} property/properties on the workflow entity but not in the write schema:`
+    );
+    for (const name of unhandledEntityOnly) console.error(`   ± ${name}`);
+    console.error(
+      '\n   n8n persists these and echoes them from GET, but the Public API write schema rejects'
+    );
+    console.error(
+      '   them, so read-modify-write updates fail. Add them to src/constants/workflow-settings.ts'
+    );
+    console.error('   with derived: true so every write strips them (see issue #1043).');
+  }
+
+  if (publishedEntityOnly.length > 0) {
+    console.error(
+      `\n❌ ${publishedEntityOnly.length} stripped property/properties now in the write schema:`
+    );
+    for (const name of publishedEntityOnly) console.error(`   ± ${name}`);
+    console.error(
+      '\n   These are stripped because the schema used to reject them, but this n8n accepts them,'
+    );
+    console.error(
+      '   so callers could be allowed to set them. Decide: drop entityOnly (and derived) in'
+    );
+    console.error('   src/constants/workflow-settings.ts, or keep stripping deliberately.');
   }
 
   process.exit(1);

--- a/scripts/check-settings-drift.ts
+++ b/scripts/check-settings-drift.ts
@@ -272,10 +272,15 @@ function installedNodesBaseVersion(): string | null {
 
 function installedEntityPackageVersion(): string | null {
   try {
-    const pkgPath = join(dirname(require.resolve('n8n-workflow')), '..', '..', 'package.json');
-    return (require(pkgPath) as { version?: string }).version ?? null;
+    return (require('n8n-workflow/package.json') as { version?: string }).version ?? null;
   } catch {
-    return null;
+    // Subpath blocked by a future exports map: walk up from the resolved entry instead.
+    try {
+      const pkgPath = join(dirname(require.resolve('n8n-workflow')), '..', '..', 'package.json');
+      return (require(pkgPath) as { version?: string }).version ?? null;
+    } catch {
+      return null;
+    }
   }
 }
 

--- a/scripts/check-settings-drift.ts
+++ b/scripts/check-settings-drift.ts
@@ -125,7 +125,9 @@ export function parseSchemaProperties(yaml: string): Set<string> {
  * throws, because an empty result would read as "no entity-only properties".
  */
 export function parseEntitySettingsProperties(dts: string): Set<string> {
-  const lines = dts.split('\n');
+  // Block comments could hide braces (breaking the depth count) or carry declaration-shaped
+  // text; neither should reach the parser.
+  const lines = dts.replace(/\/\*[\s\S]*?\*\//g, '').split('\n');
   // Anchored at line start (allowing export/declare) so comment lines mentioning the name
   // don't count as declarations.
   const declaration = new RegExp(
@@ -158,6 +160,15 @@ export function parseEntitySettingsProperties(dts: string): Set<string> {
         'Teach this parser about heritage clauses.'
     );
   }
+  // The line-based walk below only sees properties on lines after the opening brace, so
+  // content sharing the brace's line would be dropped silently. `header` ends at the line
+  // carrying the brace, wherever it is.
+  if (/\{\s*\S/.test(header)) {
+    throw new Error(
+      `"${ENTITY_INTERFACE}" has content on its opening-brace line - this parser reads ` +
+        'one property per line. Teach it the inline form.'
+    );
+  }
 
   const names = new Set<string>();
   let depth = 0;
@@ -183,6 +194,31 @@ export function parseEntitySettingsProperties(dts: string): Set<string> {
     );
   }
   return names;
+}
+
+/**
+ * The n8n-workflow version the target n8n release ships (an exact pin in its package.json),
+ * or null when it cannot be determined - the axis still runs, this only powers a warning.
+ */
+async function fetchEntityPackagePin(version: string): Promise<string | null> {
+  try {
+    const response = await fetch(`https://unpkg.com/n8n@${version}/package.json`);
+    if (!response.ok) return null;
+    const pkg = (await response.json()) as { dependencies?: Record<string, string> };
+    const pin = pkg.dependencies?.['n8n-workflow'];
+    return pin ? pin.replace(/^[^0-9]*/, '') : null;
+  } catch {
+    return null;
+  }
+}
+
+function installedEntityPackageVersion(): string | null {
+  try {
+    const pkgPath = join(dirname(require.resolve('n8n-workflow')), '..', '..', 'package.json');
+    return (require(pkgPath) as { version?: string }).version ?? null;
+  } catch {
+    return null;
+  }
 }
 
 function readEntityDeclarations(): string {
@@ -232,10 +268,15 @@ export function diffSettingsProperties(
   // whole request (additionalProperties: false). Such a property must be marked derived so every
   // write strips it. engineType (issue #1043) shipped exactly this way, and the schema-only diff
   // stayed green because the property was absent from both sides of it.
+  // Handled means BOTH flags: derived makes writes strip it, entityOnly arms the
+  // published-upstream detector below. Requiring one without the other would disarm the
+  // detector for exactly the properties it exists for.
   const unhandledEntityOnly = entityProperties
-    ? [...entityProperties].filter(
-        name => !schemaProperties.has(name) && WORKFLOW_SETTINGS_PROPERTIES[name]?.derived !== true
-      )
+    ? [...entityProperties].filter(name => {
+        if (schemaProperties.has(name)) return false;
+        const meta = WORKFLOW_SETTINGS_PROPERTIES[name];
+        return !(meta?.derived === true && meta?.entityOnly === true);
+      })
     : [];
 
   // The reverse transition: n8n published a property we strip because its schema used to reject
@@ -248,18 +289,23 @@ export function diffSettingsProperties(
   // A property we know but this version lacks is only drift when we claim it already existed:
   // one introduced in a later release is simply ahead of the pin, which is expected while the
   // pinned version trails n8n's newest. A derived property still on the entity is expected too -
-  // it is stripped from every write, so the schema not naming it cannot break anything.
+  // it is stripped from every write, so the schema not naming it cannot break anything. Without
+  // an entity set, a derived property is assumed entity-only when the target is new enough to
+  // carry it, and ahead-of-the-pin otherwise.
+  const unhandledSet = new Set(unhandledEntityOnly);
   const removed: string[] = [];
   const ahead: string[] = [];
   const entityOnly: string[] = [];
   for (const name of ours) {
     if (schemaProperties.has(name)) continue;
+    if (unhandledSet.has(name)) continue; // already reported with its actionable message
     const meta = WORKFLOW_SETTINGS_PROPERTIES[name];
-    if (meta.derived && (entityProperties === null || entityProperties.has(name))) {
+    const introducedLater = compareVersions(meta.since, target) > 0;
+    if (meta.derived && (entityProperties ? entityProperties.has(name) : !introducedLater)) {
       entityOnly.push(name);
       continue;
     }
-    (compareVersions(meta.since, target) <= 0 ? removed : ahead).push(name);
+    (introducedLater ? ahead : removed).push(name);
   }
 
   return { missing, removed, ahead, entityOnly, unhandledEntityOnly, publishedEntityOnly };
@@ -279,6 +325,18 @@ async function main(): Promise<void> {
   let entityProperties: Set<string> | null = null;
   if (!explicitVersion) {
     entityProperties = parseEntitySettingsProperties(readEntityDeclarations());
+    // The pin names an n8n-nodes-base release, not an n8n one, and sibling n8n patch releases
+    // can reuse subpackage versions - so confirm the fetched schema's release actually ships
+    // the n8n-workflow we parsed. On a mismatch the axis still runs: it can only fail loudly
+    // (a human investigates at update time), never silently pass what a matching set would fail.
+    const installed = installedEntityPackageVersion();
+    const expected = await fetchEntityPackagePin(version);
+    if (installed && expected && installed !== expected) {
+      console.log(
+        `⚠️  Installed n8n-workflow ${installed} differs from n8n ${version}'s pin ${expected} - ` +
+          'entity findings may reflect a neighbouring release.\n'
+      );
+    }
   } else {
     console.log('ℹ️  Entity axis skipped: the installed n8n-workflow may not match the requested version.\n');
   }
@@ -337,7 +395,10 @@ async function main(): Promise<void> {
     console.error(
       '   them, so read-modify-write updates fail. Add them to src/constants/workflow-settings.ts'
     );
-    console.error('   with derived: true so every write strips them (see issue #1043).');
+    console.error(
+      '   with derived: true, entityOnly: true so every write strips them and the check can'
+    );
+    console.error('   tell when n8n publishes them later (see issue #1043).');
   }
 
   if (publishedEntityOnly.length > 0) {

--- a/scripts/check-settings-drift.ts
+++ b/scripts/check-settings-drift.ts
@@ -13,8 +13,10 @@
  *   npx tsx scripts/check-settings-drift.ts 2.34.4     # explicit n8n version
  */
 
+import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
+import * as ts from 'typescript';
 import {
   WORKFLOW_SETTINGS_PROPERTIES,
   type SettingsVersion,
@@ -121,71 +123,54 @@ export function parseSchemaProperties(yaml: string): Set<string> {
 /**
  * Pull the property names out of n8n-workflow's `IWorkflowSettings` declaration - the workflow
  * entity's settings type, which the Public API schema is supposed to mirror but has trailed
- * (engineType, issue #1043). Same philosophy as the schema parser: anything this cannot find
- * throws, because an empty result would read as "no entity-only properties".
+ * (engineType, issue #1043). Parsed with the real TypeScript parser: review kept finding ways
+ * a hand-rolled lexer silently under-reports (comments, string types, inline braces), and a
+ * missed property here reads as "no entity-only properties" - the one failure mode this check
+ * must never have. Anything the walk cannot fully enumerate throws.
  */
 export function parseEntitySettingsProperties(dts: string): Set<string> {
-  // Block comments could hide braces (breaking the depth count) or carry declaration-shaped
-  // text; neither should reach the parser.
-  const lines = dts.replace(/\/\*[\s\S]*?\*\//g, '').split('\n');
-  // Anchored at line start (allowing export/declare) so comment lines mentioning the name
-  // don't count as declarations.
-  const declaration = new RegExp(
-    `^\\s*(?:export\\s+)?(?:declare\\s+)?interface ${ENTITY_INTERFACE}\\b`
-  );
-  const declarationIndices = lines.flatMap((line, i) => (declaration.test(line) ? [i] : []));
-  if (declarationIndices.length === 0) {
+  const source = ts.createSourceFile('interfaces.d.ts', dts, ts.ScriptTarget.Latest);
+
+  const declarations: ts.InterfaceDeclaration[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === ENTITY_INTERFACE) {
+      declarations.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  if (declarations.length === 0) {
     throw new Error(
       `No "${ENTITY_INTERFACE}" interface in n8n-workflow's declarations. ` +
         'n8n may have renamed or moved it - check the package.'
     );
   }
-  // These two shapes would parse cleanly but return a silently incomplete set, which reads as
-  // "no entity-only properties" - the one failure mode this check must never have.
-  if (declarationIndices.length > 1) {
-    throw new Error(
-      `"${ENTITY_INTERFACE}" is declared ${declarationIndices.length} times - declaration ` +
-        'merging would hide properties from this parser. Teach it to merge the declarations.'
-    );
-  }
-  const startIndex = declarationIndices[0];
-  let header = '';
-  for (let i = startIndex; i < lines.length; i++) {
-    header += lines[i];
-    if (lines[i].includes('{')) break;
-  }
-  if (/\bextends\b/.test(header)) {
-    throw new Error(
-      `"${ENTITY_INTERFACE}" extends a base type - inherited properties would be missed. ` +
-        'Teach this parser about heritage clauses.'
-    );
-  }
-  // The line-based walk below only sees properties on lines after the opening brace, so
-  // content sharing the brace's line would be dropped silently. `header` ends at the line
-  // carrying the brace, wherever it is.
-  if (/\{\s*\S/.test(header)) {
-    throw new Error(
-      `"${ENTITY_INTERFACE}" has content on its opening-brace line - this parser reads ` +
-        'one property per line. Teach it the inline form.'
-    );
-  }
 
+  // Declaration merging is legal TypeScript, so all declarations contribute members.
   const names = new Set<string>();
-  let depth = 0;
-  for (let i = startIndex; i < lines.length; i++) {
-    const line = lines[i];
-    // Depth 1 is the interface body; nested object types sit deeper and their keys are not
-    // settings properties. The check runs before this line's braces are counted, so a
-    // `foo?: {` line still registers foo while its members do not.
-    if (depth === 1) {
-      const match = line.trim().match(/^(?:readonly\s+)?([A-Za-z][A-Za-z0-9_]*)\??:/);
-      if (match) names.add(match[1]);
+  for (const declaration of declarations) {
+    if (declaration.heritageClauses && declaration.heritageClauses.length > 0) {
+      throw new Error(
+        `"${ENTITY_INTERFACE}" extends a base type - inherited properties would be missed. ` +
+          'Resolve the heritage clause here before trusting this check.'
+      );
     }
-    for (const char of line) {
-      if (char === '{') depth++;
-      else if (char === '}') depth--;
+    for (const member of declaration.members) {
+      if (
+        ts.isPropertySignature(member) &&
+        (ts.isIdentifier(member.name) || ts.isStringLiteral(member.name))
+      ) {
+        names.add(member.name.text);
+        continue;
+      }
+      // Index signatures, methods, computed names: not enumerable as settings properties, and
+      // skipping one silently would under-report - fail closed instead.
+      throw new Error(
+        `"${ENTITY_INTERFACE}" has a member this check cannot enumerate ` +
+          `(${ts.SyntaxKind[member.kind]}) - it would hide properties from the diff.`
+      );
     }
-    if (depth === 0 && i > startIndex) break;
   }
 
   if (names.size === 0) {
@@ -196,20 +181,66 @@ export function parseEntitySettingsProperties(dts: string): Set<string> {
   return names;
 }
 
-/**
- * The n8n-workflow version the target n8n release ships (an exact pin in its package.json),
- * or null when it cannot be determined - the axis still runs, this only powers a warning.
- */
-async function fetchEntityPackagePin(version: string): Promise<string | null> {
+interface ReleasePins {
+  nodesBase: string;
+  workflow: string;
+}
+
+/** The exact subpackage pins an n8n release publishes, or null when they cannot be fetched. */
+async function fetchReleasePins(version: string): Promise<ReleasePins | null> {
   try {
     const response = await fetch(`https://unpkg.com/n8n@${version}/package.json`);
     if (!response.ok) return null;
     const pkg = (await response.json()) as { dependencies?: Record<string, string> };
-    const pin = pkg.dependencies?.['n8n-workflow'];
-    return pin ? pin.replace(/^[^0-9]*/, '') : null;
+    const nodesBase = pkg.dependencies?.['n8n-nodes-base'];
+    const workflow = pkg.dependencies?.['n8n-workflow'];
+    if (!nodesBase || !workflow) return null;
+    return {
+      nodesBase: nodesBase.replace(/^[^0-9]*/, ''),
+      workflow: workflow.replace(/^[^0-9]*/, ''),
+    };
   } catch {
     return null;
   }
+}
+
+/**
+ * Find the n8n release whose published pins match the installed packages. The n8n-nodes-base
+ * pin only names a release on the same train, not the same release - nodes-base@2.36.4 ships
+ * in n8n@2.36.7, while n8n@2.36.4 pins nodes-base@2.36.3 - so fetching the schema "at the
+ * nodes-base version" can read a neighbouring release's schema. `npm run update:n8n` installs
+ * the latest subpackages, so the matching meta-release sits at or near the top of the version
+ * list; when none of the newest releases match, the same-number approximation stands and the
+ * caller's pin warning surfaces the residual skew.
+ */
+async function resolveSchemaRelease(
+  nodesBase: string,
+  entityVersion: string | null
+): Promise<{ version: string; pins: ReleasePins | null }> {
+  let versions: string[];
+  try {
+    versions = JSON.parse(execSync('npm view n8n versions --json', { encoding: 'utf8' }));
+  } catch {
+    return { version: nodesBase, pins: await fetchReleasePins(nodesBase) };
+  }
+
+  const floor = parseVersion(nodesBase);
+  const candidates = versions
+    .filter(candidate => /^\d+\.\d+\.\d+$/.test(candidate))
+    .filter(candidate => compareVersions(parseVersion(candidate), floor) >= 0)
+    .reverse()
+    .slice(0, 15);
+
+  let nodesBaseMatch: { version: string; pins: ReleasePins } | null = null;
+  for (const candidate of candidates) {
+    const pins = await fetchReleasePins(candidate);
+    if (!pins || pins.nodesBase !== nodesBase) continue;
+    if (entityVersion === null || pins.workflow === entityVersion) {
+      return { version: candidate, pins };
+    }
+    nodesBaseMatch ??= { version: candidate, pins };
+  }
+  return nodesBaseMatch ?? { version: nodesBase, pins: await fetchReleasePins(nodesBase) };
 }
 
 function installedEntityPackageVersion(): string | null {
@@ -313,33 +344,35 @@ export function diffSettingsProperties(
 
 async function main(): Promise<void> {
   const explicitVersion = process.argv[2];
-  const version = resolveVersion();
-  console.log(`🔍 Checking workflow settings against n8n ${version}\n`);
-
-  const schemaProperties = parseSchemaProperties(await fetchSchemaFile(version));
+  let version = resolveVersion();
 
   // The entity axis reads the INSTALLED n8n-workflow, which only describes the pinned dependency
   // set. Compared against an explicitly requested other version it would manufacture skew
   // findings (an old schema "missing" every newer entity property), so it runs in default mode
-  // only - which is the mode `npm run update:n8n` uses, right after installing the new set.
+  // only - which is the mode `npm run update:n8n` uses, right after installing the new set. In
+  // default mode the schema is fetched from the release whose pins match the installed packages.
   let entityProperties: Set<string> | null = null;
+  let releasePins: ReleasePins | null = null;
+  const installedEntity = explicitVersion ? null : installedEntityPackageVersion();
   if (!explicitVersion) {
     entityProperties = parseEntitySettingsProperties(readEntityDeclarations());
-    // The pin names an n8n-nodes-base release, not an n8n one, and sibling n8n patch releases
-    // can reuse subpackage versions - so confirm the fetched schema's release actually ships
-    // the n8n-workflow we parsed. On a mismatch the axis still runs: it can only fail loudly
-    // (a human investigates at update time), never silently pass what a matching set would fail.
-    const installed = installedEntityPackageVersion();
-    const expected = await fetchEntityPackagePin(version);
-    if (installed && expected && installed !== expected) {
-      console.log(
-        `⚠️  Installed n8n-workflow ${installed} differs from n8n ${version}'s pin ${expected} - ` +
-          'entity findings may reflect a neighbouring release.\n'
-      );
-    }
-  } else {
-    console.log('ℹ️  Entity axis skipped: the installed n8n-workflow may not match the requested version.\n');
+    ({ version, pins: releasePins } = await resolveSchemaRelease(version, installedEntity));
   }
+
+  console.log(`🔍 Checking workflow settings against n8n ${version}\n`);
+
+  if (explicitVersion) {
+    console.log('ℹ️  Entity axis skipped: the installed n8n-workflow may not match the requested version.\n');
+  } else if (installedEntity && releasePins && releasePins.workflow !== installedEntity) {
+    // Residual skew after resolution. The axis still runs: it can only fail loudly (a human
+    // investigates at update time), never silently pass what a matching set would fail.
+    console.log(
+      `⚠️  Installed n8n-workflow ${installedEntity} differs from n8n ${version}'s pin ` +
+        `${releasePins.workflow} - entity findings may reflect a neighbouring release.\n`
+    );
+  }
+
+  const schemaProperties = parseSchemaProperties(await fetchSchemaFile(version));
 
   const { missing, removed, ahead, entityOnly, unhandledEntityOnly, publishedEntityOnly } =
     diffSettingsProperties(schemaProperties, entityProperties, parseVersion(version));

--- a/scripts/check-settings-drift.ts
+++ b/scripts/check-settings-drift.ts
@@ -131,14 +131,32 @@ export function parseSchemaProperties(yaml: string): Set<string> {
 export function parseEntitySettingsProperties(dts: string): Set<string> {
   const source = ts.createSourceFile('interfaces.d.ts', dts, ts.ScriptTarget.Latest);
 
-  const declarations: ts.InterfaceDeclaration[] = [];
-  const visit = (node: ts.Node): void => {
-    if (ts.isInterfaceDeclaration(node) && node.name.text === ENTITY_INTERFACE) {
-      declarations.push(node);
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(source);
+  // createSourceFile recovers from syntax errors, so a truncated file (missing brace,
+  // unterminated string) would yield a PARTIAL property set - reject anything that does not
+  // parse cleanly. parseDiagnostics is internal API, so its disappearance must also throw
+  // rather than quietly skipping the syntax gate.
+  const diagnostics = (source as unknown as { parseDiagnostics?: readonly ts.Diagnostic[] })
+    .parseDiagnostics;
+  if (!Array.isArray(diagnostics)) {
+    throw new Error(
+      'TypeScript no longer exposes parseDiagnostics on SourceFile - rework this check to get ' +
+        'syntax diagnostics from a Program before trusting the parse.'
+    );
+  }
+  if (diagnostics.length > 0) {
+    throw new Error(
+      `n8n-workflow's declarations do not parse cleanly (` +
+        `${ts.flattenDiagnosticMessageText(diagnostics[0].messageText, ' ')}) - a partial ` +
+        'parse would under-report properties.'
+    );
+  }
+
+  // Top-level statements only: a same-named interface inside a namespace or module does not
+  // merge with the export this check is after.
+  const declarations = source.statements.filter(
+    (statement): statement is ts.InterfaceDeclaration =>
+      ts.isInterfaceDeclaration(statement) && statement.name.text === ENTITY_INTERFACE
+  );
 
   if (declarations.length === 0) {
     throw new Error(
@@ -363,13 +381,28 @@ async function main(): Promise<void> {
 
   if (explicitVersion) {
     console.log('ℹ️  Entity axis skipped: the installed n8n-workflow may not match the requested version.\n');
-  } else if (installedEntity && releasePins && releasePins.workflow !== installedEntity) {
-    // Residual skew after resolution. The axis still runs: it can only fail loudly (a human
-    // investigates at update time), never silently pass what a matching set would fail.
-    console.log(
-      `⚠️  Installed n8n-workflow ${installedEntity} differs from n8n ${version}'s pin ` +
-        `${releasePins.workflow} - entity findings may reflect a neighbouring release.\n`
-    );
+  } else {
+    // Residual skew after resolution, in either pin - the fallback release can match on
+    // n8n-workflow while shipping a different n8n-nodes-base (and so a different schema).
+    // The axis still runs: it can only fail loudly (a human investigates at update time),
+    // never silently pass what a matching set would fail.
+    const installedNodesBase = resolveVersion();
+    const skews: string[] = [];
+    if (releasePins && releasePins.nodesBase !== installedNodesBase) {
+      skews.push(`n8n-nodes-base ${installedNodesBase} vs pin ${releasePins.nodesBase}`);
+    }
+    if (releasePins && installedEntity && releasePins.workflow !== installedEntity) {
+      skews.push(`n8n-workflow ${installedEntity} vs pin ${releasePins.workflow}`);
+    }
+    if (!releasePins) {
+      skews.push(`n8n ${version}'s pins could not be fetched`);
+    }
+    if (skews.length > 0) {
+      console.log(
+        `⚠️  Installed packages differ from n8n ${version}'s (${skews.join('; ')}) - ` +
+          'findings may reflect a neighbouring release.\n'
+      );
+    }
   }
 
   const schemaProperties = parseSchemaProperties(await fetchSchemaFile(version));

--- a/src/constants/workflow-settings.ts
+++ b/src/constants/workflow-settings.ts
@@ -30,16 +30,25 @@ export interface SettingsVersion {
 export interface WorkflowSettingProperty {
   /**
    * First n8n version whose Public API schema accepted this property. `0.0.0` means it predates
-   * every version we filter for.
+   * every version we filter for. For a {@link derived} property the schema may never accept it -
+   * there it records the first version whose GET responses can carry the property.
    */
   since: SettingsVersion;
   /**
-   * n8n derives this server-side: it documents the property as ignored on create and update but
-   * still echoes it back on GET. Our writes merge over a GET, so these are always stripped -
-   * sending them back changes nothing on the instance that produced them and rejects the whole
-   * request on an older one.
+   * n8n manages this property server-side and does not take it from a write. Two flavours:
+   * the schema documents it as ignored on create and update (`binaryMode`), or the property is
+   * persisted on the workflow entity but missing from the write schema entirely (`engineType`),
+   * where `additionalProperties: false` rejects the whole request. GET echoes both back, and our
+   * writes merge over a GET, so these are always stripped - sending them back changes nothing on
+   * the instance that produced them and rejects the request on one that doesn't accept them.
    */
   derived?: true;
+  /**
+   * The second {@link derived} flavour: persisted on the workflow entity but absent from the
+   * Public API schema. The drift check fails when n8n later publishes such a property to the
+   * schema, because stripping then stops being the only option - callers might want to set it.
+   */
+  entityOnly?: true;
 }
 
 const v = (major: number, minor: number, patch = 0): SettingsVersion => ({ major, minor, patch });
@@ -69,6 +78,12 @@ export const WORKFLOW_SETTINGS_PROPERTIES: Record<string, WorkflowSettingPropert
   binaryMode: { since: v(2, 33, 0), derived: true },
   timeSavedMode: { since: v(2, 33, 0) },
   credentialResolverId: { since: v(2, 33, 0), derived: true },
+
+  // n8n 2.36.0 (n8n-io/n8n#36428): persisted on the workflow entity (the engine-v2 dispatcher
+  // reads settings.engineType === 'v2') but absent from the Public API write schema, so echoing
+  // back what GET returned rejects the whole write. Stripping is lossless: WorkflowService.update
+  // spreads stored settings under the request body, so an omitted key is preserved, not cleared.
+  engineType: { since: v(2, 36, 0), derived: true, entityOnly: true },
 };
 
 /**

--- a/tests/unit/scripts/check-settings-drift.test.ts
+++ b/tests/unit/scripts/check-settings-drift.test.ts
@@ -166,6 +166,35 @@ describe('check-settings-drift parseEntitySettingsProperties', () => {
     expect([...parseEntitySettingsProperties(dts)]).toEqual(['timezone']);
   });
 
+  it('ignores a declaration-shaped line inside a block comment', () => {
+    const dts = [
+      '/*',
+      'export interface IWorkflowSettings {',
+      '    ghost?: string;',
+      '}',
+      '*/',
+      'export interface IWorkflowSettings {',
+      '    timezone?: string;',
+      '}',
+    ].join('\n');
+    expect([...parseEntitySettingsProperties(dts)]).toEqual(['timezone']);
+  });
+
+  it('is not derailed by an unbalanced brace inside a block comment', () => {
+    const dts = [
+      'export interface IWorkflowSettings {',
+      '    /* weird note: { */',
+      '    timezone?: string;',
+      '}',
+    ].join('\n');
+    expect([...parseEntitySettingsProperties(dts)]).toEqual(['timezone']);
+  });
+
+  it('throws when a property shares the opening-brace line instead of skipping it', () => {
+    const dts = 'export interface IWorkflowSettings { engineType?: string;\n    timezone?: string;\n}';
+    expect(() => parseEntitySettingsProperties(dts)).toThrow(/opening-brace/);
+  });
+
   it('parses the installed n8n-workflow declarations, which must cover our derived properties', () => {
     // Runs against the real package so a reformat of its .d.ts fails here instead of making
     // the drift check throw (or worse, quietly agree) during the next n8n update.
@@ -230,6 +259,20 @@ describe('check-settings-drift diffSettingsProperties', () => {
     expect(drift.unhandledEntityOnly).toEqual(['someNewInternalSetting']);
   });
 
+  it('still flags an entity-only property marked derived without entityOnly (detector must stay armed)', () => {
+    // binaryMode is derived but not entityOnly. If the schema stopped naming it while the
+    // entity kept it, derived alone must not count as handled - without entityOnly the
+    // published-upstream detector would never fire for it.
+    const schema = new Set(schemaOf236);
+    schema.delete('binaryMode');
+    const drift = diffSettingsProperties(schema, entityOf236, v236);
+
+    expect(drift.unhandledEntityOnly).toEqual(['binaryMode']);
+    // And it is not simultaneously soft-reported as expected or stale
+    expect(drift.entityOnly).toEqual(['engineType']);
+    expect(drift.removed).toEqual([]);
+  });
+
   it('flags a stripped entity-only property once n8n publishes it to the schema', () => {
     const schema = new Set([...schemaOf236, 'engineType']);
     const drift = diffSettingsProperties(schema, entityOf236, v236);
@@ -271,5 +314,14 @@ describe('check-settings-drift diffSettingsProperties', () => {
     expect(drift.entityOnly).toEqual(['engineType']);
     expect(drift.unhandledEntityOnly).toEqual([]);
     expect(drift.removed).toEqual([]);
+  });
+
+  it('classifies a derived property from a later n8n as ahead, not entity-only, without an entity set', () => {
+    // For a 2.20 target, engineType (since 2.36) cannot be on the entity yet - calling it
+    // "entity-only, expected" would be misleading; it is simply ahead of the pin.
+    const drift = diffSettingsProperties(schemaOf236, null, { major: 2, minor: 20, patch: 0 });
+
+    expect(drift.ahead).toContain('engineType');
+    expect(drift.entityOnly).toEqual([]);
   });
 });

--- a/tests/unit/scripts/check-settings-drift.test.ts
+++ b/tests/unit/scripts/check-settings-drift.test.ts
@@ -1,5 +1,12 @@
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
 import { describe, it, expect } from 'vitest';
-import { parseSchemaProperties } from '../../../scripts/check-settings-drift';
+import {
+  diffSettingsProperties,
+  parseEntitySettingsProperties,
+  parseSchemaProperties,
+} from '../../../scripts/check-settings-drift';
+import { WORKFLOW_SETTINGS_PROPERTIES } from '../../../src/constants/workflow-settings';
 
 /**
  * The drift check reads n8n's OpenAPI schema with a small hand-rolled parser rather than a YAML
@@ -73,5 +80,196 @@ describe('check-settings-drift parseSchemaProperties', () => {
   it('throws on a response that is not the schema at all', () => {
     expect(() => parseSchemaProperties('')).toThrow();
     expect(() => parseSchemaProperties('<!doctype html><html>404</html>')).toThrow();
+  });
+});
+
+/**
+ * The entity parser reads IWorkflowSettings out of n8n-workflow's type declarations. It exists
+ * because the schema-only diff is blind to properties n8n persists but never published to the
+ * Public API schema - engineType broke every workflow update that way (issue #1043). Same
+ * contract as the schema parser: malformed input must throw, never yield an empty set.
+ */
+describe('check-settings-drift parseEntitySettingsProperties', () => {
+  it('reads the property names of the IWorkflowSettings interface', () => {
+    const dts = [
+      'export interface ISomethingElse {',
+      '    unrelated?: string;',
+      '}',
+      'export interface IWorkflowSettings {',
+      "    timezone?: 'DEFAULT' | string;",
+      "    engineType?: 'v1' | 'v2';",
+      '    customTelemetryTags?: ICustomTelemetryTag[];',
+      '}',
+      'export interface WorkflowFEMeta {',
+      '    onboardingId?: string;',
+      '}',
+    ].join('\n');
+
+    expect([...parseEntitySettingsProperties(dts)]).toEqual([
+      'timezone',
+      'engineType',
+      'customTelemetryTags',
+    ]);
+  });
+
+  it('registers a nested object property without leaking its members', () => {
+    const dts = [
+      'export interface IWorkflowSettings {',
+      '    executionTimeout?: number;',
+      '    someNested?: {',
+      '        inner?: string;',
+      '    };',
+      '}',
+    ].join('\n');
+
+    expect([...parseEntitySettingsProperties(dts)]).toEqual(['executionTimeout', 'someNested']);
+  });
+
+  it('throws when n8n renames the interface', () => {
+    const dts = 'export interface IWorkflowConfig {\n    timezone?: string;\n}';
+    expect(() => parseEntitySettingsProperties(dts)).toThrow(/IWorkflowSettings/);
+  });
+
+  it('throws rather than reporting an empty property set', () => {
+    const dts = 'export interface IWorkflowSettings {\n}';
+    expect(() => parseEntitySettingsProperties(dts)).toThrow(/zero properties/);
+  });
+
+  it('throws when the interface extends a base type instead of missing inherited properties', () => {
+    const dts = [
+      'export interface IWorkflowSettings extends IBaseSettings {',
+      '    timezone?: string;',
+      '}',
+    ].join('\n');
+    expect(() => parseEntitySettingsProperties(dts)).toThrow(/extends/);
+  });
+
+  it('throws on declaration merging instead of reading only the first block', () => {
+    const dts = [
+      'export interface IWorkflowSettings {',
+      '    timezone?: string;',
+      '}',
+      'export interface IWorkflowSettings {',
+      '    engineType?: string;',
+      '}',
+    ].join('\n');
+    expect(() => parseEntitySettingsProperties(dts)).toThrow(/declaration/i);
+  });
+
+  it('does not mistake a comment mentioning the interface for its declaration', () => {
+    const dts = [
+      '// The shape of interface IWorkflowSettings mirrors the schema',
+      'export interface IWorkflowSettings {',
+      '    timezone?: string;',
+      '}',
+    ].join('\n');
+    expect([...parseEntitySettingsProperties(dts)]).toEqual(['timezone']);
+  });
+
+  it('parses the installed n8n-workflow declarations, which must cover our derived properties', () => {
+    // Runs against the real package so a reformat of its .d.ts fails here instead of making
+    // the drift check throw (or worse, quietly agree) during the next n8n update.
+    const dts = readFileSync(
+      join(dirname(require.resolve('n8n-workflow')), 'interfaces.d.ts'),
+      'utf8'
+    );
+
+    const entityProperties = parseEntitySettingsProperties(dts);
+    expect(entityProperties.has('executionOrder')).toBe(true);
+    expect(entityProperties.has('engineType')).toBe(true);
+
+    // Every property we strip as derived should still exist on the entity - one that vanished
+    // from n8n entirely is a stale entry this table no longer needs.
+    for (const [name, meta] of Object.entries(WORKFLOW_SETTINGS_PROPERTIES)) {
+      if (meta.derived) {
+        expect(entityProperties.has(name), `${name} is marked derived but not on the entity`).toBe(true);
+      }
+    }
+
+    // The reverse: every entity property must be in our table. "On the entity but unknown to us"
+    // is the engineType signature (#1043) - a property GET echoes into our read-modify-write that
+    // no strip or filter knows about. The full drift check only runs inside `npm run update:n8n`;
+    // this offline approximation makes the same class fail in CI on any n8n-workflow bump.
+    for (const name of entityProperties) {
+      expect(
+        name in WORKFLOW_SETTINGS_PROPERTIES,
+        `entity settings property ${name} is missing from WORKFLOW_SETTINGS_PROPERTIES`
+      ).toBe(true);
+    }
+  });
+});
+
+/**
+ * The gate itself: which bucket each property lands in decides whether the check fails, so the
+ * classification is tested directly against the real table rather than only via parsers.
+ */
+describe('check-settings-drift diffSettingsProperties', () => {
+  const v236 = { major: 2, minor: 36, patch: 4 };
+  // The published schema of n8n 2.36 as the table models it: everything except derived-only keys
+  const schemaOf236 = new Set(
+    Object.entries(WORKFLOW_SETTINGS_PROPERTIES)
+      .filter(([, meta]) => !meta.entityOnly)
+      .map(([name]) => name)
+  );
+  const entityOf236 = new Set([...schemaOf236, 'engineType']);
+
+  it('reports no drift for a consistent pinned set', () => {
+    const drift = diffSettingsProperties(schemaOf236, entityOf236, v236);
+
+    expect(drift.missing).toEqual([]);
+    expect(drift.removed).toEqual([]);
+    expect(drift.unhandledEntityOnly).toEqual([]);
+    expect(drift.publishedEntityOnly).toEqual([]);
+    expect(drift.entityOnly).toEqual(['engineType']);
+  });
+
+  it('flags an entity property the schema rejects and the table does not strip', () => {
+    const entity = new Set([...entityOf236, 'someNewInternalSetting']);
+    const drift = diffSettingsProperties(schemaOf236, entity, v236);
+
+    expect(drift.unhandledEntityOnly).toEqual(['someNewInternalSetting']);
+  });
+
+  it('flags a stripped entity-only property once n8n publishes it to the schema', () => {
+    const schema = new Set([...schemaOf236, 'engineType']);
+    const drift = diffSettingsProperties(schema, entityOf236, v236);
+
+    expect(drift.publishedEntityOnly).toEqual(['engineType']);
+    expect(drift.unhandledEntityOnly).toEqual([]);
+    expect(drift.entityOnly).toEqual([]);
+  });
+
+  it('flags a new schema property missing from the table', () => {
+    const schema = new Set([...schemaOf236, 'brandNewSetting']);
+    const drift = diffSettingsProperties(schema, entityOf236, v236);
+
+    expect(drift.missing).toEqual(['brandNewSetting']);
+  });
+
+  it('splits table properties the schema lacks into removed vs ahead by the target version', () => {
+    const schema = new Set(schemaOf236);
+    schema.delete('timezone'); // since 0.0.0 - claiming this version has it makes its absence drift
+    schema.delete('redactionPolicy'); // since 2.26.0 - ahead of a 2.20 target, expected
+    const entity = new Set([...schema, 'engineType']);
+    const drift = diffSettingsProperties(schema, entity, { major: 2, minor: 20, patch: 0 });
+
+    expect(drift.removed).toEqual(['timezone']);
+    expect(drift.ahead).toEqual(['redactionPolicy']);
+  });
+
+  it('treats a derived property gone from the entity as well as stale, not entity-only', () => {
+    const entity = new Set(schemaOf236); // no engineType anywhere any more
+    const drift = diffSettingsProperties(schemaOf236, entity, v236);
+
+    expect(drift.entityOnly).toEqual([]);
+    expect(drift.removed).toContain('engineType');
+  });
+
+  it('assumes derived properties are entity-only when no entity set is available', () => {
+    const drift = diffSettingsProperties(schemaOf236, null, v236);
+
+    expect(drift.entityOnly).toEqual(['engineType']);
+    expect(drift.unhandledEntityOnly).toEqual([]);
+    expect(drift.removed).toEqual([]);
   });
 });

--- a/tests/unit/scripts/check-settings-drift.test.ts
+++ b/tests/unit/scripts/check-settings-drift.test.ts
@@ -206,6 +206,25 @@ describe('check-settings-drift parseEntitySettingsProperties', () => {
     expect([...parseEntitySettingsProperties(dts)]).toEqual(['first', 'second', 'third']);
   });
 
+  it('throws on a truncated file instead of returning the partial property set', () => {
+    const dts = 'export interface IWorkflowSettings {\n    timezone?: string;';
+    expect(() => parseEntitySettingsProperties(dts)).toThrow(/parse cleanly/);
+  });
+
+  it('does not accept a same-named interface nested in a namespace as the target', () => {
+    const dts = [
+      'export namespace Other {',
+      '    export interface IWorkflowSettings {',
+      '        ghost?: string;',
+      '    }',
+      '}',
+      'export interface IWorkflowSettings {',
+      '    timezone?: string;',
+      '}',
+    ].join('\n');
+    expect([...parseEntitySettingsProperties(dts)]).toEqual(['timezone']);
+  });
+
   it('throws on a member it cannot enumerate rather than skipping it', () => {
     const dts = [
       'export interface IWorkflowSettings {',

--- a/tests/unit/scripts/check-settings-drift.test.ts
+++ b/tests/unit/scripts/check-settings-drift.test.ts
@@ -144,7 +144,7 @@ describe('check-settings-drift parseEntitySettingsProperties', () => {
     expect(() => parseEntitySettingsProperties(dts)).toThrow(/extends/);
   });
 
-  it('throws on declaration merging instead of reading only the first block', () => {
+  it('merges split declarations instead of reading only the first block', () => {
     const dts = [
       'export interface IWorkflowSettings {',
       '    timezone?: string;',
@@ -153,7 +153,7 @@ describe('check-settings-drift parseEntitySettingsProperties', () => {
       '    engineType?: string;',
       '}',
     ].join('\n');
-    expect(() => parseEntitySettingsProperties(dts)).toThrow(/declaration/i);
+    expect([...parseEntitySettingsProperties(dts)]).toEqual(['timezone', 'engineType']);
   });
 
   it('does not mistake a comment mentioning the interface for its declaration', () => {
@@ -190,9 +190,30 @@ describe('check-settings-drift parseEntitySettingsProperties', () => {
     expect([...parseEntitySettingsProperties(dts)]).toEqual(['timezone']);
   });
 
-  it('throws when a property shares the opening-brace line instead of skipping it', () => {
+  it('reads a property that shares the opening-brace line instead of skipping it', () => {
     const dts = 'export interface IWorkflowSettings { engineType?: string;\n    timezone?: string;\n}';
-    expect(() => parseEntitySettingsProperties(dts)).toThrow(/opening-brace/);
+    expect([...parseEntitySettingsProperties(dts)]).toEqual(['engineType', 'timezone']);
+  });
+
+  it('is not derailed by braces inside line comments or string literal types', () => {
+    const dts = [
+      'export interface IWorkflowSettings {',
+      '    first?: string; // }',
+      "    second?: '{';",
+      '    third?: string;',
+      '}',
+    ].join('\n');
+    expect([...parseEntitySettingsProperties(dts)]).toEqual(['first', 'second', 'third']);
+  });
+
+  it('throws on a member it cannot enumerate rather than skipping it', () => {
+    const dts = [
+      'export interface IWorkflowSettings {',
+      '    timezone?: string;',
+      '    [key: string]: unknown;',
+      '}',
+    ].join('\n');
+    expect(() => parseEntitySettingsProperties(dts)).toThrow(/cannot enumerate/);
   });
 
   it('parses the installed n8n-workflow declarations, which must cover our derived properties', () => {

--- a/tests/unit/services/n8n-validation.test.ts
+++ b/tests/unit/services/n8n-validation.test.ts
@@ -328,6 +328,7 @@ describe('n8n-validation', () => {
             redactionPolicy: 'all' as const,
             binaryMode: 'combined',
             credentialResolverId: 'resolver-1',
+            engineType: 'v2',
           },
         };
 
@@ -668,6 +669,9 @@ describe('n8n-validation', () => {
             // Echoed by GET on n8n 2.33+, ignored on write, rejected outright by older n8n
             binaryMode: 'combined',
             credentialResolverId: 'resolver-1',
+            // Echoed by GET on n8n 2.36+ but rejected by the write schema on every version -
+            // echoing it back fails the whole update (Issue #1043)
+            engineType: 'v2',
           },
         } as any;
 

--- a/tests/unit/services/n8n-version.test.ts
+++ b/tests/unit/services/n8n-version.test.ts
@@ -277,6 +277,13 @@ describe('n8n-version', () => {
 
         expect(cleaned).toEqual({ executionOrder: 'v1' });
       });
+
+      it('still drops engineType, which the write schema rejects on every version (Issue #1043)', () => {
+        const v = parseVersion('2.36.0')!;
+        const cleaned = cleanSettingsForVersion({ executionOrder: 'v1', engineType: 'v2' }, v);
+
+        expect(cleaned).toEqual({ executionOrder: 'v1' });
+      });
     });
 
     describe('below the pass-through floor', () => {
@@ -309,6 +316,14 @@ describe('n8n-version', () => {
       );
 
       expect(cleaned).toEqual({ executionOrder: 'v1', redactionPolicy: 'all' });
+    });
+
+    it('drops engineType even when the version could not be detected (Issue #1043)', () => {
+      // Modern n8n hides its version from API clients, so this null-version path is what
+      // production takes - derived stripping must not depend on the version probe
+      const cleaned = cleanSettingsForVersion({ executionOrder: 'v1', engineType: 'v2' }, null);
+
+      expect(cleaned).toEqual({ executionOrder: 'v1' });
     });
   });
 


### PR DESCRIPTION
Fixes #1043.

## Problem

`n8n_update_partial_workflow` and `n8n_update_full_workflow` fail against n8n ≥ 2.36.0 with `settings must NOT have additional properties`. n8n 2.36.0 ([n8n-io/n8n#36428](https://github.com/n8n-io/n8n/pull/36428)) added `engineType` to the workflow entity's persisted settings without adding it to the Public API write schema (`additionalProperties: false`). Our writes are read-modify-write, so `GET` hands us the property and we echo it into a `PUT` that rejects it. The version-aware filter never fires because modern n8n hides its version from API clients, and the drift guard was blind to the entity-vs-schema axis — `engineType` was absent from both sides of the schema-only diff. 16 occurrences in 24h on the hosted server, growing as instances update.

## Fix

- **`src/constants/workflow-settings.ts`**: `engineType` is marked `derived: true`, routing it through `stripDerivedSettings` — removed from every create and update payload regardless of the (dead) version probe, the same treatment `binaryMode` and `credentialResolverId` get. Stripping is lossless: n8n's `WorkflowService.update` spreads stored settings under the request body, so an omitted key is preserved, not cleared (verified on the `n8n@2.36.0` tag and live, below).
- **`scripts/check-settings-drift.ts`** now checks the axis that was blind to this class: it parses `IWorkflowSettings` from the installed `n8n-workflow` package and fails when n8n persists a settings property the write schema rejects that our table does not strip — and fails again in the reverse direction, when n8n later publishes a property we strip (so an upstream schema fix cannot leave us stripping it forever). Verified red on the pre-fix tree, green post-fix. The entity parser fails loudly on `extends`/declaration merging instead of returning a silently incomplete set, and the classification gate is extracted into a pure `diffSettingsProperties` with direct tests.
- **Tests**: `engineType` strip coverage on the create, update, and version-filter paths — including the null-version path production actually takes — plus an offline CI assertion that every entity settings property is known to the table (the full drift check only runs inside `npm run update:n8n`; this makes the same class fail in CI on any `n8n-workflow` bump).

## Verification

- Typecheck, full unit suite, and `npm run check:settings-drift` green (both default and explicit-version modes).
- Live E2E against n8n 2.36.7: created a workflow, injected `settings.engineType = "v2"` server-side (the Public API cannot set it — that is the bug), confirmed `GET` echoes it, ran `n8n_update_partial_workflow` through the fixed server — success, where 2.76.0 fails with the 400 — and confirmed `engineType: "v2"` still persisted after the write.
- Review gauntlet: code-simplifier (no changes needed), independent code review (no blocking findings; parser fail-loud gaps and CI-visibility hardening adopted), Codex review (no write-leak or data-loss findings; version-skew in explicit-version mode fixed by scoping the entity axis to the pinned set, classification gate now unit-tested).

## Follow-up (out of scope)

- Upstream PR to n8n adding `engineType` to the Public API settings schema — as it stands the property can be neither read-modify-written nor deliberately set through the API. The new `publishedEntityOnly` drift failure will surface when that lands.
- A generic degrade-and-retry for the `settings must NOT have additional properties` 400 in `sendWorkflowWrite` (issue #1043 follow-up 3), which would turn the next property of this class into a warning instead of a hard failure.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)