### PR TITLE
Recognize legacy Cron nodes as activatable triggers

### DIFF
--- a/src/utils/node-type-utils.ts
+++ b/src/utils/node-type-utils.ts
@@ -179,7 +179,7 @@ export function isTriggerNode(nodeType: string): boolean {
 
   // Check for specific trigger types that don't have 'trigger' in their name
   // (manualTrigger and formTrigger are already caught by the 'trigger' check above)
-  return normalized === 'nodes-base.start';
+  return normalized === 'nodes-base.start' || normalized === 'nodes-base.cron';
 }
 
 /**

--- a/tests/unit/services/n8n-validation.test.ts
+++ b/tests/unit/services/n8n-validation.test.ts
@@ -861,6 +861,22 @@ describe('n8n-validation', () => {
       expect(errors).toEqual([]);
     });
 
+    it('should allow active workflow with legacy cron trigger', () => {
+      const workflow: Partial<Workflow> = {
+        name: 'Cron Workflow',
+        active: true,
+        nodes: [
+          webhookNode('cron-1', 'Cron', 'n8n-nodes-base.cron', 1),
+          webhookNode('set-1', 'Set', 'n8n-nodes-base.set', 3),
+        ],
+        connections: {
+          Cron: { main: [[{ node: 'Set', type: 'main', index: 0 }]] },
+        },
+      };
+
+      expect(validateWorkflowStructure(workflow)).toEqual([]);
+    });
+
     it('should detect missing workflow name', () => {
       const workflow = {
         nodes: [],


### PR DESCRIPTION
Fixes https://github.com/czlonkowski/n8n-mcp/issues/1050.

## Problem

The legacy `n8n-nodes-base.cron` node normalizes to `nodes-base.cron`, then falls through `isTriggerNode` because its name contains none of the existing trigger markers. Validation therefore rejects otherwise valid active workflows on any partial update.

## Fix

Recognize the exact normalized legacy Cron type as a trigger. The regression exercises `validateWorkflowStructure`, the boundary that emitted the false activation error.

## User impact

Active workflows that still use the legacy Cron node can be updated through `n8n_update_partial_workflow` without replacing the trigger.

## Verification

- `npx vitest run tests/unit/services/n8n-validation.test.ts --coverage.enabled=false` — 116 tests passed. On the base commit, the regression failed with `Cannot activate workflow: No activatable trigger nodes found`.
- `npm run typecheck` — passed.
- `npm run build` — passed.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en