### PR TITLE
fix: default executions action and versions mode to list, alias retired get_node vocabulary (#1051)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.79.0] - 2026-09-02
+
+### Changed
+
+- **The most common agent call errors now resolve instead of failing** ([#1051](https://github.com/czlonkowski/n8n-mcp/issues/1051)). Telemetry for the last week showed roughly 1,800 `error_occurred` events from three call shapes that carried enough information to act on. `n8n_executions` no longer requires `action`: an omitted value lists executions, and `action=get` without an `id` lists the executions of the given workflow (or recent executions) and says so in the response `message`; `delete` still requires `id`, and an unknown action gets a suggestion when the value belongs to another tool or is a common misspelling of `list`. `n8n_workflow_versions` defaults `mode` to `list`. `n8n_workflow_versions` and `n8n_test_workflow` accept `id` as an alias for `workflowId`, and the missing-parameter error of `n8n_test_workflow` names the parameter and the alias. `get_node` maps the retired `get_node_essentials` / `get_node_info` vocabulary onto the canonical parameters before validation: `mode` values `essentials`, `minimal`, `standard`, `full` and `operations` become `mode=info` at the matching `detail`, `properties` and `search` become `search_properties`, and `detail` values `essentials`, `summary` and `short` become `standard`, `minimal` and `minimal`. Aliases are logged at debug level; the schemas and documentation advertise only the canonical values. The `DISABLED_TOOL_OPERATIONS` policy treats an omitted `action` or `mode` as the new default, so a rule that disables `list` still applies, the `get`-without-`id` fallback refuses to list when `list` is disabled, and a filtered tool schema drops a `default` that names a disabled operation. Callers that already pass the canonical parameters see no change.
+
 ## [2.78.0] - 2026-09-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.77.0",
+  "version": "2.79.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.77.0",
+      "version": "2.79.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.78.0",
+  "version": "2.79.0",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.78.0",
+  "version": "2.79.0",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/src/mcp/handlers-n8n-manager.ts
+++ b/src/mcp/handlers-n8n-manager.ts
@@ -608,7 +608,7 @@ const cancelTestRunSchema = z.object({
 const versionIdValue = z.union([z.number().int(), z.string().min(1)]);
 
 const workflowVersionsSchema = z.object({
-  mode: z.enum(['list', 'get', 'rollback', 'delete', 'prune', 'diff']),
+  mode: z.preprocess(emptyToUndefined, z.enum(['list', 'get', 'rollback', 'delete', 'prune', 'diff']).default('list')),
   source: z.enum(['local', 'native']).optional(),
   workflowId: z.string().optional(),
   versionId: versionIdValue.optional(),

--- a/src/mcp/param-aliases.ts
+++ b/src/mcp/param-aliases.ts
@@ -103,7 +103,8 @@ export function suggestExecutionsAction(action: string): string | undefined {
 /**
  * Agents send `id` and `workflowId` interchangeably for tools whose only
  * identifier is a workflow id. Returns a copy of the arguments with
- * `workflowId` filled from `id` when the canonical key is absent or blank.
+ * `workflowId` filled from `id` when the canonical key is absent or blank; a
+ * blank `workflowId` that nothing replaces is removed.
  * `id` is not a schema property, so the server's type coercion never sees it
  * and a numeric value has to be accepted here.
  */
@@ -116,7 +117,8 @@ export function withWorkflowIdAlias<T extends Record<string, unknown>>(args: T):
   }
   const id = typeof args.id === 'number' ? String(args.id) : args.id;
   if (typeof id !== 'string' || id.trim() === '') {
-    return args;
+    // A blank workflowId with nothing to replace it is dropped so handlers see it as absent.
+    return typeof args.workflowId === 'string' ? { ...args, workflowId: undefined } : args;
   }
   return { ...args, workflowId: id };
 }

--- a/src/mcp/param-aliases.ts
+++ b/src/mcp/param-aliases.ts
@@ -1,0 +1,119 @@
+/**
+ * Aliases for parameter vocabulary that agents keep sending after a tool was
+ * renamed or consolidated. Each map is applied before validation so a caller
+ * using the old spelling gets the canonical behaviour instead of an error.
+ * The tool schemas and documentation advertise only the canonical values.
+ */
+
+import { logger } from '../utils/logger';
+
+/**
+ * `get_node` grew out of `get_node_essentials` / `get_node_info`, and prompts
+ * written against those tools still send their vocabulary as `mode` or
+ * `detail`. Retired values map onto the canonical `mode` + `detail` pair.
+ */
+const GET_NODE_MODE_ALIASES: Record<string, { mode: string; detail?: string }> = {
+  essentials: { mode: 'info', detail: 'standard' },
+  minimal: { mode: 'info', detail: 'minimal' },
+  standard: { mode: 'info', detail: 'standard' },
+  full: { mode: 'info', detail: 'full' },
+  operations: { mode: 'info', detail: 'standard' },
+  properties: { mode: 'search_properties' },
+  search: { mode: 'search_properties' },
+};
+
+const GET_NODE_DETAIL_ALIASES: Record<string, string> = {
+  essentials: 'standard',
+  summary: 'minimal',
+  short: 'minimal',
+};
+
+export interface GetNodeParams {
+  mode?: string;
+  detail?: string;
+}
+
+/**
+ * Resolves retired `mode` / `detail` spellings for `get_node` to canonical
+ * values. Unknown and non-string values pass through unchanged so the
+ * existing validation still names them in its error. Undefined stays
+ * undefined so the handler's own defaults apply.
+ */
+export function resolveGetNodeAliases(mode?: unknown, detail?: unknown): GetNodeParams {
+  const aliased: string[] = [];
+  let resolvedMode = mode as string | undefined;
+  let resolvedDetail = detail as string | undefined;
+
+  if (typeof resolvedDetail === 'string') {
+    const detailAlias = GET_NODE_DETAIL_ALIASES[resolvedDetail.toLowerCase()];
+    if (detailAlias) {
+      aliased.push(`detail=${resolvedDetail}→${detailAlias}`);
+      resolvedDetail = detailAlias;
+    }
+  }
+
+  if (typeof resolvedMode === 'string') {
+    const modeAlias = GET_NODE_MODE_ALIASES[resolvedMode.toLowerCase()];
+    if (modeAlias) {
+      // A retired mode value is the caller's statement of intent for the
+      // detail level too (mode=full meant "everything"), so it wins over a
+      // detail value that most clients only send because the schema defaults it.
+      const target = modeAlias.detail
+        ? `mode=${modeAlias.mode}, detail=${modeAlias.detail}`
+        : `mode=${modeAlias.mode}`;
+      aliased.push(`mode=${resolvedMode}→${target}`);
+      resolvedMode = modeAlias.mode;
+      if (modeAlias.detail) resolvedDetail = modeAlias.detail;
+    }
+  }
+
+  if (aliased.length > 0) {
+    logger.debug(`get_node: retired parameter vocabulary aliased (${aliased.join('; ')})`);
+  }
+
+  return { mode: resolvedMode, detail: resolvedDetail };
+}
+
+/**
+ * Suggestions for `n8n_executions` action values seen in telemetry that belong
+ * to other tools or to no tool. Returned text is appended to the unknown-action
+ * error so the caller can correct itself in one step.
+ */
+const EXECUTIONS_ACTION_HINTS: Record<string, string> = {
+  get_many: "Did you mean action='list'?",
+  getmany: "Did you mean action='list'?",
+  getall: "Did you mean action='list'?",
+  get_all: "Did you mean action='list'?",
+  list_executions: "Did you mean action='list'?",
+  listexecutions: "Did you mean action='list'?",
+  search: "Did you mean action='list'?",
+  get_execution: "Did you mean action='get'?",
+  getexecution: "Did you mean action='get'?",
+  retry: "Retrying an execution is not supported; re-run the workflow with n8n_test_workflow.",
+  list_runs: 'Evaluation test runs are managed by n8n_evaluations.',
+  get_run: 'Evaluation test runs are managed by n8n_evaluations.',
+  getrows: 'Data table rows are managed by n8n_manage_datatable.',
+  get_rows: 'Data table rows are managed by n8n_manage_datatable.',
+};
+
+export function suggestExecutionsAction(action: string): string | undefined {
+  return EXECUTIONS_ACTION_HINTS[action.toLowerCase()];
+}
+
+/**
+ * Agents send `id` and `workflowId` interchangeably for tools whose only
+ * identifier is a workflow id. Returns a copy of the arguments with
+ * `workflowId` filled from `id` when the canonical key is absent or blank.
+ * `id` is not a schema property, so the server's type coercion never sees it
+ * and a numeric value has to be accepted here.
+ */
+export function withWorkflowIdAlias<T extends Record<string, unknown>>(args: T): T {
+  if (typeof args.workflowId === 'string' && args.workflowId.trim() !== '') {
+    return args;
+  }
+  const id = typeof args.id === 'number' ? String(args.id) : args.id;
+  if (typeof id !== 'string' || id.trim() === '') {
+    return args;
+  }
+  return { ...args, workflowId: id };
+}

--- a/src/mcp/param-aliases.ts
+++ b/src/mcp/param-aliases.ts
@@ -108,7 +108,10 @@ export function suggestExecutionsAction(action: string): string | undefined {
  * and a numeric value has to be accepted here.
  */
 export function withWorkflowIdAlias<T extends Record<string, unknown>>(args: T): T {
-  if (typeof args.workflowId === 'string' && args.workflowId.trim() !== '') {
+  const workflowIdMissing = args.workflowId === undefined || args.workflowId === null
+    || (typeof args.workflowId === 'string' && args.workflowId.trim() === '');
+  if (!workflowIdMissing) {
+    // A non-string workflowId is left for validation to reject rather than overwritten.
     return args;
   }
   const id = typeof args.id === 'number' ? String(args.id) : args.id;
@@ -116,4 +119,9 @@ export function withWorkflowIdAlias<T extends Record<string, unknown>>(args: T):
     return args;
   }
   return { ...args, workflowId: id };
+}
+
+/** True when the value is a string with content once trimmed. */
+export function hasText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -27,7 +27,7 @@ import {
 import { makeToolsN8nFriendly } from './tools-n8n-friendly';
 import { getWorkflowExampleString } from './workflow-examples';
 import { logger } from '../utils/logger';
-import { resolveGetNodeAliases, suggestExecutionsAction, withWorkflowIdAlias } from './param-aliases';
+import { hasText, resolveGetNodeAliases, suggestExecutionsAction, withWorkflowIdAlias } from './param-aliases';
 import { installStdioGuard } from '../utils/stdio-guard';
 import { summarizeToolCallArgs } from '../utils/redaction';
 import { NodeRepository } from '../database/node-repository';
@@ -1304,7 +1304,7 @@ export class N8NDocumentationMCPServer {
         validationResult = { valid: true, errors: [] };
         break;
       case 'n8n_test_workflow':
-        validationResult = typeof args.workflowId === 'string' && args.workflowId.trim() !== ''
+        validationResult = hasText(args.workflowId)
           ? { valid: true, errors: [] }
           : {
               valid: false,
@@ -1607,7 +1607,7 @@ export class N8NDocumentationMCPServer {
     }
     const result = await n8nHandlers.handleListExecutions(args, this.instanceContext);
     if (!result.success) return result;
-    const scope = args.workflowId ? `executions of workflow ${args.workflowId}` : 'recent executions';
+    const scope = hasText(args.workflowId) ? `executions of workflow ${args.workflowId}` : 'recent executions';
     return {
       ...result,
       message: `action=get was called without an execution id, so ${scope} were listed instead. Pass id to get one execution.`
@@ -1846,14 +1846,14 @@ export class N8NDocumentationMCPServer {
         const execAction = String(resolveRequestedOperation(name, args));
         switch (execAction) {
           case 'get':
-            if (!args.id) {
+            if (!hasText(args.id)) {
               return this.listExecutionsInsteadOfGet(args);
             }
             return n8nHandlers.handleGetExecution(args, this.instanceContext);
           case 'list':
             return n8nHandlers.handleListExecutions(args, this.instanceContext);
           case 'delete':
-            if (!args.id) {
+            if (!hasText(args.id)) {
               throw new Error('id is required for action=delete');
             }
             return n8nHandlers.handleDeleteExecution(args, this.instanceContext);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -3351,7 +3351,9 @@ Full documentation is being prepared. For now, use get_node_essentials for confi
     }
 
     if (!validModes.includes(mode)) {
-      throw new Error(`get_node: Invalid mode "${mode}". Valid options: ${validModes.join(', ')}`);
+      // docs and search_properties are dispatched before this method; list them so the
+      // error names every mode the tool accepts.
+      throw new Error(`get_node: Invalid mode "${mode}". Valid options: info, docs, search_properties, ${validModes.slice(1).join(', ')}`);
     }
 
     const normalizedType = NodeTypeNormalizer.normalizeToFullForm(nodeType);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -676,9 +676,9 @@ export class N8NDocumentationMCPServer {
       const remaining = [...getValidOperations(toolName)].filter(v => !ops.has(v));
 
       const param = cloned.inputSchema?.properties?.[paramName];
+      let defaultRemoved = false;
       if (param?.enum) {
         param.enum = (param.enum as string[]).filter(v => !ops.has(v.toLowerCase()));
-        let defaultRemoved = false;
         if (typeof param.default === 'string' && ops.has(param.default.toLowerCase())) {
           delete param.default;
           defaultRemoved = true;
@@ -698,7 +698,8 @@ export class N8NDocumentationMCPServer {
       }
 
       const disabledList = [...ops].join(', ');
-      cloned.description = `${cloned.description}\n\n> Operations disabled by server policy: ${disabledList}`;
+      cloned.description = `${cloned.description}\n\n> Operations disabled by server policy: ${disabledList}`
+        + (defaultRemoved ? `. The default for ${paramName} was one of them, so ${paramName} must be passed explicitly.` : '');
 
       // If filtering removed every destructive operation, the tool is now
       // read-only — recompute its MCP annotations so hosts that honor them

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,6 +10,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ToolDefinition } from '../types';
+import type { McpToolResponse } from '../types/n8n-api';
 import { existsSync, readFileSync, promises as fs } from 'fs';
 import path from 'path';
 import { n8nDocumentationToolsFinal } from './tools';
@@ -20,11 +21,13 @@ import {
   getDisabledTools as getDisabledToolsPolicy,
   getDisabledToolOperations as getDisabledToolOperationsPolicy,
   getValidOperations,
+  isOperationDisabled,
   resolveRequestedOperation,
 } from './tool-policy';
 import { makeToolsN8nFriendly } from './tools-n8n-friendly';
 import { getWorkflowExampleString } from './workflow-examples';
 import { logger } from '../utils/logger';
+import { resolveGetNodeAliases, suggestExecutionsAction, withWorkflowIdAlias } from './param-aliases';
 import { installStdioGuard } from '../utils/stdio-guard';
 import { summarizeToolCallArgs } from '../utils/redaction';
 import { NodeRepository } from '../database/node-repository';
@@ -675,6 +678,9 @@ export class N8NDocumentationMCPServer {
       const param = cloned.inputSchema?.properties?.[paramName];
       if (param?.enum) {
         param.enum = (param.enum as string[]).filter(v => !ops.has(v.toLowerCase()));
+        if (typeof param.default === 'string' && ops.has(param.default.toLowerCase())) {
+          delete param.default;
+        }
         if (param.enum.length === 0) {
           logger.warn(
             `DISABLED_TOOL_OPERATIONS: all operations for '${toolName}' are disabled ` +
@@ -1291,10 +1297,19 @@ export class N8NDocumentationMCPServer {
         validationResult = ToolValidation.validateWorkflowId(args);
         break;
       case 'n8n_executions':
-        // Requires action parameter, id validation done in handler based on action
-        validationResult = args.action
+        // action defaults to list; id validation is done in dispatch based on action
+        validationResult = { valid: true, errors: [] };
+        break;
+      case 'n8n_test_workflow':
+        validationResult = typeof args.workflowId === 'string' && args.workflowId.trim() !== ''
           ? { valid: true, errors: [] }
-          : { valid: false, errors: [{ field: 'action', message: 'action is required' }] };
+          : {
+              valid: false,
+              errors: [{
+                field: 'workflowId',
+                message: 'workflowId is required: the ID of the workflow to run ("id" is accepted as an alias)'
+              }]
+            };
         break;
       case 'n8n_evaluations': {
         // Every action of this tool requires action and workflowId;
@@ -1576,6 +1591,26 @@ export class N8NDocumentationMCPServer {
     return coerced;
   }
 
+  /**
+   * `n8n_executions` with action=get but no execution id is the most frequent
+   * agent call error in telemetry, and the caller wants the listing. Serve it
+   * and say so, rather than failing the call.
+   */
+  private async listExecutionsInsteadOfGet(args: any): Promise<McpToolResponse> {
+    // The policy gate checked this call as `get`; the fallback must not open a
+    // listing that a DISABLED_TOOL_OPERATIONS rule has closed.
+    if (isOperationDisabled('n8n_executions', 'list')) {
+      throw new Error('id is required for action=get');
+    }
+    const result = await n8nHandlers.handleListExecutions(args, this.instanceContext);
+    if (!result.success) return result;
+    const scope = args.workflowId ? `executions of workflow ${args.workflowId}` : 'recent executions';
+    return {
+      ...result,
+      message: `action=get was called without an execution id, so ${scope} were listed instead. Pass id to get one execution.`
+    };
+  }
+
   async executeTool(name: string, args: any): Promise<any> {
     // Ensure args is an object and validate it
     args = args || {};
@@ -1628,13 +1663,15 @@ export class N8NDocumentationMCPServer {
           includeOperations: args.includeOperations,
           source: args.source
         });
-      case 'get_node':
+      case 'get_node': {
         this.validateToolParams(name, args, ['nodeType']);
+        // Retired get_node_essentials / get_node_info vocabulary maps onto mode + detail
+        const { mode: nodeMode, detail: nodeDetail } = resolveGetNodeAliases(args.mode, args.detail);
         // Handle consolidated modes: docs, search_properties
-        if (args.mode === 'docs') {
+        if (nodeMode === 'docs') {
           return this.getNodeDocumentation(args.nodeType);
         }
-        if (args.mode === 'search_properties') {
+        if (nodeMode === 'search_properties') {
           if (!args.propertyQuery) {
             throw new Error('propertyQuery is required for mode=search_properties');
           }
@@ -1643,13 +1680,14 @@ export class N8NDocumentationMCPServer {
         }
         return this.getNode(
           args.nodeType,
-          args.detail,
-          args.mode,
+          nodeDetail,
+          nodeMode,
           args.includeTypeInfo,
           args.includeExamples,
           args.fromVersion,
           args.toVersion
         );
+      }
       case 'validate_node':
         this.validateToolParams(name, args, ['nodeType', 'config']);
         // Ensure config is an object
@@ -1792,16 +1830,21 @@ export class N8NDocumentationMCPServer {
         await this.ensureInitialized();
         if (!this.repository) throw new Error('Repository not initialized');
         return n8nHandlers.handleAutofixWorkflow(args, this.repository, this.instanceContext);
-      case 'n8n_test_workflow':
-        this.validateToolParams(name, args, ['workflowId']);
-        return n8nHandlers.handleTestWorkflow(args, this.instanceContext);
+      case 'n8n_test_workflow': {
+        const testArgs = withWorkflowIdAlias(args);
+        this.validateToolParams(name, testArgs);
+        return n8nHandlers.handleTestWorkflow(testArgs, this.instanceContext);
+      }
       case 'n8n_executions': {
-        this.validateToolParams(name, args, ['action']);
-        const execAction = args.action;
+        this.validateToolParams(name, args);
+        // Agents that only want a listing often omit action or send get without an id.
+        // The same normalisation the policy gate uses, so a disabled-operation rule
+        // and the dispatch always see the same value.
+        const execAction = String(resolveRequestedOperation(name, args));
         switch (execAction) {
           case 'get':
             if (!args.id) {
-              throw new Error('id is required for action=get');
+              return this.listExecutionsInsteadOfGet(args);
             }
             return n8nHandlers.handleGetExecution(args, this.instanceContext);
           case 'list':
@@ -1811,8 +1854,11 @@ export class N8NDocumentationMCPServer {
               throw new Error('id is required for action=delete');
             }
             return n8nHandlers.handleDeleteExecution(args, this.instanceContext);
-          default:
-            throw new Error(`Unknown action: ${execAction}. Valid actions: get, list, delete`);
+          default: {
+            const message = `Unknown action: ${execAction}. Valid actions: get, list, delete.`;
+            const hint = suggestExecutionsAction(execAction);
+            throw new Error(hint ? `${message} ${hint}` : message);
+          }
         }
       }
       case 'n8n_evaluations': {
@@ -1849,8 +1895,8 @@ export class N8NDocumentationMCPServer {
         }
         return n8nHandlers.handleHealthCheck(this.instanceContext);
       case 'n8n_workflow_versions':
-        this.validateToolParams(name, args, ['mode']);
-        return n8nHandlers.handleWorkflowVersions(args, this.repository!, this.instanceContext);
+        // mode defaults to list in the handler schema; workflowId is filled from id
+        return n8nHandlers.handleWorkflowVersions(withWorkflowIdAlias(args), this.repository!, this.instanceContext);
 
       case 'n8n_deploy_template':
         this.validateToolParams(name, args, ['templateId']);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -678,8 +678,10 @@ export class N8NDocumentationMCPServer {
       const param = cloned.inputSchema?.properties?.[paramName];
       if (param?.enum) {
         param.enum = (param.enum as string[]).filter(v => !ops.has(v.toLowerCase()));
+        let defaultRemoved = false;
         if (typeof param.default === 'string' && ops.has(param.default.toLowerCase())) {
           delete param.default;
+          defaultRemoved = true;
         }
         if (param.enum.length === 0) {
           logger.warn(
@@ -690,7 +692,8 @@ export class N8NDocumentationMCPServer {
         }
         if (param.description) {
           const disabledList = [...ops].join(', ');
-          param.description = `${param.description} (disabled by server policy: ${disabledList})`;
+          param.description = `${param.description} (disabled by server policy: ${disabledList}`
+            + `${defaultRemoved ? '; no default, pass a value' : ''})`;
         }
       }
 

--- a/src/mcp/tool-docs/workflow_management/n8n-executions.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-executions.ts
@@ -37,7 +37,7 @@ export const n8nExecutionsDoc: ToolDocumentation = {
 - Token-efficient (80-90% smaller than full mode)`,
     parameters: {
       action: { type: 'string', required: false, description: 'Operation: "get", "list" (default), or "delete". "get" without an id lists executions instead' },
-      id: { type: 'string', required: false, description: 'Execution ID (required for action=get or action=delete)' },
+      id: { type: 'string', required: false, description: 'Execution ID. Required for action=delete; for action=get, omitting it lists executions instead' },
       mode: { type: 'string', required: false, description: 'For action=get: "preview", "summary" (default), "filtered", "full", "error"' },
       nodeNames: { type: 'array', required: false, description: 'For action=get with mode=filtered: Filter to specific nodes by name' },
       itemsLimit: { type: 'number', required: false, description: 'For action=get with mode=filtered: Items per node (0=structure, 2=default, -1=unlimited)' },

--- a/src/mcp/tool-docs/workflow_management/n8n-executions.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-executions.ts
@@ -36,7 +36,7 @@ export const n8nExecutionsDoc: ToolDocumentation = {
 - Provides AI-friendly fix suggestions based on error patterns
 - Token-efficient (80-90% smaller than full mode)`,
     parameters: {
-      action: { type: 'string', required: true, description: 'Operation: "get", "list", or "delete"' },
+      action: { type: 'string', required: false, description: 'Operation: "get", "list" (default), or "delete". "get" without an id lists executions instead' },
       id: { type: 'string', required: false, description: 'Execution ID (required for action=get or action=delete)' },
       mode: { type: 'string', required: false, description: 'For action=get: "preview", "summary" (default), "filtered", "full", "error"' },
       nodeNames: { type: 'array', required: false, description: 'For action=get with mode=filtered: Filter to specific nodes by name' },

--- a/src/mcp/tool-docs/workflow_management/n8n-test-workflow.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-test-workflow.ts
@@ -52,7 +52,7 @@ Every response states \`method\` and \`backend\` ('public-api' or 'official-mcp'
       workflowId: {
         type: 'string',
         required: true,
-        description: 'Workflow ID to execute'
+        description: 'Workflow ID to execute ("id" is accepted as an alias)'
       },
       method: {
         type: 'string',

--- a/src/mcp/tool-docs/workflow_management/n8n-workflow-versions.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-workflow-versions.ts
@@ -97,8 +97,8 @@ per workflow, plus an age-based retention window). Native history retention is n
     parameters: {
       mode: {
         type: 'string',
-        required: true,
-        description: 'Operation mode: "list", "get", "rollback", "diff", "delete", or "prune"',
+        required: false,
+        description: 'Operation mode: "list" (default), "get", "rollback", "diff", "delete", or "prune"',
         enum: ['list', 'get', 'rollback', 'delete', 'prune', 'diff']
       },
       source: {

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -487,7 +487,7 @@ export const n8nManagementTools: ToolDefinition[] = [
         // For action='get' and action='delete'
         id: {
           type: 'string',
-          description: 'Execution ID (required for action=get or action=delete)'
+          description: 'Execution ID. Required for action=delete; for action=get, omitting it lists executions instead'
         },
         // For action='get' - detail level
         mode: {

--- a/src/mcp/tools-n8n-manager.ts
+++ b/src/mcp/tools-n8n-manager.ts
@@ -474,14 +474,15 @@ export const n8nManagementTools: ToolDefinition[] = [
   },
   {
     name: 'n8n_executions',
-    description: `Manage workflow executions: get details, list, or delete. Use action='get' with id for execution details, action='list' for listing executions, action='delete' to remove execution record.`,
+    description: `Manage workflow executions: get details, list, or delete. Use action='get' with id for execution details, action='list' (the default) for listing executions, action='delete' to remove execution record.`,
     inputSchema: {
       type: 'object',
       properties: {
         action: {
           type: 'string',
           enum: ['get', 'list', 'delete'],
-          description: 'Operation: get=get execution details, list=list executions, delete=delete execution'
+          default: 'list',
+          description: 'Operation: get=get execution details, list=list executions (default), delete=delete execution'
         },
         // For action='get' and action='delete'
         id: {
@@ -550,8 +551,7 @@ export const n8nManagementTools: ToolDefinition[] = [
           type: 'boolean',
           description: 'For action=list: include execution data (default: false)'
         }
-      },
-      required: ['action']
+      }
     },
     annotations: {
       title: 'Manage Executions',
@@ -648,7 +648,8 @@ Two sources:
         mode: {
           type: 'string',
           enum: ['list', 'get', 'rollback', 'delete', 'prune', 'diff'],
-          description: 'Operation mode'
+          default: 'list',
+          description: 'Operation mode (default: list)'
         },
         source: {
           type: 'string',
@@ -704,8 +705,7 @@ Two sources:
           maximum: 600000,
           description: 'Client deadline for the native call (default 30000)'
         }
-      },
-      required: ['mode']
+      }
     },
     annotations: {
       title: 'Workflow Versions',
@@ -1001,7 +1001,9 @@ export const TOOL_OPERATION_PARAM: Record<string, string> = {
  * default here — otherwise an omitted value would slip past a rule naming it.
  */
 export const TOOL_OPERATION_DEFAULT: Record<string, string> = {
+  'n8n_executions': 'list',
   'n8n_test_workflow': 'auto',
+  'n8n_workflow_versions': 'list',
 };
 
 /**

--- a/tests/unit/mcp/agent-call-defaults.test.ts
+++ b/tests/unit/mcp/agent-call-defaults.test.ts
@@ -185,6 +185,7 @@ describe('agent call defaults and aliases (#1051)', () => {
       expect(action.enum).toEqual(['get', 'delete']);
       expect(action.default).toBeUndefined();
       expect(action.description).toContain('disabled by server policy: list; no default, pass a value)');
+      expect(filtered.get('n8n_executions').description).toContain('The default for action was one of them, so action must be passed explicitly.');
 
       const untouched = (server as any).buildFilteredToolDefinitions(new Map([['n8n_executions', new Set(['delete'])]]));
       expect(untouched.get('n8n_executions').inputSchema.properties.action.default).toBe('list');
@@ -204,6 +205,12 @@ describe('agent call defaults and aliases (#1051)', () => {
       await server.testExecuteTool('n8n_workflow_versions', { id: 'wf1' });
 
       expect(handlerMocks.handleWorkflowVersions.mock.calls[0][0]).toEqual({ id: 'wf1', workflowId: 'wf1' });
+    });
+
+    it('drops a blank workflowId so the handler reports it as missing', async () => {
+      await server.testExecuteTool('n8n_workflow_versions', { workflowId: '   ' });
+
+      expect(handlerMocks.handleWorkflowVersions.mock.calls[0][0]).toEqual({ workflowId: undefined });
     });
 
     it('keeps an explicit workflowId when both spellings are sent', async () => {

--- a/tests/unit/mcp/agent-call-defaults.test.ts
+++ b/tests/unit/mcp/agent-call-defaults.test.ts
@@ -112,6 +112,15 @@ describe('agent call defaults and aliases (#1051)', () => {
       expect(result.message).toContain('recent executions');
     });
 
+    it('treats a blank id as absent and a blank workflowId as unscoped', async () => {
+      const result = await server.testExecuteTool('n8n_executions', { action: 'get', id: '   ', workflowId: '  ' });
+
+      expect(handlerMocks.handleGetExecution).not.toHaveBeenCalled();
+      expect(handlerMocks.handleListExecutions).toHaveBeenCalledTimes(1);
+      expect(result.message).toContain('recent executions');
+      expect(result.message).not.toContain('executions of workflow');
+    });
+
     it('does not decorate a failed listing with the fallback note', async () => {
       handlerMocks.handleListExecutions.mockResolvedValue({ success: false, error: 'n8n API not configured' });
 
@@ -132,6 +141,8 @@ describe('agent call defaults and aliases (#1051)', () => {
 
     it('keeps delete strict about id', async () => {
       await expect(server.testExecuteTool('n8n_executions', { action: 'delete', workflowId: 'wf1' }))
+        .rejects.toThrow('id is required for action=delete');
+      await expect(server.testExecuteTool('n8n_executions', { action: 'delete', id: '   ' }))
         .rejects.toThrow('id is required for action=delete');
       expect(handlerMocks.handleDeleteExecution).not.toHaveBeenCalled();
       expect(handlerMocks.handleListExecutions).not.toHaveBeenCalled();

--- a/tests/unit/mcp/agent-call-defaults.test.ts
+++ b/tests/unit/mcp/agent-call-defaults.test.ts
@@ -173,6 +173,7 @@ describe('agent call defaults and aliases (#1051)', () => {
       const action = filtered.get('n8n_executions').inputSchema.properties.action;
       expect(action.enum).toEqual(['get', 'delete']);
       expect(action.default).toBeUndefined();
+      expect(action.description).toContain('disabled by server policy: list; no default, pass a value)');
 
       const untouched = (server as any).buildFilteredToolDefinitions(new Map([['n8n_executions', new Set(['delete'])]]));
       expect(untouched.get('n8n_executions').inputSchema.properties.action.default).toBe('list');

--- a/tests/unit/mcp/agent-call-defaults.test.ts
+++ b/tests/unit/mcp/agent-call-defaults.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Issue #1051: the most frequent agent call errors came from missing defaults
+// and retired parameter names. These tests pin the server-level dispatch:
+// n8n_executions defaults action to list and serves get-without-id as a
+// listing; n8n_workflow_versions and n8n_test_workflow accept id for workflowId.
+const handlerMocks = vi.hoisted(() => ({
+  handleGetExecution: vi.fn().mockResolvedValue({ success: true, data: { handler: 'get' } }),
+  handleListExecutions: vi.fn().mockResolvedValue({ success: true, data: { handler: 'list' } }),
+  handleDeleteExecution: vi.fn().mockResolvedValue({ success: true, data: { handler: 'delete' } }),
+  handleWorkflowVersions: vi.fn().mockResolvedValue({ success: true, data: { handler: 'versions' } }),
+  handleTestWorkflow: vi.fn().mockResolvedValue({ success: true, data: { handler: 'test' } }),
+}));
+
+vi.mock('../../../src/mcp/handlers-n8n-manager', async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return {
+    ...actual,
+    ...handlerMocks,
+  };
+});
+
+vi.mock('../../../src/database/database-adapter');
+vi.mock('../../../src/database/node-repository');
+vi.mock('../../../src/templates/template-service');
+vi.mock('../../../src/utils/logger');
+
+import { N8NDocumentationMCPServer } from '../../../src/mcp/server';
+
+class TestableServer extends N8NDocumentationMCPServer {
+  public async testExecuteTool(name: string, args: any): Promise<any> {
+    return (this as any).executeTool(name, args);
+  }
+}
+
+describe('agent call defaults and aliases (#1051)', () => {
+  let server: TestableServer;
+
+  beforeEach(() => {
+    process.env.NODE_DB_PATH = ':memory:';
+    process.env.N8N_API_URL = 'https://example.invalid';
+    process.env.N8N_API_KEY = 'test-key';
+    delete process.env.DISABLED_TOOL_OPERATIONS;
+    server = new TestableServer();
+    vi.clearAllMocks();
+    // The global afterEach runs vi.restoreAllMocks(), which strips the hoisted
+    // resolved values; re-apply them so every test sees the same handler results.
+    handlerMocks.handleGetExecution.mockResolvedValue({ success: true, data: { handler: 'get' } });
+    handlerMocks.handleListExecutions.mockResolvedValue({ success: true, data: { handler: 'list' } });
+    handlerMocks.handleDeleteExecution.mockResolvedValue({ success: true, data: { handler: 'delete' } });
+    handlerMocks.handleWorkflowVersions.mockResolvedValue({ success: true, data: { handler: 'versions' } });
+    handlerMocks.handleTestWorkflow.mockResolvedValue({ success: true, data: { handler: 'test' } });
+  });
+
+  afterEach(() => {
+    delete process.env.NODE_DB_PATH;
+    delete process.env.N8N_API_URL;
+    delete process.env.N8N_API_KEY;
+    delete process.env.DISABLED_TOOL_OPERATIONS;
+  });
+
+  describe('n8n_executions', () => {
+    it('lists executions when action is omitted', async () => {
+      const result = await server.testExecuteTool('n8n_executions', { workflowId: 'wf1' });
+
+      expect(handlerMocks.handleListExecutions).toHaveBeenCalledTimes(1);
+      expect(handlerMocks.handleListExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ workflowId: 'wf1' }),
+        undefined
+      );
+      expect(handlerMocks.handleGetExecution).not.toHaveBeenCalled();
+      expect(result.data.handler).toBe('list');
+      expect(result.message).toBeUndefined();
+    });
+
+    it('lists executions when called with no arguments at all', async () => {
+      const result = await server.testExecuteTool('n8n_executions', {});
+      expect(handlerMocks.handleListExecutions).toHaveBeenCalledTimes(1);
+      expect(result.data.handler).toBe('list');
+    });
+
+    it('treats a blank action as omitted', async () => {
+      await server.testExecuteTool('n8n_executions', { action: '  ' });
+      expect(handlerMocks.handleListExecutions).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a non-string action rather than silently defaulting past the policy gate', async () => {
+      await expect(server.testExecuteTool('n8n_executions', { action: 42 }))
+        .rejects.toThrow('Unknown action: 42');
+      expect(handlerMocks.handleListExecutions).not.toHaveBeenCalled();
+    });
+
+    it('serves get without id as a listing of the workflow and says so', async () => {
+      const result = await server.testExecuteTool('n8n_executions', { action: 'get', workflowId: 'wf1' });
+
+      expect(handlerMocks.handleGetExecution).not.toHaveBeenCalled();
+      expect(handlerMocks.handleListExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ workflowId: 'wf1' }),
+        undefined
+      );
+      expect(result.success).toBe(true);
+      expect(result.data.handler).toBe('list');
+      expect(result.message).toContain('without an execution id');
+      expect(result.message).toContain('workflow wf1');
+      expect(result.message).toContain('Pass id');
+    });
+
+    it('serves get without id or workflowId as a listing of recent executions', async () => {
+      const result = await server.testExecuteTool('n8n_executions', { action: 'get' });
+
+      expect(handlerMocks.handleListExecutions).toHaveBeenCalledTimes(1);
+      expect(result.message).toContain('recent executions');
+    });
+
+    it('does not decorate a failed listing with the fallback note', async () => {
+      handlerMocks.handleListExecutions.mockResolvedValue({ success: false, error: 'n8n API not configured' });
+
+      const result = await server.testExecuteTool('n8n_executions', { action: 'get' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('n8n API not configured');
+      expect(result.message).toBeUndefined();
+    });
+
+    it('still routes get with an id to handleGetExecution', async () => {
+      const result = await server.testExecuteTool('n8n_executions', { action: 'get', id: 'exec1' });
+
+      expect(handlerMocks.handleGetExecution).toHaveBeenCalledTimes(1);
+      expect(handlerMocks.handleListExecutions).not.toHaveBeenCalled();
+      expect(result.data.handler).toBe('get');
+    });
+
+    it('keeps delete strict about id', async () => {
+      await expect(server.testExecuteTool('n8n_executions', { action: 'delete', workflowId: 'wf1' }))
+        .rejects.toThrow('id is required for action=delete');
+      expect(handlerMocks.handleDeleteExecution).not.toHaveBeenCalled();
+      expect(handlerMocks.handleListExecutions).not.toHaveBeenCalled();
+    });
+
+    it('suggests list for get_many and names the owning tool for foreign vocabulary', async () => {
+      await expect(server.testExecuteTool('n8n_executions', { action: 'get_many' }))
+        .rejects.toThrow("Unknown action: get_many. Valid actions: get, list, delete. Did you mean action='list'?");
+      await expect(server.testExecuteTool('n8n_executions', { action: 'list_runs' }))
+        .rejects.toThrow(/Unknown action: list_runs.*n8n_evaluations/);
+      await expect(server.testExecuteTool('n8n_executions', { action: 'frobnicate' }))
+        .rejects.toThrow('Unknown action: frobnicate. Valid actions: get, list, delete.');
+    });
+
+    it('applies a disabled-operation rule to the defaulted list action', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:list';
+      const { resetToolPolicyCache } = await import('../../../src/mcp/tool-policy');
+      resetToolPolicyCache();
+
+      await expect(server.testExecuteTool('n8n_executions', {})).rejects.toThrow(/disabled/i);
+      expect(handlerMocks.handleListExecutions).not.toHaveBeenCalled();
+      resetToolPolicyCache();
+    });
+
+    it('does not let get without id open a listing that policy has disabled', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_executions:list';
+      const { resetToolPolicyCache } = await import('../../../src/mcp/tool-policy');
+      resetToolPolicyCache();
+
+      await expect(server.testExecuteTool('n8n_executions', { action: 'get', workflowId: 'wf1' }))
+        .rejects.toThrow('id is required for action=get');
+      expect(handlerMocks.handleListExecutions).not.toHaveBeenCalled();
+      resetToolPolicyCache();
+    });
+
+    it('drops the schema default when policy disables the defaulted operation', async () => {
+      const disabled = new Map([['n8n_executions', new Set(['list'])]]);
+      const filtered = (server as any).buildFilteredToolDefinitions(disabled);
+      const action = filtered.get('n8n_executions').inputSchema.properties.action;
+      expect(action.enum).toEqual(['get', 'delete']);
+      expect(action.default).toBeUndefined();
+
+      const untouched = (server as any).buildFilteredToolDefinitions(new Map([['n8n_executions', new Set(['delete'])]]));
+      expect(untouched.get('n8n_executions').inputSchema.properties.action.default).toBe('list');
+    });
+  });
+
+  describe('n8n_workflow_versions', () => {
+    it('no longer requires mode at the server layer', async () => {
+      const result = await server.testExecuteTool('n8n_workflow_versions', { workflowId: 'wf1' });
+
+      expect(handlerMocks.handleWorkflowVersions).toHaveBeenCalledTimes(1);
+      expect(handlerMocks.handleWorkflowVersions.mock.calls[0][0]).toEqual({ workflowId: 'wf1' });
+      expect(result.data.handler).toBe('versions');
+    });
+
+    it('fills workflowId from id', async () => {
+      await server.testExecuteTool('n8n_workflow_versions', { id: 'wf1' });
+
+      expect(handlerMocks.handleWorkflowVersions.mock.calls[0][0]).toEqual({ id: 'wf1', workflowId: 'wf1' });
+    });
+
+    it('keeps an explicit workflowId when both spellings are sent', async () => {
+      await server.testExecuteTool('n8n_workflow_versions', { mode: 'list', id: 'x', workflowId: 'wf1' });
+
+      expect(handlerMocks.handleWorkflowVersions.mock.calls[0][0]).toEqual({ mode: 'list', id: 'x', workflowId: 'wf1' });
+    });
+
+    it('applies a disabled-operation rule to the defaulted list mode', async () => {
+      process.env.DISABLED_TOOL_OPERATIONS = 'n8n_workflow_versions:list';
+      const { resetToolPolicyCache } = await import('../../../src/mcp/tool-policy');
+      resetToolPolicyCache();
+
+      await expect(server.testExecuteTool('n8n_workflow_versions', { workflowId: 'wf1' })).rejects.toThrow(/disabled/i);
+      expect(handlerMocks.handleWorkflowVersions).not.toHaveBeenCalled();
+      resetToolPolicyCache();
+    });
+  });
+
+  describe('n8n_test_workflow', () => {
+    it('accepts id as an alias for workflowId', async () => {
+      const result = await server.testExecuteTool('n8n_test_workflow', { id: 'wf1' });
+
+      expect(handlerMocks.handleTestWorkflow).toHaveBeenCalledTimes(1);
+      expect(handlerMocks.handleTestWorkflow.mock.calls[0][0]).toEqual({ id: 'wf1', workflowId: 'wf1' });
+      expect(result.data.handler).toBe('test');
+    });
+
+    it('names the parameter and the alias when neither spelling is sent', async () => {
+      await expect(server.testExecuteTool('n8n_test_workflow', { method: 'prepare' }))
+        .rejects.toThrow('n8n_test_workflow: Validation failed:\n  • workflowId: workflowId is required: the ID of the workflow to run ("id" is accepted as an alias)');
+      expect(handlerMocks.handleTestWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('treats an empty or blank workflowId as missing', async () => {
+      await expect(server.testExecuteTool('n8n_test_workflow', { workflowId: '' }))
+        .rejects.toThrow('workflowId is required');
+      await expect(server.testExecuteTool('n8n_test_workflow', { workflowId: '   ' }))
+        .rejects.toThrow('workflowId is required');
+      expect(handlerMocks.handleTestWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('uses the id alias when workflowId is blank', async () => {
+      await server.testExecuteTool('n8n_test_workflow', { workflowId: '  ', id: 'wf1' });
+      expect(handlerMocks.handleTestWorkflow.mock.calls[0][0]).toMatchObject({ workflowId: 'wf1' });
+    });
+  });
+});

--- a/tests/unit/mcp/get-node-unified.test.ts
+++ b/tests/unit/mcp/get-node-unified.test.ts
@@ -254,7 +254,7 @@ describe('Unified get_node Tool', () => {
     });
 
     it('still rejects values that are not aliases', async () => {
-      await expect(call({ mode: 'schema' })).rejects.toThrow('Invalid mode "schema"');
+      await expect(call({ mode: 'schema' })).rejects.toThrow('Invalid mode "schema". Valid options: info, docs, search_properties, versions, compare, breaking, migrations');
       await expect(call({ detail: 'huge' })).rejects.toThrow('Invalid detail level "huge"');
       await expect(call({ mode: 42 })).rejects.toThrow('Invalid mode "42"');
     });

--- a/tests/unit/mcp/get-node-unified.test.ts
+++ b/tests/unit/mcp/get-node-unified.test.ts
@@ -218,6 +218,48 @@ describe('Unified get_node Tool', () => {
     });
   });
 
+  describe('Retired parameter vocabulary (#1051)', () => {
+    const call = (args: Record<string, unknown>) =>
+      (server as any).executeTool('get_node', { nodeType: 'nodes-base.httpRequest', ...args });
+
+    it('serves mode=essentials as info at standard detail', async () => {
+      const [aliased, canonical] = await Promise.all([
+        call({ mode: 'essentials' }),
+        call({ mode: 'info', detail: 'standard' }),
+      ]);
+      expect(aliased).toEqual(canonical);
+    });
+
+    it('serves mode=full as info at full detail', async () => {
+      const [aliased, canonical] = await Promise.all([
+        call({ mode: 'full' }),
+        call({ detail: 'full' }),
+      ]);
+      expect(aliased).toEqual(canonical);
+      expect(aliased.properties.length).toBe(canonical.properties.length);
+    });
+
+    it('serves detail=summary as minimal', async () => {
+      const [aliased, canonical] = await Promise.all([
+        call({ detail: 'summary' }),
+        call({ detail: 'minimal' }),
+      ]);
+      expect(aliased).toEqual(canonical);
+    });
+
+    it('routes mode=properties to search_properties and still requires propertyQuery', async () => {
+      await expect(call({ mode: 'properties' })).rejects.toThrow('propertyQuery is required for mode=search_properties');
+      const result = await call({ mode: 'properties', propertyQuery: 'url' });
+      expect(result).toEqual(await call({ mode: 'search_properties', propertyQuery: 'url' }));
+    });
+
+    it('still rejects values that are not aliases', async () => {
+      await expect(call({ mode: 'schema' })).rejects.toThrow('Invalid mode "schema"');
+      await expect(call({ detail: 'huge' })).rejects.toThrow('Invalid detail level "huge"');
+      await expect(call({ mode: 42 })).rejects.toThrow('Invalid mode "42"');
+    });
+  });
+
   describe('Info Mode - minimal detail', () => {
     it('should return only basic metadata for minimal detail', async () => {
       const result = await (server as any).getNode('nodes-base.httpRequest', 'minimal', 'info');

--- a/tests/unit/mcp/handlers-n8n-manager.test.ts
+++ b/tests/unit/mcp/handlers-n8n-manager.test.ts
@@ -2043,6 +2043,43 @@ describe('handlers-n8n-manager', () => {
     });
   });
 
+  describe('handleWorkflowVersions - mode default (#1051)', () => {
+    async function mockHistory(versions: unknown[]) {
+      const { WorkflowVersioningService } = await import('@/services/workflow-versioning-service');
+      const getVersionHistory = vi.fn().mockResolvedValue(versions);
+      vi.mocked(WorkflowVersioningService).mockImplementation(() => ({ getVersionHistory }) as any);
+      return getVersionHistory;
+    }
+
+    it('lists versions when mode is omitted', async () => {
+      const getVersionHistory = await mockHistory([{ versionId: 1 }, { versionId: 2 }]);
+
+      const result = await handlers.handleWorkflowVersions({ workflowId: 'wf-1' }, mockRepository);
+
+      expect(getVersionHistory).toHaveBeenCalledWith('wf-1', undefined);
+      expect(result.success).toBe(true);
+      expect((result.data as any).count).toBe(2);
+    });
+
+    it('treats a blank mode as omitted', async () => {
+      await mockHistory([]);
+
+      const result = await handlers.handleWorkflowVersions({ mode: '', workflowId: 'wf-1' }, mockRepository);
+
+      expect(result.success).toBe(true);
+      expect((result.data as any).count).toBe(0);
+    });
+
+    it('still rejects an unknown mode', async () => {
+      await mockHistory([]);
+
+      const result = await handlers.handleWorkflowVersions({ mode: 'history', workflowId: 'wf-1' }, mockRepository);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid input');
+    });
+  });
+
   describe('handleWorkflowVersions - rollback', () => {
     // Regression: the handler resolved its API client only when an InstanceContext was supplied,
     // which skipped getN8nApiClient's environment-variable fallback. On a plain N8N_API_URL setup

--- a/tests/unit/mcp/param-aliases.test.ts
+++ b/tests/unit/mcp/param-aliases.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../src/utils/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  resolveGetNodeAliases,
+  suggestExecutionsAction,
+  withWorkflowIdAlias,
+} from '../../../src/mcp/param-aliases';
+import { logger } from '../../../src/utils/logger';
+
+describe('resolveGetNodeAliases', () => {
+  it('passes canonical values and undefined through unchanged', () => {
+    expect(resolveGetNodeAliases(undefined, undefined)).toEqual({ mode: undefined, detail: undefined });
+    expect(resolveGetNodeAliases('info', 'full')).toEqual({ mode: 'info', detail: 'full' });
+    expect(resolveGetNodeAliases('search_properties', undefined)).toEqual({ mode: 'search_properties', detail: undefined });
+    expect(resolveGetNodeAliases('versions', 'minimal')).toEqual({ mode: 'versions', detail: 'minimal' });
+  });
+
+  it('passes unknown values through so validation still names them', () => {
+    expect(resolveGetNodeAliases('bogus', 'huge')).toEqual({ mode: 'bogus', detail: 'huge' });
+  });
+
+  it.each([
+    ['essentials', 'info', 'standard'],
+    ['minimal', 'info', 'minimal'],
+    ['standard', 'info', 'standard'],
+    ['full', 'info', 'full'],
+    ['operations', 'info', 'standard'],
+  ])('maps retired mode=%s to mode=%s with detail=%s', (mode, expectedMode, expectedDetail) => {
+    expect(resolveGetNodeAliases(mode, undefined)).toEqual({ mode: expectedMode, detail: expectedDetail });
+  });
+
+  it.each(['properties', 'search'])('maps mode=%s to search_properties without touching detail', (mode) => {
+    expect(resolveGetNodeAliases(mode, undefined)).toEqual({ mode: 'search_properties', detail: undefined });
+    expect(resolveGetNodeAliases(mode, 'minimal')).toEqual({ mode: 'search_properties', detail: 'minimal' });
+  });
+
+  it.each([
+    ['essentials', 'standard'],
+    ['summary', 'minimal'],
+    ['short', 'minimal'],
+  ])('maps retired detail=%s to %s', (detail, expected) => {
+    expect(resolveGetNodeAliases(undefined, detail)).toEqual({ mode: undefined, detail: expected });
+    expect(resolveGetNodeAliases('info', detail)).toEqual({ mode: 'info', detail: expected });
+  });
+
+  it('lets a retired mode value decide the detail level over a supplied detail', () => {
+    expect(resolveGetNodeAliases('full', 'standard')).toEqual({ mode: 'info', detail: 'full' });
+    expect(resolveGetNodeAliases('essentials', 'full')).toEqual({ mode: 'info', detail: 'standard' });
+  });
+
+  it('is case-insensitive for alias lookup', () => {
+    expect(resolveGetNodeAliases('Essentials', 'SUMMARY')).toEqual({ mode: 'info', detail: 'standard' });
+  });
+
+  it('passes non-string values through so validation rejects them instead of defaulting', () => {
+    expect(resolveGetNodeAliases(42 as any, { a: 1 } as any)).toEqual({ mode: 42, detail: { a: 1 } });
+  });
+
+  it('logs at debug level when an alias was applied and stays silent otherwise', () => {
+    vi.mocked(logger.debug).mockClear();
+    resolveGetNodeAliases('info', 'standard');
+    expect(logger.debug).not.toHaveBeenCalled();
+
+    resolveGetNodeAliases('essentials', 'short');
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    const message = vi.mocked(logger.debug).mock.calls[0][0] as string;
+    expect(message).toContain('detail=short→minimal');
+    expect(message).toContain('mode=essentials→mode=info, detail=standard');
+  });
+});
+
+describe('suggestExecutionsAction', () => {
+  it('points list-shaped spellings at action=list', () => {
+    expect(suggestExecutionsAction('get_many')).toBe("Did you mean action='list'?");
+    expect(suggestExecutionsAction('getAll')).toBe("Did you mean action='list'?");
+    expect(suggestExecutionsAction('list_executions')).toBe("Did you mean action='list'?");
+  });
+
+  it('names the owning tool for vocabulary that belongs elsewhere', () => {
+    expect(suggestExecutionsAction('list_runs')).toContain('n8n_evaluations');
+    expect(suggestExecutionsAction('getRows')).toContain('n8n_manage_datatable');
+  });
+
+  it('returns undefined for an unrecognised value', () => {
+    expect(suggestExecutionsAction('frobnicate')).toBeUndefined();
+  });
+});
+
+describe('withWorkflowIdAlias', () => {
+  it('fills workflowId from id when the canonical key is absent', () => {
+    expect(withWorkflowIdAlias({ id: 'wf-1' })).toEqual({ id: 'wf-1', workflowId: 'wf-1' });
+    expect(withWorkflowIdAlias({ id: 'wf-1', workflowId: '' })).toEqual({ id: 'wf-1', workflowId: 'wf-1' });
+  });
+
+  it('keeps an explicit workflowId even when id is also present', () => {
+    expect(withWorkflowIdAlias({ id: 'other', workflowId: 'wf-1' })).toEqual({ id: 'other', workflowId: 'wf-1' });
+  });
+
+  it('treats a blank workflowId as absent', () => {
+    expect(withWorkflowIdAlias({ id: 'wf-1', workflowId: '   ' })).toEqual({ id: 'wf-1', workflowId: 'wf-1' });
+  });
+
+  it('accepts a numeric id, which the schema-driven coercion never sees', () => {
+    expect(withWorkflowIdAlias({ id: 12345 })).toEqual({ id: 12345, workflowId: '12345' });
+  });
+
+  it('returns the same object when there is nothing to alias', () => {
+    const args = { mode: 'list' };
+    expect(withWorkflowIdAlias(args)).toBe(args);
+    expect(withWorkflowIdAlias({ id: '   ' })).toEqual({ id: '   ' });
+    expect(withWorkflowIdAlias({ id: true })).toEqual({ id: true });
+  });
+
+  it('does not mutate the input', () => {
+    const args = { id: 'wf-1' };
+    withWorkflowIdAlias(args);
+    expect(args).toEqual({ id: 'wf-1' });
+  });
+});

--- a/tests/unit/mcp/param-aliases.test.ts
+++ b/tests/unit/mcp/param-aliases.test.ts
@@ -5,6 +5,7 @@ vi.mock('../../../src/utils/logger', () => ({
 }));
 
 import {
+  hasText,
   resolveGetNodeAliases,
   suggestExecutionsAction,
   withWorkflowIdAlias,
@@ -100,6 +101,10 @@ describe('withWorkflowIdAlias', () => {
     expect(withWorkflowIdAlias({ id: 'other', workflowId: 'wf-1' })).toEqual({ id: 'other', workflowId: 'wf-1' });
   });
 
+  it('leaves a non-string workflowId for validation instead of overwriting it', () => {
+    expect(withWorkflowIdAlias({ workflowId: 123, id: 'wf-1' })).toEqual({ workflowId: 123, id: 'wf-1' });
+  });
+
   it('treats a blank workflowId as absent', () => {
     expect(withWorkflowIdAlias({ id: 'wf-1', workflowId: '   ' })).toEqual({ id: 'wf-1', workflowId: 'wf-1' });
   });
@@ -119,5 +124,17 @@ describe('withWorkflowIdAlias', () => {
     const args = { id: 'wf-1' };
     withWorkflowIdAlias(args);
     expect(args).toEqual({ id: 'wf-1' });
+  });
+});
+
+describe('hasText', () => {
+  it('is true only for a string with content once trimmed', () => {
+    expect(hasText('wf-1')).toBe(true);
+    expect(hasText(' x ')).toBe(true);
+    expect(hasText('')).toBe(false);
+    expect(hasText('   ')).toBe(false);
+    expect(hasText(undefined)).toBe(false);
+    expect(hasText(null)).toBe(false);
+    expect(hasText(42)).toBe(false);
   });
 });

--- a/tests/unit/mcp/param-aliases.test.ts
+++ b/tests/unit/mcp/param-aliases.test.ts
@@ -120,6 +120,11 @@ describe('withWorkflowIdAlias', () => {
     expect(withWorkflowIdAlias({ id: true })).toEqual({ id: true });
   });
 
+  it('drops a blank workflowId when no usable id replaces it', () => {
+    expect(withWorkflowIdAlias({ workflowId: '   ' })).toEqual({ workflowId: undefined });
+    expect(withWorkflowIdAlias({ workflowId: '', id: ' ' })).toEqual({ workflowId: undefined, id: ' ' });
+  });
+
   it('does not mutate the input', () => {
     const args = { id: 'wf-1' };
     withWorkflowIdAlias(args);

--- a/tests/unit/mcp/parameter-validation.test.ts
+++ b/tests/unit/mcp/parameter-validation.test.ts
@@ -539,7 +539,7 @@ describe('Parameter Validation', () => {
         .rejects.toThrow('Missing required parameters for n8n_update_partial_workflow: id, operations');
 
       await expect(server.testExecuteTool('n8n_test_workflow', {}))
-        .rejects.toThrow('Missing required parameters for n8n_test_workflow: workflowId');
+        .rejects.toThrow('n8n_test_workflow: Validation failed:\n  • workflowId: workflowId is required');
 
       await expect(server.testExecuteTool('n8n_manage_datatable', {}))
         .rejects.toThrow('n8n_manage_datatable: Validation failed:\n  • action: action is required');

--- a/tests/unit/mcp/parameter-validation.test.ts
+++ b/tests/unit/mcp/parameter-validation.test.ts
@@ -534,7 +534,7 @@ describe('Parameter Validation', () => {
         { name: 'n8n_validate_workflow', args: {}, expected: 'n8n_validate_workflow: Validation failed:\n  • id: id is required' },
       ];
 
-      // n8n_update_partial_workflow and n8n_test_workflow use legacy validation
+      // n8n_update_partial_workflow uses legacy validation; n8n_test_workflow moved to the schema-style format
       await expect(server.testExecuteTool('n8n_update_partial_workflow', {}))
         .rejects.toThrow('Missing required parameters for n8n_update_partial_workflow: id, operations');
 

--- a/tests/unit/mcp/tool-policy.test.ts
+++ b/tests/unit/mcp/tool-policy.test.ts
@@ -45,6 +45,7 @@ import {
   getDisabledOperations,
   isOperationDisabled,
   getValidOperations,
+  resolveRequestedOperation,
   resetToolPolicyCache,
 } from '../../../src/mcp/tool-policy';
 
@@ -92,6 +93,24 @@ describe('getDisabledTools', () => {
   it('caps the list at 200 entries', () => {
     process.env.DISABLED_TOOLS = Array.from({ length: 250 }, (_, i) => `tool_${i}`).join(',');
     expect(getDisabledTools().size).toBe(200);
+  });
+});
+
+describe('resolveRequestedOperation', () => {
+  it('returns the value the caller sent', () => {
+    expect(resolveRequestedOperation('n8n_executions', { action: 'delete' })).toBe('delete');
+  });
+
+  it('resolves an omitted or blank operation to the tool default (#1051)', () => {
+    expect(resolveRequestedOperation('n8n_executions', {})).toBe('list');
+    expect(resolveRequestedOperation('n8n_executions', { action: ' ' })).toBe('list');
+    expect(resolveRequestedOperation('n8n_workflow_versions', { workflowId: 'wf' })).toBe('list');
+    expect(resolveRequestedOperation('n8n_test_workflow', { workflowId: 'wf' })).toBe('auto');
+  });
+
+  it('is undefined for a tool without an operation parameter or default', () => {
+    expect(resolveRequestedOperation('n8n_get_workflow', {})).toBeUndefined();
+    expect(resolveRequestedOperation('n8n_manage_folders', {})).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #1051.

Telemetry for 2026-08-26 to 2026-09-02 showed roughly 1,800 `error_occurred` events a week from three call shapes that carried enough information to act on. Each is a schema or dispatch change; callers that already pass the canonical parameters see no change.

## What changed

**`n8n_executions`**
- `action` is optional and defaults to `list` (schema `default`, `required` dropped, `TOOL_OPERATION_DEFAULT` entry so a `DISABLED_TOOL_OPERATIONS` rule naming `list` still applies to an omitted value).
- `action=get` without `id` lists the executions of the given `workflowId` (or recent executions) and says so in the response `message`. `delete` stays strict.
- Unknown actions get a hint: `get_many` / `getAll` / `list_executions` point at `list`; `list_runs` and `getRows` name `n8n_evaluations` and `n8n_manage_datatable`.

**`n8n_workflow_versions`**
- `mode` defaults to `list` (JSON schema, Zod schema, policy default). A blank string is treated as omitted, matching the other operation parameters.
- `id` is accepted as an alias for `workflowId`.

**`n8n_test_workflow`**
- `id` is accepted as an alias for `workflowId`.
- The missing-parameter error now uses the same format as the other validated tools and names the alias: `workflowId is required: the ID of the workflow to run ("id" is accepted as an alias)`.

**`get_node`**
- Retired `get_node_essentials` / `get_node_info` vocabulary is mapped before validation, in a new `src/mcp/param-aliases.ts`:
  - `mode` `essentials` / `minimal` / `standard` / `full` / `operations` → `mode=info` with `detail` `standard` / `minimal` / `standard` / `full` / `standard`
  - `mode` `properties` / `search` → `search_properties` (still requires `propertyQuery`)
  - `detail` `essentials` / `summary` / `short` → `standard` / `minimal` / `minimal`
- A retired `mode` value also sets `detail`, since `mode=full` was the caller's statement of intent and most clients only send `detail` because the schema defaults it.
- Aliases are logged at debug level. Tool schemas, tool docs and the skills pack keep advertising only the canonical values.

## Review rounds

Simplifier, an Opus code review and a Codex review ran on the branch. Adopted: the dispatch now normalises `action` through the same `resolveRequestedOperation` the policy gate uses (a non-string value no longer defaults past a rule); the `get`-without-`id` fallback refuses to list when `n8n_executions:list` is disabled; `required: ['mode']` was still present on the versions schema and is removed; a filtered schema drops a `default` that names a disabled operation; a blank `workflowId` is treated as missing again (the legacy validator rejected it) and yields to the `id` alias; a numeric `id` is accepted; a non-string `get_node` `mode`/`detail` passes through to validation instead of being erased.

Declined: declaring `id` as a schema property and relaxing `required: ['workflowId']` on `n8n_test_workflow` so schema-validating hosts accept `{id}`. The telemetry counts are server-side errors, so the affected clients already let those calls through; the alias covers them without loosening the advertised contract of a tool that runs workflows. Also declined: filling `versionId` from `id` in versions `get`/`diff` modes, since `id` is ambiguous there.

Copilot rounds adopted: a filtered parameter description now says when policy removed its default; whitespace-only `id` takes the `get` fallback and is rejected by `delete`; a blank `workflowId` no longer claims a workflow-scoped listing in the fallback message; `withWorkflowIdAlias` leaves a non-string `workflowId` for validation; the executions `id` description no longer says it is required for `get`. The live test run also found the `get_node` invalid-mode error omitted `docs` and `search_properties`; it now names every accepted mode.

## Verification

- `npm run typecheck` clean; `npm run test:unit` 191 files, 6191 passed.
- New tests: `tests/unit/mcp/param-aliases.test.ts` (alias maps), `tests/unit/mcp/agent-call-defaults.test.ts` (server dispatch for all three tools, including the policy gate on the defaulted operation), plus cases in `get-node-unified`, `handlers-n8n-manager`, `tool-policy` and an updated expectation in `parameter-validation`.
- The n8n-mcp-tester agent ran 21 cases against the reloaded server: 20 pass, 1 skipped (no executions on the instance to fetch by id).
- Live check against the built `dist` with the test instance: omitted `action` lists, `get` without `id` lists with the note, `delete` without `id` errors, `get_many` gets the hint, omitted `mode` lists versions, `id` alias works for versions and test_workflow, and every `get_node` alias returns the same payload as its canonical call.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)
