### PR TITLE
fix(mcp): enforce end-to-end timeout budgets

### DIFF
--- a/src/mcp/handlers-official-tools.ts
+++ b/src/mcp/handlers-official-tools.ts
@@ -60,7 +60,8 @@ const DEFAULT_MIN_VERSION = '2.34';
 /**
  * Shared "call one official tool, wrap the result" path for the passthrough
  * tools. `idempotent` says whether the call may be re-sent after a
- * connection-level failure — see `N8nOfficialMcpClient.callTool`.
+ * connection-level failure. `timeoutMs` is one budget for connection, tool
+ * discovery, the tool call and any retry.
  */
 export async function callOfficialTool(
   context: InstanceContext | undefined,
@@ -72,15 +73,16 @@ export async function callOfficialTool(
 ): Promise<McpToolResponse> {
   const client = getOfficialMcpClient(context);
   if (!client) return notConfiguredResponse(context, label) as McpToolResponse;
+  const deadlineAt = Date.now() + timeoutMs;
   try {
-    const caps = await client.capabilities();
+    const caps = await client.capabilities(false, { deadlineAt });
     if (!caps.reachable) return officialFailure(new OfficialMcpError(caps.error ?? 'OFFICIAL_MCP_TRANSPORT_ERROR', 'n8n MCP server is not reachable'), label) as McpToolResponse;
     const tool = toolAliases.find(t => caps.toolNames.includes(t));
     if (!tool) {
       const minVersion = OFFICIAL_TOOL_MIN_VERSION[toolAliases[0]] ?? DEFAULT_MIN_VERSION;
       return officialFailure(new OfficialMcpError('OFFICIAL_MCP_TOOL_UNAVAILABLE', `This instance does not expose ${toolAliases.join(' / ')} (needs n8n >= ${minVersion})`), label) as McpToolResponse;
     }
-    const result = await client.callTool(tool, args, { timeoutMs, idempotent });
+    const result = await client.callTool(tool, args, { timeoutMs, idempotent, deadlineAt });
     const data = result.json ?? result.text;
     // "Input validation error" is the literal prefix n8n's MCP server puts on
     // an arguments-rejected response (observed on n8n 2.36.7 — see the spike

--- a/src/mcp/tool-docs/discovery/n8n-explore-node-resources.ts
+++ b/src/mcp/tool-docs/discovery/n8n-explore-node-resources.ts
@@ -31,7 +31,7 @@ Not workflow-scoped — this reads live account data, so it always runs when ins
       filter: { type: 'string', required: false, description: 'Search/filter text to narrow results (listSearch only)' },
       paginationToken: { type: 'string', required: false, description: 'Token from a previous response to fetch the next page (listSearch only)' },
       currentNodeParameters: { type: 'object', required: false, description: 'Parameters the method depends on (loadOptionsDependsOn), e.g. {documentId: {__rl: true, mode: "id", value: "…"}}' },
-      timeoutMs: { type: 'integer', required: false, description: 'Request timeout in ms, 5000-600000. Default 30000.' },
+      timeoutMs: { type: 'integer', required: false, description: 'Whole-call timeout in ms, including connection, tool discovery and execution. 5000-600000, default 30000.' },
     },
     returns: '{success: true, officialTool: "explore_node_resources", data: {results: [{name, value, url?, description?}], paginationToken?, builderHint?}} on success; {success: false, code, error, hint?} on failure. Codes: NOT_CONFIGURED, OFFICIAL_MCP_AUTH_FAILED, OFFICIAL_MCP_NOT_ENABLED, OFFICIAL_MCP_RATE_LIMITED, OFFICIAL_MCP_TOOL_UNAVAILABLE, OFFICIAL_MCP_URL_REJECTED, OFFICIAL_MCP_TIMEOUT, OFFICIAL_MCP_TRANSPORT_ERROR, INVALID_ARGS, OFFICIAL_MCP_ERROR.',
     examples: [

--- a/src/mcp/tool-docs/workflow_management/n8n-manage-datatable.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-manage-datatable.ts
@@ -65,7 +65,7 @@ Column names must start with a letter, contain only letters, digits and undersco
       projectId: { type: 'string', required: false, description: 'For createTable: project to create the table in. For the column actions: project owning the table - auto-resolved when exactly one project is accessible' },
       column: { type: 'object', required: false, description: 'For addColumn: {name, type} - name must match ^[a-zA-Z][a-zA-Z0-9_]*$ and be at most 63 characters; type is string, number, boolean or date' },
       columnId: { type: 'string', required: false, description: 'For deleteColumn/renameColumn: ID of the column (read it from getTable)' },
-      timeoutMs: { type: 'integer', required: false, description: 'For the column actions: client timeout in ms (5000-600000, default 30000)' },
+      timeoutMs: { type: 'integer', required: false, description: 'For the column actions: whole-call timeout in ms, including connection, tool discovery and execution (5000-600000, default 30000)' },
     },
     returns: `Depends on action:
 - createTable: {id, name}

--- a/src/mcp/tool-docs/workflow_management/n8n-test-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-test-workflow.ts
@@ -131,7 +131,7 @@ Every response states \`method\` and \`backend\` ('public-api' or 'official-mcp'
       timeoutMs: {
         type: 'integer',
         required: false,
-        description: 'Client-side deadline for the official call, 5000-600000 (default: 30000 for prepare, 300000 for pinned/direct)'
+        description: 'Whole-call timeout for the official path, including connection, tool discovery and execution, 5000-600000 (default: 30000 for prepare, 300000 for pinned/direct)'
       }
     },
     returns: `Execution response including:

--- a/src/mcp/tool-docs/workflow_management/n8n-workflow-versions.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-workflow-versions.ts
@@ -161,7 +161,7 @@ per workflow, plus an age-based retention window). Native history retention is n
         type: 'integer',
         required: false,
         default: 30000,
-        description: 'Client deadline for the native call (5000-600000)'
+        description: 'Whole-call timeout for the native path, including connection, tool discovery and execution (5000-600000)'
       }
     },
     returns: `Response varies by mode:

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -458,7 +458,7 @@ export const n8nManagementTools: ToolDefinition[] = [
           type: 'integer',
           minimum: 5000,
           maximum: 600000,
-          description: 'Client-side deadline for the official call (default: 30000 for prepare, 300000 for pinned/direct)'
+          description: 'Whole-call timeout for the official path, including connection, tool discovery and execution (default: 30000 for prepare, 300000 for pinned/direct)'
         }
       },
       required: ['workflowId']
@@ -702,7 +702,7 @@ Two sources:
           type: 'integer',
           minimum: 5000,
           maximum: 600000,
-          description: 'Client deadline for the native call (default 30000)'
+          description: 'Whole-call timeout for the native path, including connection, tool discovery and execution (default 30000)'
         }
       },
       required: ['mode']
@@ -807,7 +807,7 @@ Two sources:
           type: 'integer',
           minimum: 5000,
           maximum: 600000,
-          description: 'For the column actions: client timeout in ms (5000-600000, default 30000).',
+          description: 'For the column actions: whole-call timeout in ms, including connection, tool discovery and execution (5000-600000, default 30000).',
         },
       },
       required: ['action'],
@@ -955,7 +955,7 @@ Two sources:
         filter: { type: 'string', description: 'Search text (listSearch only)' },
         paginationToken: { type: 'string', description: 'Token from a previous page (listSearch only)' },
         currentNodeParameters: { type: 'object', description: 'Parameters the method depends on (loadOptionsDependsOn), e.g. {documentId: {...}}' },
-        timeoutMs: { type: 'integer', minimum: 5000, maximum: 600000, description: 'Request timeout in ms (default 30000)' },
+        timeoutMs: { type: 'integer', minimum: 5000, maximum: 600000, description: 'Whole-call timeout in ms, including connection, tool discovery and execution (default 30000)' },
       },
       required: ['nodeType', 'version', 'methodName', 'methodType', 'credentialType', 'credentialId'],
     },

--- a/src/services/n8n-official-mcp-client.ts
+++ b/src/services/n8n-official-mcp-client.ts
@@ -94,6 +94,32 @@ export const OFFICIAL_MCP_FAILURE_TTL_MS = 30_000;
 export const OFFICIAL_RESULT_MAX_BYTES = 256 * 1024;
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+function timeoutError(): OfficialMcpError {
+  return new OfficialMcpError('OFFICIAL_MCP_TIMEOUT', 'Request to n8n MCP server timed out');
+}
+
+function remainingTimeout(deadlineAt: number): number {
+  const remaining = deadlineAt - Date.now();
+  if (remaining <= 0) throw timeoutError();
+  return remaining;
+}
+
+/** Bounds one caller's wait without cancelling work shared with other callers. */
+async function waitUntilDeadline<T>(promise: Promise<T>, deadlineAt: number): Promise<T> {
+  const timeoutMs = remainingTimeout(deadlineAt);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(timeoutError()), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 /** Errors are mapped by transport status first, then by MCP error code; anything else is a transport error. */
 export function mapOfficialTransportError(err: unknown): OfficialMcpError {
   if (err instanceof OfficialMcpError) return err;
@@ -247,51 +273,57 @@ export class N8nOfficialMcpClient {
     this.host = new URL(opts.endpoint).host;
   }
 
-  private async connect(): Promise<Connected> {
+  private async connect(deadlineAt: number): Promise<Connected> {
     // A closed client is terminal: reconnecting here would resurrect a
     // transport the owner already disposed of (an evicted cache entry, a
     // shut-down server).
     if (this.closed) throw new OfficialMcpError('OFFICIAL_MCP_TRANSPORT_ERROR', 'Client is closed');
+    remainingTimeout(deadlineAt);
     if (this.client) return { client: this.client, generation: this.generation };
-    if (this.connecting) return this.connecting;
-    const myGeneration = this.generation;
-    this.connecting = (async () => {
-      const validation = await SSRFProtection.validateWebhookUrl(this.endpoint);
-      if (!validation.valid) throw new OfficialMcpError('OFFICIAL_MCP_URL_REJECTED', validation.reason || 'Endpoint rejected');
-      // DNS validation is the first await in this handshake, and close() can
-      // run while it is pending. Check before anything is created: the
-      // post-handshake check below can only tear down a transport that was
-      // already opened, which still sends a request to an instance the owner
-      // has stopped talking to.
-      if (this.closed || this.generation !== myGeneration) {
-        throw new OfficialMcpError('OFFICIAL_MCP_TRANSPORT_ERROR', 'Client was closed while connecting');
-      }
-      const addresses = validation.addresses ?? (validation.address ? [{ address: validation.address, family: validation.family as 4 | 6 }] : []);
-      const pinned = SSRFProtection.createPinnedFetch(addresses);
-      const transport = new StreamableHTTPClientTransport(new URL(this.endpoint), {
-        requestInit: { headers: { Authorization: `Bearer ${this.token}` } },
-        fetch: pinned.fetch,
-      });
-      const client = new Client({ name: 'n8n-mcp', version: PROJECT_VERSION }, { capabilities: {}, jsonSchemaValidator: PERMISSIVE_JSON_SCHEMA_VALIDATOR });
-      try {
-        await client.connect(transport, { timeout: DEFAULT_TIMEOUT_MS });
-      } catch (err) {
-        await pinned.close().catch(() => undefined);
-        throw mapOfficialTransportError(err);
-      }
-      if (this.closed || this.generation !== myGeneration) {
-        // close() (or a concurrent reset) ran while this handshake was in
-        // flight. Nothing else references this client/pinned pair, so it
-        // must be torn down here — otherwise the transport and its pinned
-        // undici dispatcher leak.
-        await closeTransport(client, pinned);
-        throw new OfficialMcpError('OFFICIAL_MCP_TRANSPORT_ERROR', 'Client was closed while connecting');
-      }
-      this.client = client; this.pinned = pinned; this.hasConnectedSuccessfully = true;
-      logger.debug('Connected to n8n MCP server', { host: this.host });
-      return { client, generation: this.generation };
-    })();
-    try { return await this.connecting; } finally { this.connecting = null; }
+    if (!this.connecting) {
+      const myGeneration = this.generation;
+      const connecting = (async () => {
+        const validation = await SSRFProtection.validateWebhookUrl(this.endpoint);
+        if (!validation.valid) throw new OfficialMcpError('OFFICIAL_MCP_URL_REJECTED', validation.reason || 'Endpoint rejected');
+        // DNS validation is the first await in this handshake, and close() can
+        // run while it is pending. Check before anything is created: the
+        // post-handshake check below can only tear down a transport that was
+        // already opened, which still sends a request to an instance the owner
+        // has stopped talking to.
+        if (this.closed || this.generation !== myGeneration) {
+          throw new OfficialMcpError('OFFICIAL_MCP_TRANSPORT_ERROR', 'Client was closed while connecting');
+        }
+        const addresses = validation.addresses ?? (validation.address ? [{ address: validation.address, family: validation.family as 4 | 6 }] : []);
+        const pinned = SSRFProtection.createPinnedFetch(addresses);
+        const transport = new StreamableHTTPClientTransport(new URL(this.endpoint), {
+          requestInit: { headers: { Authorization: `Bearer ${this.token}` } },
+          fetch: pinned.fetch,
+        });
+        const client = new Client({ name: 'n8n-mcp', version: PROJECT_VERSION }, { capabilities: {}, jsonSchemaValidator: PERMISSIVE_JSON_SCHEMA_VALIDATOR });
+        try {
+          await client.connect(transport, { timeout: DEFAULT_TIMEOUT_MS });
+        } catch (err) {
+          await pinned.close().catch(() => undefined);
+          throw mapOfficialTransportError(err);
+        }
+        if (this.closed || this.generation !== myGeneration) {
+          // close() (or a concurrent reset) ran while this handshake was in
+          // flight. Nothing else references this client/pinned pair, so it
+          // must be torn down here, otherwise the transport and its pinned
+          // undici dispatcher leak.
+          await closeTransport(client, pinned);
+          throw new OfficialMcpError('OFFICIAL_MCP_TRANSPORT_ERROR', 'Client was closed while connecting');
+        }
+        this.client = client; this.pinned = pinned; this.hasConnectedSuccessfully = true;
+        logger.debug('Connected to n8n MCP server', { host: this.host });
+        return { client, generation: this.generation };
+      })();
+      this.connecting = connecting;
+      void connecting.finally(() => {
+        if (this.connecting === connecting) this.connecting = null;
+      }).catch(() => undefined);
+    }
+    return waitUntilDeadline(this.connecting, deadlineAt);
   }
 
   /** Discards the stored client/pinned pair, but only if it is still the one identified by `generation` — a stale caller (superseded by a later reset or reconnect) is a no-op. */
@@ -303,14 +335,15 @@ export class N8nOfficialMcpClient {
     await closeTransport(client, pinned);
   }
 
-  async capabilities(force = false): Promise<OfficialMcpCapabilities> {
+  async capabilities(force = false, opts: { deadlineAt?: number } = {}): Promise<OfficialMcpCapabilities> {
     const ttl = this.caps?.reachable === false ? OFFICIAL_MCP_FAILURE_TTL_MS : OFFICIAL_MCP_CACHE_TTL_MS;
     if (!force && this.caps && Date.now() - this.caps.checkedAt < ttl) return this.caps;
+    const deadlineAt = opts.deadlineAt ?? Date.now() + DEFAULT_TIMEOUT_MS;
     let generation: number | undefined;
     try {
-      const connected = await this.connect();
+      const connected = await this.connect(deadlineAt);
       generation = connected.generation;
-      const { tools } = await connected.client.listTools(undefined, { timeout: DEFAULT_TIMEOUT_MS });
+      const { tools } = await connected.client.listTools(undefined, { timeout: remainingTimeout(deadlineAt) });
       const toolNames = tools.map(t => t.name);
       this.caps = { reachable: true, toolCount: toolNames.length, toolNames, agentTools: toolNames.some(n => (AGENT_TOOL_NAMES as readonly string[]).includes(n)), checkedAt: Date.now() };
     } catch (err) {
@@ -320,7 +353,11 @@ export class N8nOfficialMcpClient {
       // callTool), and a protocol error means n8n answered — in both cases
       // the transport is still usable and may be shared with other calls.
       if (mapped.retryable && generation !== undefined) await this.resetTransport(generation);
-      this.caps = { reachable: false, toolCount: 0, toolNames: [], agentTools: false, checkedAt: Date.now(), error: mapped.code };
+      const failure: OfficialMcpCapabilities = { reachable: false, toolCount: 0, toolNames: [], agentTools: false, checkedAt: Date.now(), error: mapped.code };
+      // This deadline belongs to one caller. The shared connection may still
+      // complete for another caller, so a timeout is not endpoint health.
+      if (mapped.code === 'OFFICIAL_MCP_TIMEOUT') return failure;
+      this.caps = failure;
     }
     return this.caps;
   }
@@ -341,13 +378,14 @@ export class N8nOfficialMcpClient {
    * a non-error result with no `structuredContent` on a tool that declares an
    * output schema.
    */
-  async callTool(name: string, args: Record<string, unknown>, opts: { timeoutMs?: number; idempotent?: boolean } = {}): Promise<OfficialToolResult> {
+  async callTool(name: string, args: Record<string, unknown>, opts: { timeoutMs?: number; idempotent?: boolean; deadlineAt?: number } = {}): Promise<OfficialToolResult> {
     const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const deadlineAt = opts.deadlineAt ?? Date.now() + timeout;
     const state: { generation?: number } = {};
     const attempt = async (): Promise<OfficialToolResult> => {
-      const { client, generation } = await this.connect();
+      const { client, generation } = await this.connect(deadlineAt);
       state.generation = generation;
-      const raw = await client.callTool({ name, arguments: args }, undefined, { timeout });
+      const raw = await client.callTool({ name, arguments: args }, undefined, { timeout: remainingTimeout(deadlineAt) });
       return parseResult(raw as any);
     };
     logger.debug('Calling n8n MCP tool', { host: this.host, tool: name });

--- a/tests/helpers/fake-official-mcp-server.ts
+++ b/tests/helpers/fake-official-mcp-server.ts
@@ -37,6 +37,7 @@ export interface FakeOfficialMcpOptions {
   token?: string;
   raw?: { status: number; body: string; contentType?: string };
   jsonRpcError?: FakeJsonRpcError;
+  methodDelayMs?: Partial<Record<string, number>>;
 }
 export interface FakeOfficialMcp {
   url: string;
@@ -125,6 +126,8 @@ export async function startFakeOfficialMcp(opts: FakeOfficialMcpOptions = {}): P
       if (req.method === 'GET') { res.statusCode = 405; res.end(); return; }
       const body = req.method === 'POST' ? await readBody(req) : undefined;
       const rpc = body as { id?: unknown; method?: string } | undefined;
+      const delayMs = rpc?.method ? opts.methodDelayMs?.[rpc.method] : undefined;
+      if (delayMs) await new Promise(resolve => setTimeout(resolve, delayMs));
       if (jsonRpcError && rpc?.method === jsonRpcError.method) {
         res.statusCode = 200;
         res.setHeader('content-type', 'application/json');

--- a/tests/unit/mcp/handlers-official-tools.test.ts
+++ b/tests/unit/mcp/handlers-official-tools.test.ts
@@ -38,7 +38,11 @@ describe('handleExploreNodeResources', () => {
   it('forwards the validated args and returns data verbatim', async () => {
     const client = fakeClient(['explore_node_resources']); access.getOfficialMcpClient.mockReturnValue(client);
     const r = await handleExploreNodeResources({ ...VALID, filter: 'gen', timeoutMs: 60000 });
-    expect(client.callTool).toHaveBeenCalledWith('explore_node_resources', { ...VALID, filter: 'gen' }, { timeoutMs: 60000, idempotent: true });
+    expect(client.callTool).toHaveBeenCalledWith('explore_node_resources', { ...VALID, filter: 'gen' }, {
+      timeoutMs: 60000,
+      idempotent: true,
+      deadlineAt: expect.any(Number),
+    });
     expect(r).toMatchObject({ success: true, officialTool: 'explore_node_resources', data: { results: [{ value: 'C1' }] } });
   });
   it('OFFICIAL_MCP_TOOL_UNAVAILABLE when the instance lacks the tool', async () => {
@@ -114,7 +118,11 @@ describe('handleListCatalog', () => {
     const client = fakeClient(['search_projects'], { ok: true, data: [{ id: 'p1', name: 'Personal', type: 'personal' }] });
     access.getOfficialMcpClient.mockReturnValue(client);
     const r = await handleListCatalog({ kind: 'projects' });
-    expect(client.callTool).toHaveBeenCalledWith('search_projects', {}, { timeoutMs: 30000, idempotent: true });
+    expect(client.callTool).toHaveBeenCalledWith('search_projects', {}, {
+      timeoutMs: 30000,
+      idempotent: true,
+      deadlineAt: expect.any(Number),
+    });
     expect(r).toMatchObject({ success: true, backend: 'official-mcp', data: { teamProjectsEnabled: false, items: [{ id: 'p1', personal: true }] } });
   });
   it('uses the official teamProjectsEnabled flag when present, even with only a personal project returned', async () => {
@@ -315,6 +323,25 @@ describe('callOfficialTool over the wire', () => {
     await connect([{ name: 'get_workflow_history', handler: () => ({ success: true, workflowId: 'w', versions: [{ id: 1 }], count: 1 }) }]);
     const r: any = await callOfficialTool(undefined, ['get_workflow_history'], { workflowId: 'w' }, 30000, 'workflow_versions', true);
     expect(r).toMatchObject({ success: true, data: { success: true, count: 1 } });
+  });
+
+  it('uses one timeout budget for connection, discovery, and the tool call', async () => {
+    fake = await startFakeOfficialMcp({
+      methodDelayMs: { initialize: 50, 'tools/list': 50 },
+      tools: [{
+        name: 'get_workflow_history',
+        handler: () => new Promise(resolve => setTimeout(
+          () => resolve({ success: true, workflowId: 'w', versions: [], count: 0 }),
+          50,
+        )),
+      }],
+    });
+    client = new N8nOfficialMcpClient({ endpoint: fake.url, token: 'tok' });
+    access.getOfficialMcpClient.mockReturnValue(client);
+
+    const r = await callOfficialTool(undefined, ['get_workflow_history'], { workflowId: 'w' }, 120, 'workflow_versions', true);
+
+    expect(r).toMatchObject({ success: false, code: 'OFFICIAL_MCP_TIMEOUT' });
   });
 
   it('names the minimum n8n version when the instance lacks the tool', async () => {

--- a/tests/unit/services/n8n-official-mcp-client.test.ts
+++ b/tests/unit/services/n8n-official-mcp-client.test.ts
@@ -12,19 +12,31 @@ afterAll(() => { if (savedMode === undefined) delete process.env.WEBHOOK_SECURIT
 function spyOnPinnedFetch() {
   const original = SSRFProtection.createPinnedFetch.bind(SSRFProtection);
   let failNext = false;
+  let failNextDelayMs = 0;
   const spy = vi.spyOn(SSRFProtection, 'createPinnedFetch').mockImplementation((addresses) => {
     const real = original(addresses);
     return {
       fetch: (url, init) => {
         // A genuine connection-level error: rejects with no HTTP status, the
         // same shape a socket reset or DNS failure produces.
-        if (failNext) { failNext = false; return Promise.reject(new Error('simulated socket reset')); }
+        if (failNext) {
+          failNext = false;
+          const delayMs = failNextDelayMs;
+          failNextDelayMs = 0;
+          return new Promise((_, reject) => setTimeout(() => reject(new Error('simulated socket reset')), delayMs));
+        }
         return real.fetch(url, init);
       },
       close: () => real.close(),
     };
   });
-  return { spy, breakNextFetch: () => { failNext = true; } };
+  return {
+    spy,
+    breakNextFetch: (delayMs = 0) => {
+      failNext = true;
+      failNextDelayMs = delayMs;
+    },
+  };
 }
 
 describe('N8nOfficialMcpClient', () => {
@@ -334,6 +346,21 @@ describe('N8nOfficialMcpClient', () => {
     }
   });
 
+  it('does not cache a capabilities timeout as an unreachable instance', async () => {
+    fake = await startFakeOfficialMcp({
+      methodDelayMs: { initialize: 100 },
+      tools: [{ name: 'search_agents' }],
+    });
+    const client = new N8nOfficialMcpClient({ endpoint: fake.url, token: 'tok' });
+
+    const timedOut = await client.capabilities(false, { deadlineAt: Date.now() + 50 });
+    expect(timedOut).toMatchObject({ reachable: false, error: 'OFFICIAL_MCP_TIMEOUT' });
+
+    const recovered = await client.capabilities();
+    expect(recovered).toMatchObject({ reachable: true, toolCount: 1 });
+    await client.close();
+  });
+
   // A failed reference must not be cached: an instance whose agents module is
   // still starting would otherwise serve that failure as the guide for the
   // whole success TTL.
@@ -398,6 +425,28 @@ describe('N8nOfficialMcpClient', () => {
     }
   });
 
+  it('does not reset the timeout budget when retrying a connection failure', async () => {
+    fake = await startFakeOfficialMcp({
+      tools: [
+        { name: 'warmup' },
+        { name: 'slow', handler: () => new Promise(resolve => setTimeout(() => resolve({ ok: true }), 100)) },
+      ],
+    });
+    const client = new N8nOfficialMcpClient({ endpoint: fake.url, token: 'tok' });
+    const { spy, breakNextFetch } = spyOnPinnedFetch();
+    try {
+      await client.callTool('warmup', {}, { idempotent: true });
+      breakNextFetch(80);
+
+      await expect(client.callTool('slow', {}, { timeoutMs: 150, idempotent: true }))
+        .rejects.toMatchObject({ code: 'OFFICIAL_MCP_TIMEOUT' });
+      expect(spy).toHaveBeenCalledTimes(2);
+    } finally {
+      spy.mockRestore();
+      await client.close();
+    }
+  });
+
   // A dead socket does not prove the request never reached n8n: create_agent,
   // publish_agent and call_agent may already have run. Only a call the caller
   // declares idempotent is re-sent.
@@ -456,6 +505,23 @@ describe('N8nOfficialMcpClient', () => {
     if (a.status === 'rejected') expect(a.reason).toMatchObject({ code: 'OFFICIAL_MCP_TIMEOUT' });
     expect(b.status).toBe('fulfilled');
     if (b.status === 'fulfilled') { expect(b.value.isError).toBe(false); expect(b.value.json).toEqual({ ok: true }); }
+    await client.close();
+  });
+
+  it('keeps concurrent connection waits on their own timeout budgets', async () => {
+    fake = await startFakeOfficialMcp({
+      methodDelayMs: { initialize: 100 },
+      tools: [{ name: 'fast' }],
+    });
+    const client = new N8nOfficialMcpClient({ endpoint: fake.url, token: 'tok' });
+    const [short, long] = await Promise.allSettled([
+      client.callTool('fast', {}, { timeoutMs: 50 }),
+      client.callTool('fast', {}, { timeoutMs: 300 }),
+    ]);
+
+    expect(short.status).toBe('rejected');
+    if (short.status === 'rejected') expect(short.reason).toMatchObject({ code: 'OFFICIAL_MCP_TIMEOUT' });
+    expect(long.status).toBe('fulfilled');
     await client.close();
   });
 


### PR DESCRIPTION
This makes `timeoutMs` one deadline for the full official MCP request. Connection setup and tool discovery now use the same budget as the tool call and its one allowed idempotent retry.

A timeout only stops that caller. It does not close shared connection work or cache the instance as unreachable.

Tests cover cold connections, discovery, retry budgeting, concurrent callers with different deadlines, and recovery after a capabilities timeout. The public timeout descriptions now match the behavior.

Testing:

- `tsc --noEmit`
- `tsc -p tsconfig.build.json`
- 212 focused unit tests
- 5,966 Windows-compatible unit tests

Closes #1032

Conceived by Romuald Członkowski - www.aiadvisors.pl/en
