### PR TITLE
fix: n8n_executions reads AI sub-node data and every run of a node (v2.80.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.80.1] - 2026-09-03
+
+### Fixed
+
+- **`n8n_executions` now returns the data of AI Agent sub-nodes and of every run of a node** ([#965](https://github.com/czlonkowski/n8n-mcp/pull/965)). The execution processors read only `runData[node][0].data.main`, so a Chat Model, Tool, Memory or Output Parser node, whose task data lives under `ai_*` connection types, showed no items, and a node invoked more than once in an execution (an agent's model, called once per tool round) lost every run after the first. Items are now merged across runs, keyed by connection type and output port, so a node whose runs populate different types keeps them apart, and a port n8n recorded as `null` stays `null`. The last failing run's error is reported in every mode, `executionTime` is the sum across runs, and `preview` mode reads the first item without merging. In `summary` and `filtered` modes only as many items as the limit are merged, and inputs (`includeInputData`), which for AI sub-nodes carry whole prompts, are truncated with the same limit and described by a new `inputMetadata` field. The error processor reads the same helpers, so `error` mode's upstream context and execution path include AI sub-nodes too.
+
 ## [2.80.0] - 2026-09-03
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.80.0",
+      "version": "2.80.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/src/mcp/tool-docs/workflow_management/n8n-executions.ts
+++ b/src/mcp/tool-docs/workflow_management/n8n-executions.ts
@@ -40,7 +40,7 @@ export const n8nExecutionsDoc: ToolDocumentation = {
       id: { type: 'string', required: false, description: 'Execution ID. Required for action=delete; for action=get, omitting it lists executions instead' },
       mode: { type: 'string', required: false, description: 'For action=get: "preview", "summary" (default), "filtered", "full", "error"' },
       nodeNames: { type: 'array', required: false, description: 'For action=get with mode=filtered: Filter to specific nodes by name' },
-      itemsLimit: { type: 'number', required: false, description: 'For action=get with mode=filtered: Items per node (0=structure, 2=default, -1=unlimited)' },
+      itemsLimit: { type: 'number', required: false, description: 'For action=get with mode=summary or filtered: Items per node (0=structure, 2=default, -1=unlimited); applies to input data too when includeInputData is set' },
       includeInputData: { type: 'boolean', required: false, description: 'For action=get: Include input data in addition to output (default: false)' },
       errorItemsLimit: { type: 'number', required: false, description: 'For action=get with mode=error: Sample items from upstream (default: 2, max: 100)' },
       includeStackTrace: { type: 'boolean', required: false, description: 'For action=get with mode=error: Include full stack trace (default: false, shows truncated)' },

--- a/src/services/error-execution-processor.ts
+++ b/src/services/error-execution-processor.ts
@@ -18,6 +18,14 @@ import {
   ErrorSuggestion,
 } from '../types/n8n-api';
 import { logger } from '../utils/logger';
+import {
+  countRunItems,
+  getRunError,
+  latestStartTime,
+  hasRunOutputData,
+  sampleRunItems,
+  totalExecutionTime,
+} from './execution-run-data';
 
 /**
  * Options for error processing
@@ -31,83 +39,6 @@ export interface ErrorProcessorOptions {
 
 // Constants
 const MAX_STACK_LINES = 3;
-
-/**
- * Extract per-branch item arrays from a task-data connections object
- * (e.g. `run.data`). Regular nodes populate `main`, but LangChain AI
- * Agent sub-nodes (Chat Model, Output Parser, Tool, Memory, etc.) use
- * special `ai_*` connection types instead. A node's task data only ever
- * populates one of these keys, so merging all of them is equivalent to
- * "whichever one this node uses".
- */
-function extractConnectionBranches(connections: unknown): unknown[][] {
-  const branches: unknown[][] = [];
-
-  if (!connections || typeof connections !== 'object') {
-    return branches;
-  }
-
-  for (const value of Object.values(connections as Record<string, unknown>)) {
-    if (Array.isArray(value)) {
-      for (const branch of value) {
-        branches.push(Array.isArray(branch) ? branch : []);
-      }
-    }
-  }
-
-  return branches;
-}
-
-/**
- * Whether a node's runData entry has any connection-type data at all
- * (as opposed to genuinely having zero items in an existing branch).
- */
-function nodeHasConnectionData(nodeData: unknown): boolean {
-  if (!Array.isArray(nodeData)) return false;
-  return nodeData.some(run => extractConnectionBranches(run?.data).length > 0);
-}
-
-/**
- * Get a node's first-branch output items, merged across every run in
- * run order.
- *
- * A node's runData entry is an array of runs, not a single run: nodes
- * invoked more than once within an execution (e.g. an AI Agent's Chat
- * Model, called once to decide to call a tool and again to produce the
- * final answer) get one array entry per invocation. Reading only
- * `nodeData[0]` silently drops every later invocation's data.
- */
-function getAllRunsOutputItems(nodeData: unknown): unknown[] {
-  const merged: unknown[] = [];
-  if (!Array.isArray(nodeData)) return merged;
-
-  for (const run of nodeData) {
-    const branches = extractConnectionBranches(run?.data);
-    if (branches[0]) {
-      merged.push(...branches[0]);
-    }
-  }
-
-  return merged;
-}
-
-/**
- * Find the error from a node's runs, if any. A node invoked multiple
- * times only fails on one of its runs, and the last run with an error is
- * the one that actually stopped the branch, so it wins over any earlier
- * error.
- */
-function getAnyRunError(nodeData: unknown): any {
-  if (!Array.isArray(nodeData)) return undefined;
-
-  let found: any;
-  for (const run of nodeData) {
-    if (run?.error) {
-      found = run.error;
-    }
-  }
-  return found;
-}
 
 /**
  * Keys that could enable prototype pollution attacks
@@ -207,9 +138,9 @@ function extractPrimaryError(
   const errorNode = error?.node as Record<string, unknown> | undefined;
   const nodeName = (errorNode?.name as string) || lastNode || 'Unknown';
 
-  // Also check runData for node-level errors, across every run of the node
+  // Also check runData for node-level errors
   const nodeRunData = runData[nodeName];
-  const nodeError = getAnyRunError(nodeRunData);
+  const nodeError = getRunError(nodeRunData);
 
   const stackTrace = (error?.stack || nodeError?.stack) as string | undefined;
 
@@ -254,12 +185,13 @@ function extractUpstreamContext(
     .filter(([name, data]) => {
       if (name === errorNodeName) return false;
       const runs = data as any[];
-      return getAllRunsOutputItems(runs).length > 0 && !getAnyRunError(runs);
+      return countRunItems(runs) > 0 && !getRunError(runs);
     })
     .map(([name, data]) => ({
       name,
-      executionTime: (data as any[])?.[0]?.executionTime || 0,
-      startTime: (data as any[])?.[0]?.startTime || 0
+      executionTime: totalExecutionTime(data) ?? 0,
+      // The most recent run decides recency for a node that ran more than once
+      startTime: latestStartTime(data)
     }))
     .sort((a, b) => b.startTime - a.startTime);
 
@@ -329,18 +261,19 @@ function extractNodeOutput(
   itemsLimit: number
 ): ErrorAnalysis['upstreamContext'] | undefined {
   const nodeData = runData[nodeName];
-  if (!nodeHasConnectionData(nodeData)) return undefined;
-  const items = getAllRunsOutputItems(nodeData);
+  if (!hasRunOutputData(nodeData)) return undefined;
 
-  // Sanitize sample items to remove sensitive data (flat, run-ordered
-  // across every invocation of the node)
+  // Merge only the samples; the count covers every port and comes from a pass that copies nothing.
+  const items = sampleRunItems(nodeData, Math.max(itemsLimit, 1));
+
+  // Sanitize sample items to remove sensitive data
   const rawSamples = items.slice(0, itemsLimit);
   const sanitizedSamples = rawSamples.map((item: unknown) => sanitizeData(item));
 
   return {
     nodeName,
     nodeType: '', // Will be enriched if workflow available
-    itemCount: items.length,
+    itemCount: countRunItems(nodeData),
     sampleItems: sanitizedSamples,
     dataStructure: extractStructure(items[0])
   };
@@ -364,14 +297,14 @@ function buildExecutionPath(
     for (const nodeName of upstreamNodes) {
       const nodeData = runData[nodeName];
       const runs = nodeData as any[] | undefined;
-      const hasError = getAnyRunError(runs);
-      const itemCount = getAllRunsOutputItems(runs).length;
+      const hasError = getRunError(runs);
+      const itemCount = countRunItems(runs);
 
       path.push({
         nodeName,
         status: hasError ? 'error' : (runs ? 'success' : 'skipped'),
         itemCount,
-        executionTime: runs?.[0]?.executionTime
+        executionTime: totalExecutionTime(runs)
       });
     }
 
@@ -381,7 +314,7 @@ function buildExecutionPath(
       nodeName: errorNodeName,
       status: 'error',
       itemCount: 0,
-      executionTime: errorNodeData?.[0]?.executionTime
+      executionTime: totalExecutionTime(errorNodeData)
     });
   } else {
     // Without workflow, list all executed nodes by execution order (best effort)
@@ -389,16 +322,16 @@ function buildExecutionPath(
       .map(([name, data]) => ({
         name,
         data: data as any[],
-        startTime: (data as any[])?.[0]?.startTime || 0
+        startTime: latestStartTime(data)
       }))
       .sort((a, b) => a.startTime - b.startTime);
 
     for (const { name, data } of nodesByTime) {
       path.push({
         nodeName: name,
-        status: getAnyRunError(data) ? 'error' : 'success',
-        itemCount: getAllRunsOutputItems(data).length,
-        executionTime: data?.[0]?.executionTime
+        status: getRunError(data) ? 'error' : 'success',
+        itemCount: countRunItems(data),
+        executionTime: totalExecutionTime(data)
       });
     }
   }
@@ -419,7 +352,7 @@ function findAdditionalErrors(
     if (nodeName === primaryErrorNode) continue;
 
     const runs = data as any[];
-    const error = getAnyRunError(runs);
+    const error = getRunError(runs);
     if (error) {
       additional.push({
         nodeName,

--- a/src/services/error-execution-processor.ts
+++ b/src/services/error-execution-processor.ts
@@ -59,11 +59,54 @@ function extractConnectionBranches(connections: unknown): unknown[][] {
 }
 
 /**
- * Get the first output branch's items for a run, across `main` and any
- * `ai_*` connection types.
+ * Whether a node's runData entry has any connection-type data at all
+ * (as opposed to genuinely having zero items in an existing branch).
  */
-function getRunOutputItems(run: any): unknown[] {
-  return extractConnectionBranches(run?.data)[0] || [];
+function nodeHasConnectionData(nodeData: unknown): boolean {
+  if (!Array.isArray(nodeData)) return false;
+  return nodeData.some(run => extractConnectionBranches(run?.data).length > 0);
+}
+
+/**
+ * Get a node's first-branch output items, merged across every run in
+ * run order.
+ *
+ * A node's runData entry is an array of runs, not a single run: nodes
+ * invoked more than once within an execution (e.g. an AI Agent's Chat
+ * Model, called once to decide to call a tool and again to produce the
+ * final answer) get one array entry per invocation. Reading only
+ * `nodeData[0]` silently drops every later invocation's data.
+ */
+function getAllRunsOutputItems(nodeData: unknown): unknown[] {
+  const merged: unknown[] = [];
+  if (!Array.isArray(nodeData)) return merged;
+
+  for (const run of nodeData) {
+    const branches = extractConnectionBranches(run?.data);
+    if (branches[0]) {
+      merged.push(...branches[0]);
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Find the error from a node's runs, if any. A node invoked multiple
+ * times only fails on one of its runs, and the last run with an error is
+ * the one that actually stopped the branch, so it wins over any earlier
+ * error.
+ */
+function getAnyRunError(nodeData: unknown): any {
+  if (!Array.isArray(nodeData)) return undefined;
+
+  let found: any;
+  for (const run of nodeData) {
+    if (run?.error) {
+      found = run.error;
+    }
+  }
+  return found;
 }
 
 /**
@@ -164,9 +207,9 @@ function extractPrimaryError(
   const errorNode = error?.node as Record<string, unknown> | undefined;
   const nodeName = (errorNode?.name as string) || lastNode || 'Unknown';
 
-  // Also check runData for node-level errors
+  // Also check runData for node-level errors, across every run of the node
   const nodeRunData = runData[nodeName];
-  const nodeError = nodeRunData?.[0]?.error;
+  const nodeError = getAnyRunError(nodeRunData);
 
   const stackTrace = (error?.stack || nodeError?.stack) as string | undefined;
 
@@ -211,7 +254,7 @@ function extractUpstreamContext(
     .filter(([name, data]) => {
       if (name === errorNodeName) return false;
       const runs = data as any[];
-      return getRunOutputItems(runs?.[0]).length > 0 && !runs?.[0]?.error;
+      return getAllRunsOutputItems(runs).length > 0 && !getAnyRunError(runs);
     })
     .map(([name, data]) => ({
       name,
@@ -286,11 +329,11 @@ function extractNodeOutput(
   itemsLimit: number
 ): ErrorAnalysis['upstreamContext'] | undefined {
   const nodeData = runData[nodeName];
-  const branches = extractConnectionBranches(nodeData?.[0]?.data);
-  if (branches.length === 0) return undefined;
-  const items = branches[0];
+  if (!nodeHasConnectionData(nodeData)) return undefined;
+  const items = getAllRunsOutputItems(nodeData);
 
-  // Sanitize sample items to remove sensitive data
+  // Sanitize sample items to remove sensitive data (flat, run-ordered
+  // across every invocation of the node)
   const rawSamples = items.slice(0, itemsLimit);
   const sanitizedSamples = rawSamples.map((item: unknown) => sanitizeData(item));
 
@@ -321,8 +364,8 @@ function buildExecutionPath(
     for (const nodeName of upstreamNodes) {
       const nodeData = runData[nodeName];
       const runs = nodeData as any[] | undefined;
-      const hasError = runs?.[0]?.error;
-      const itemCount = getRunOutputItems(runs?.[0]).length;
+      const hasError = getAnyRunError(runs);
+      const itemCount = getAllRunsOutputItems(runs).length;
 
       path.push({
         nodeName,
@@ -353,8 +396,8 @@ function buildExecutionPath(
     for (const { name, data } of nodesByTime) {
       path.push({
         nodeName: name,
-        status: data?.[0]?.error ? 'error' : 'success',
-        itemCount: getRunOutputItems(data?.[0]).length,
+        status: getAnyRunError(data) ? 'error' : 'success',
+        itemCount: getAllRunsOutputItems(data).length,
         executionTime: data?.[0]?.executionTime
       });
     }
@@ -376,7 +419,7 @@ function findAdditionalErrors(
     if (nodeName === primaryErrorNode) continue;
 
     const runs = data as any[];
-    const error = runs?.[0]?.error;
+    const error = getAnyRunError(runs);
     if (error) {
       additional.push({
         nodeName,

--- a/src/services/error-execution-processor.ts
+++ b/src/services/error-execution-processor.ts
@@ -33,6 +33,40 @@ export interface ErrorProcessorOptions {
 const MAX_STACK_LINES = 3;
 
 /**
+ * Extract per-branch item arrays from a task-data connections object
+ * (e.g. `run.data`). Regular nodes populate `main`, but LangChain AI
+ * Agent sub-nodes (Chat Model, Output Parser, Tool, Memory, etc.) use
+ * special `ai_*` connection types instead. A node's task data only ever
+ * populates one of these keys, so merging all of them is equivalent to
+ * "whichever one this node uses".
+ */
+function extractConnectionBranches(connections: unknown): unknown[][] {
+  const branches: unknown[][] = [];
+
+  if (!connections || typeof connections !== 'object') {
+    return branches;
+  }
+
+  for (const value of Object.values(connections as Record<string, unknown>)) {
+    if (Array.isArray(value)) {
+      for (const branch of value) {
+        branches.push(Array.isArray(branch) ? branch : []);
+      }
+    }
+  }
+
+  return branches;
+}
+
+/**
+ * Get the first output branch's items for a run, across `main` and any
+ * `ai_*` connection types.
+ */
+function getRunOutputItems(run: any): unknown[] {
+  return extractConnectionBranches(run?.data)[0] || [];
+}
+
+/**
  * Keys that could enable prototype pollution attacks
  * These are blocked entirely from processing
  */
@@ -177,7 +211,7 @@ function extractUpstreamContext(
     .filter(([name, data]) => {
       if (name === errorNodeName) return false;
       const runs = data as any[];
-      return runs?.[0]?.data?.main?.[0]?.length > 0 && !runs?.[0]?.error;
+      return getRunOutputItems(runs?.[0]).length > 0 && !runs?.[0]?.error;
     })
     .map(([name, data]) => ({
       name,
@@ -252,9 +286,9 @@ function extractNodeOutput(
   itemsLimit: number
 ): ErrorAnalysis['upstreamContext'] | undefined {
   const nodeData = runData[nodeName];
-  if (!nodeData?.[0]?.data?.main?.[0]) return undefined;
-
-  const items = nodeData[0].data.main[0];
+  const branches = extractConnectionBranches(nodeData?.[0]?.data);
+  if (branches.length === 0) return undefined;
+  const items = branches[0];
 
   // Sanitize sample items to remove sensitive data
   const rawSamples = items.slice(0, itemsLimit);
@@ -288,7 +322,7 @@ function buildExecutionPath(
       const nodeData = runData[nodeName];
       const runs = nodeData as any[] | undefined;
       const hasError = runs?.[0]?.error;
-      const itemCount = runs?.[0]?.data?.main?.[0]?.length || 0;
+      const itemCount = getRunOutputItems(runs?.[0]).length;
 
       path.push({
         nodeName,
@@ -320,7 +354,7 @@ function buildExecutionPath(
       path.push({
         nodeName: name,
         status: data?.[0]?.error ? 'error' : 'success',
-        itemCount: data?.[0]?.data?.main?.[0]?.length || 0,
+        itemCount: getRunOutputItems(data?.[0]).length,
         executionTime: data?.[0]?.executionTime
       });
     }

--- a/src/services/execution-processor.ts
+++ b/src/services/execution-processor.ts
@@ -25,6 +25,14 @@ import {
 } from '../types/n8n-api';
 import { logger } from '../utils/logger';
 import { processErrorExecution } from './error-execution-processor';
+import {
+  extractConnectionBranches,
+  firstRunItem,
+  getRunError,
+  mergeRunBranches,
+  totalExecutionTime,
+  type RunBranch,
+} from './execution-run-data';
 
 /**
  * Size estimation and threshold constants
@@ -106,117 +114,6 @@ function estimateDataSize(data: unknown): number {
 }
 
 /**
- * Extract per-branch item arrays from a task-data connections object
- * (e.g. `run.data` or `run.inputOverride`).
- *
- * Regular nodes connect via the `main` connection type, but LangChain
- * AI Agent sub-nodes (Chat Model, Output Parser, Tool, Memory, etc.)
- * connect via special `ai_*` connection types (ai_languageModel,
- * ai_outputParser, ai_tool, ai_memory, ai_embedding, ...) instead of
- * `main`. A node's task data only ever populates one of these keys, so
- * merging all of them is equivalent to "whichever one this node uses".
- */
-function extractConnectionBranches(connections: unknown): unknown[][] {
-  const branches: unknown[][] = [];
-
-  if (!connections || typeof connections !== 'object') {
-    return branches;
-  }
-
-  for (const value of Object.values(connections as Record<string, unknown>)) {
-    if (Array.isArray(value)) {
-      for (const branch of value) {
-        branches.push(Array.isArray(branch) ? branch : []);
-      }
-    }
-  }
-
-  return branches;
-}
-
-/**
- * Get a run's output data across `main` and any `ai_*` connection types.
- */
-function getRunOutputData(run: any): unknown[][] {
-  return extractConnectionBranches(run?.data);
-}
-
-/**
- * Get a run's input data (n8n stores this under `inputOverride`, keyed by
- * connection type, mirroring the `data` field's shape).
- */
-function getRunInputData(run: any): unknown[][] {
-  return extractConnectionBranches(run?.inputOverride);
-}
-
-/**
- * Merge per-branch item arrays across every run of a node, aligned by
- * branch/port index, in run order.
- *
- * A node's `runData` entry is an array of runs, not a single run: nodes
- * invoked more than once within an execution (e.g. an AI Agent's Chat
- * Model, called once to decide to call a tool and again to produce the
- * final answer) get one array entry per invocation. Reading only
- * `nodeData[0]` silently drops every later invocation's data - this
- * merges branch[i] of every run into a single flat, run-ordered branch[i],
- * so `itemsLimit` truncation still behaves like "first N items overall".
- */
-function mergeRunsByBranch(nodeData: unknown, selector: (run: any) => unknown[][]): unknown[][] {
-  const merged: unknown[][] = [];
-
-  if (!Array.isArray(nodeData)) {
-    return merged;
-  }
-
-  for (const run of nodeData) {
-    const branches = selector(run);
-    branches.forEach((items, branchIndex) => {
-      if (!merged[branchIndex]) {
-        merged[branchIndex] = [];
-      }
-      merged[branchIndex].push(...items);
-    });
-  }
-
-  return merged;
-}
-
-/**
- * Get output data across `main`/`ai_*` connection types AND across every
- * run of the node (see {@link mergeRunsByBranch}).
- */
-function getAllRunsOutputData(nodeData: unknown): unknown[][] {
-  return mergeRunsByBranch(nodeData, getRunOutputData);
-}
-
-/**
- * Get input data (`inputOverride`) across every run of the node.
- */
-function getAllRunsInputData(nodeData: unknown): unknown[][] {
-  return mergeRunsByBranch(nodeData, getRunInputData);
-}
-
-/**
- * Find the error from a node's runs, if any. A node invoked multiple times
- * only fails on one of its runs, and n8n does not necessarily record that
- * as the first one - the last run with an error is the one that actually
- * stopped the branch, so it wins over any earlier error.
- */
-function getAnyRunError(nodeData: unknown): unknown {
-  if (!Array.isArray(nodeData)) {
-    return undefined;
-  }
-
-  let found: unknown;
-  for (const run of nodeData) {
-    if (run?.error) {
-      found = run.error;
-    }
-  }
-  return found;
-}
-
-/**
  * Count items in execution data
  */
 function countItems(nodeData: unknown): { input: number; output: number } {
@@ -227,11 +124,11 @@ function countItems(nodeData: unknown): { input: number; output: number } {
   }
 
   for (const run of nodeData) {
-    for (const output of getRunOutputData(run)) {
-      counts.output += output.length;
+    for (const output of extractConnectionBranches(run?.data)) {
+      counts.output += output?.length ?? 0;
     }
-    for (const input of getRunInputData(run)) {
-      counts.input += input.length;
+    for (const input of extractConnectionBranches(run?.inputOverride)) {
+      counts.input += input?.length ?? 0;
     }
   }
 
@@ -274,13 +171,11 @@ export function generatePreview(execution: Execution): {
     const nodeData = runData[nodeName];
     const itemCounts = countItems(nodeData);
 
-    // Extract structure from the first available output item across all runs
+    // Structure of the first output item any run produced
     let dataStructure: Record<string, unknown> = {};
-    if (Array.isArray(nodeData) && nodeData.length > 0) {
-      const firstItem = getAllRunsOutputData(nodeData)?.[0]?.[0];
-      if (firstItem) {
-        dataStructure = extractStructure(firstItem) as Record<string, unknown>;
-      }
+    const firstItem = firstRunItem(nodeData);
+    if (firstItem) {
+      dataStructure = extractStructure(firstItem) as Record<string, unknown>;
     }
 
     const nodeSize = estimateDataSize(nodeData);
@@ -292,15 +187,10 @@ export function generatePreview(execution: Execution): {
       estimatedSizeKB: nodeSize,
     };
 
-    // Check for errors
-    if (Array.isArray(nodeData)) {
-      for (const run of nodeData) {
-        if (run.error) {
-          nodePreview.status = 'error';
-          nodePreview.error = extractErrorMessage(run.error);
-          break;
-        }
-      }
+    const runError = getRunError(nodeData);
+    if (runError) {
+      nodePreview.status = 'error';
+      nodePreview.error = extractErrorMessage(runError);
     }
 
     preview.nodes[nodeName] = nodePreview;
@@ -362,33 +252,38 @@ function generateRecommendation(
  * Truncate items array with metadata
  */
 function truncateItems(
-  items: unknown[][],
-  limit: number
+  items: RunBranch[],
+  limit: number,
+  knownTotal?: number
 ): {
-  truncated: unknown[][];
+  truncated: RunBranch[];
   metadata: { totalItems: number; itemsShown: number; truncated: boolean };
 } {
   if (!Array.isArray(items) || items.length === 0) {
     return {
       truncated: items || [],
       metadata: {
-        totalItems: 0,
+        totalItems: knownTotal ?? 0,
         itemsShown: 0,
-        truncated: false,
+        truncated: (knownTotal ?? 0) > 0,
       },
     };
   }
 
-  let totalItems = 0;
-  for (const output of items) {
-    if (Array.isArray(output)) {
-      totalItems += output.length;
+  // `knownTotal` lets the caller pass branches merged only up to the limit.
+  let totalItems = knownTotal ?? 0;
+  if (knownTotal === undefined) {
+    for (const output of items) {
+      if (Array.isArray(output)) {
+        totalItems += output.length;
+      }
     }
   }
 
   // Special case: limit = 0 means structure only
   if (limit === 0) {
     const structureOnly = items.map(output => {
+      if (output === null) return null;
       if (!Array.isArray(output) || output.length === 0) {
         return [];
       }
@@ -400,7 +295,7 @@ function truncateItems(
       metadata: {
         totalItems,
         itemsShown: 0,
-        truncated: true,
+        truncated: totalItems > 0,
       },
     };
   }
@@ -418,7 +313,7 @@ function truncateItems(
   }
 
   // Apply limit
-  const result: unknown[][] = [];
+  const result: RunBranch[] = [];
   let itemsShown = 0;
 
   for (const output of items) {
@@ -566,49 +461,40 @@ export function filterExecutionData(
       continue;
     }
 
-    // Node-level metadata (executionTime) still comes from the first run;
-    // item data and error status are aggregated across every run below,
-    // since a node invoked multiple times in one execution (e.g. an AI
-    // Agent's Chat Model, called once to decide to call a tool and again
-    // to produce the final answer) produces one runData entry per call.
-    const firstRun = nodeData[0];
+    // Every field aggregates across all runs of the node.
     const itemCounts = countItems(nodeData);
     totalItems += itemCounts.output;
 
     const nodeResult: FilteredNodeData = {
-      executionTime: firstRun.executionTime,
+      executionTime: totalExecutionTime(nodeData),
       itemsInput: itemCounts.input,
       itemsOutput: itemCounts.output,
       status: 'success',
     };
 
-    // Check for errors across all runs, not just the first
-    const runError = getAnyRunError(nodeData);
+    const runError = getRunError(nodeData);
     if (runError) {
       nodeResult.status = 'error';
       nodeResult.error = extractErrorMessage(runError);
     }
 
-    // Handle full mode - include all data
+    // Merge only as many items per branch as will be shown; the counts above supply the totals.
+    // Structure-only (limit 0) still needs the first item of each branch.
+    const maxPerBranch = mode === 'full' || itemsLimit < 0 ? -1 : Math.max(itemsLimit, 1);
+    const outputData = mergeRunBranches(nodeData, 'data', maxPerBranch);
+
     if (mode === 'full') {
       nodeResult.data = {
-        output: getAllRunsOutputData(nodeData),
+        output: outputData,
         metadata: {
           totalItems: itemCounts.output,
           itemsShown: itemCounts.output,
           truncated: false,
         },
       };
-
-      const inputData = getAllRunsInputData(nodeData);
-      if (includeInputData && inputData.length > 0) {
-        nodeResult.data.input = inputData;
-      }
     } else {
-      // Summary or filtered mode - apply limits (flat, run-ordered across
-      // every invocation of the node)
-      const outputData = getAllRunsOutputData(nodeData);
-      const { truncated, metadata } = truncateItems(outputData, itemsLimit);
+      // Summary or filtered mode - apply item limits
+      const { truncated, metadata } = truncateItems(outputData, itemsLimit, itemCounts.output);
 
       if (metadata.truncated) {
         hasMoreData = true;
@@ -618,10 +504,19 @@ export function filterExecutionData(
         output: truncated,
         metadata,
       };
+    }
 
-      const inputData = getAllRunsInputData(nodeData);
-      if (includeInputData && inputData.length > 0) {
+    if (includeInputData && itemCounts.input > 0) {
+      const inputData = mergeRunBranches(nodeData, 'inputOverride', maxPerBranch);
+      if (mode === 'full') {
         nodeResult.data.input = inputData;
+      } else {
+        const { truncated, metadata } = truncateItems(inputData, itemsLimit, itemCounts.input);
+        if (metadata.truncated) {
+          hasMoreData = true;
+        }
+        nodeResult.data.input = truncated;
+        nodeResult.data.inputMetadata = metadata;
       }
     }
 

--- a/src/services/execution-processor.ts
+++ b/src/services/execution-processor.ts
@@ -150,6 +150,73 @@ function getRunInputData(run: any): unknown[][] {
 }
 
 /**
+ * Merge per-branch item arrays across every run of a node, aligned by
+ * branch/port index, in run order.
+ *
+ * A node's `runData` entry is an array of runs, not a single run: nodes
+ * invoked more than once within an execution (e.g. an AI Agent's Chat
+ * Model, called once to decide to call a tool and again to produce the
+ * final answer) get one array entry per invocation. Reading only
+ * `nodeData[0]` silently drops every later invocation's data - this
+ * merges branch[i] of every run into a single flat, run-ordered branch[i],
+ * so `itemsLimit` truncation still behaves like "first N items overall".
+ */
+function mergeRunsByBranch(nodeData: unknown, selector: (run: any) => unknown[][]): unknown[][] {
+  const merged: unknown[][] = [];
+
+  if (!Array.isArray(nodeData)) {
+    return merged;
+  }
+
+  for (const run of nodeData) {
+    const branches = selector(run);
+    branches.forEach((items, branchIndex) => {
+      if (!merged[branchIndex]) {
+        merged[branchIndex] = [];
+      }
+      merged[branchIndex].push(...items);
+    });
+  }
+
+  return merged;
+}
+
+/**
+ * Get output data across `main`/`ai_*` connection types AND across every
+ * run of the node (see {@link mergeRunsByBranch}).
+ */
+function getAllRunsOutputData(nodeData: unknown): unknown[][] {
+  return mergeRunsByBranch(nodeData, getRunOutputData);
+}
+
+/**
+ * Get input data (`inputOverride`) across every run of the node.
+ */
+function getAllRunsInputData(nodeData: unknown): unknown[][] {
+  return mergeRunsByBranch(nodeData, getRunInputData);
+}
+
+/**
+ * Find the error from a node's runs, if any. A node invoked multiple times
+ * only fails on one of its runs, and n8n does not necessarily record that
+ * as the first one - the last run with an error is the one that actually
+ * stopped the branch, so it wins over any earlier error.
+ */
+function getAnyRunError(nodeData: unknown): unknown {
+  if (!Array.isArray(nodeData)) {
+    return undefined;
+  }
+
+  let found: unknown;
+  for (const run of nodeData) {
+    if (run?.error) {
+      found = run.error;
+    }
+  }
+  return found;
+}
+
+/**
  * Count items in execution data
  */
 function countItems(nodeData: unknown): { input: number; output: number } {
@@ -207,11 +274,10 @@ export function generatePreview(execution: Execution): {
     const nodeData = runData[nodeName];
     const itemCounts = countItems(nodeData);
 
-    // Extract structure from first run's first output item
+    // Extract structure from the first available output item across all runs
     let dataStructure: Record<string, unknown> = {};
     if (Array.isArray(nodeData) && nodeData.length > 0) {
-      const firstRun = nodeData[0];
-      const firstItem = getRunOutputData(firstRun)?.[0]?.[0];
+      const firstItem = getAllRunsOutputData(nodeData)?.[0]?.[0];
       if (firstItem) {
         dataStructure = extractStructure(firstItem) as Record<string, unknown>;
       }
@@ -500,7 +566,11 @@ export function filterExecutionData(
       continue;
     }
 
-    // Get first run data
+    // Node-level metadata (executionTime) still comes from the first run;
+    // item data and error status are aggregated across every run below,
+    // since a node invoked multiple times in one execution (e.g. an AI
+    // Agent's Chat Model, called once to decide to call a tool and again
+    // to produce the final answer) produces one runData entry per call.
     const firstRun = nodeData[0];
     const itemCounts = countItems(nodeData);
     totalItems += itemCounts.output;
@@ -512,16 +582,17 @@ export function filterExecutionData(
       status: 'success',
     };
 
-    // Check for errors
-    if (firstRun.error) {
+    // Check for errors across all runs, not just the first
+    const runError = getAnyRunError(nodeData);
+    if (runError) {
       nodeResult.status = 'error';
-      nodeResult.error = extractErrorMessage(firstRun.error);
+      nodeResult.error = extractErrorMessage(runError);
     }
 
     // Handle full mode - include all data
     if (mode === 'full') {
       nodeResult.data = {
-        output: getRunOutputData(firstRun),
+        output: getAllRunsOutputData(nodeData),
         metadata: {
           totalItems: itemCounts.output,
           itemsShown: itemCounts.output,
@@ -529,13 +600,14 @@ export function filterExecutionData(
         },
       };
 
-      const inputData = getRunInputData(firstRun);
+      const inputData = getAllRunsInputData(nodeData);
       if (includeInputData && inputData.length > 0) {
         nodeResult.data.input = inputData;
       }
     } else {
-      // Summary or filtered mode - apply limits
-      const outputData = getRunOutputData(firstRun);
+      // Summary or filtered mode - apply limits (flat, run-ordered across
+      // every invocation of the node)
+      const outputData = getAllRunsOutputData(nodeData);
       const { truncated, metadata } = truncateItems(outputData, itemsLimit);
 
       if (metadata.truncated) {
@@ -547,7 +619,7 @@ export function filterExecutionData(
         metadata,
       };
 
-      const inputData = getRunInputData(firstRun);
+      const inputData = getAllRunsInputData(nodeData);
       if (includeInputData && inputData.length > 0) {
         nodeResult.data.input = inputData;
       }

--- a/src/services/execution-processor.ts
+++ b/src/services/execution-processor.ts
@@ -106,6 +106,50 @@ function estimateDataSize(data: unknown): number {
 }
 
 /**
+ * Extract per-branch item arrays from a task-data connections object
+ * (e.g. `run.data` or `run.inputOverride`).
+ *
+ * Regular nodes connect via the `main` connection type, but LangChain
+ * AI Agent sub-nodes (Chat Model, Output Parser, Tool, Memory, etc.)
+ * connect via special `ai_*` connection types (ai_languageModel,
+ * ai_outputParser, ai_tool, ai_memory, ai_embedding, ...) instead of
+ * `main`. A node's task data only ever populates one of these keys, so
+ * merging all of them is equivalent to "whichever one this node uses".
+ */
+function extractConnectionBranches(connections: unknown): unknown[][] {
+  const branches: unknown[][] = [];
+
+  if (!connections || typeof connections !== 'object') {
+    return branches;
+  }
+
+  for (const value of Object.values(connections as Record<string, unknown>)) {
+    if (Array.isArray(value)) {
+      for (const branch of value) {
+        branches.push(Array.isArray(branch) ? branch : []);
+      }
+    }
+  }
+
+  return branches;
+}
+
+/**
+ * Get a run's output data across `main` and any `ai_*` connection types.
+ */
+function getRunOutputData(run: any): unknown[][] {
+  return extractConnectionBranches(run?.data);
+}
+
+/**
+ * Get a run's input data (n8n stores this under `inputOverride`, keyed by
+ * connection type, mirroring the `data` field's shape).
+ */
+function getRunInputData(run: any): unknown[][] {
+  return extractConnectionBranches(run?.inputOverride);
+}
+
+/**
  * Count items in execution data
  */
 function countItems(nodeData: unknown): { input: number; output: number } {
@@ -116,15 +160,11 @@ function countItems(nodeData: unknown): { input: number; output: number } {
   }
 
   for (const run of nodeData) {
-    if (run?.data?.main) {
-      const mainData = run.data.main;
-      if (Array.isArray(mainData)) {
-        for (const output of mainData) {
-          if (Array.isArray(output)) {
-            counts.output += output.length;
-          }
-        }
-      }
+    for (const output of getRunOutputData(run)) {
+      counts.output += output.length;
+    }
+    for (const input of getRunInputData(run)) {
+      counts.input += input.length;
     }
   }
 
@@ -171,7 +211,7 @@ export function generatePreview(execution: Execution): {
     let dataStructure: Record<string, unknown> = {};
     if (Array.isArray(nodeData) && nodeData.length > 0) {
       const firstRun = nodeData[0];
-      const firstItem = firstRun?.data?.main?.[0]?.[0];
+      const firstItem = getRunOutputData(firstRun)?.[0]?.[0];
       if (firstItem) {
         dataStructure = extractStructure(firstItem) as Record<string, unknown>;
       }
@@ -481,7 +521,7 @@ export function filterExecutionData(
     // Handle full mode - include all data
     if (mode === 'full') {
       nodeResult.data = {
-        output: firstRun.data?.main || [],
+        output: getRunOutputData(firstRun),
         metadata: {
           totalItems: itemCounts.output,
           itemsShown: itemCounts.output,
@@ -489,12 +529,13 @@ export function filterExecutionData(
         },
       };
 
-      if (includeInputData && firstRun.inputData) {
-        nodeResult.data.input = firstRun.inputData;
+      const inputData = getRunInputData(firstRun);
+      if (includeInputData && inputData.length > 0) {
+        nodeResult.data.input = inputData;
       }
     } else {
       // Summary or filtered mode - apply limits
-      const outputData = firstRun.data?.main || [];
+      const outputData = getRunOutputData(firstRun);
       const { truncated, metadata } = truncateItems(outputData, itemsLimit);
 
       if (metadata.truncated) {
@@ -506,8 +547,9 @@ export function filterExecutionData(
         metadata,
       };
 
-      if (includeInputData && firstRun.inputData) {
-        nodeResult.data.input = firstRun.inputData;
+      const inputData = getRunInputData(firstRun);
+      if (includeInputData && inputData.length > 0) {
+        nodeResult.data.input = inputData;
       }
     }
 

--- a/src/services/execution-run-data.ts
+++ b/src/services/execution-run-data.ts
@@ -1,0 +1,161 @@
+/**
+ * Helpers for reading n8n execution `runData`.
+ *
+ * n8n stores execution results as `runData[nodeName]`: an array with one
+ * entry per invocation of the node ("run"), not a single entry. Nodes can
+ * run more than once in an execution (an AI Agent's Chat Model is called
+ * once to decide on a tool and again to produce the final answer), so
+ * reading only `nodeData[0]` drops every later invocation.
+ *
+ * Each run holds its items under a connections object keyed by connection
+ * type (`ITaskDataConnections` in n8n-workflow), whose values are arrays of
+ * branches (output or input ports), each branch an array of items or
+ * `null` when n8n recorded nothing on that port:
+ *
+ *   { data: { main: [[item, item], null] } }
+ *
+ * Outputs live under `data`, inputs under `inputOverride`. Regular nodes
+ * use the `main` connection type; LangChain AI Agent sub-nodes (Chat
+ * Model, Output Parser, Tool, Memory, Embedding, ...) use `ai_*` types
+ * instead. Merging keeps branches of different connection types apart, so
+ * a node whose runs populate different types still reads correctly.
+ */
+
+/** Field of a run holding its connections object. */
+export type RunDataField = 'data' | 'inputOverride';
+
+/** One port's items, or `null` when n8n recorded no data on that port. */
+export type RunBranch = unknown[] | null;
+
+/** Branches of a connections object grouped by connection type, in the order the keys appear. */
+function branchesByType(connections: unknown): Array<[string, RunBranch[]]> {
+  if (!connections || typeof connections !== 'object') return [];
+  const grouped: Array<[string, RunBranch[]]> = [];
+  for (const [type, value] of Object.entries(connections as Record<string, unknown>)) {
+    if (!Array.isArray(value)) continue;
+    grouped.push([type, value.map(branch => (Array.isArray(branch) ? branch : null))]);
+  }
+  return grouped;
+}
+
+/** Flatten a connections object into its branches, connection types in the order the keys appear. */
+export function extractConnectionBranches(connections: unknown): RunBranch[] {
+  return branchesByType(connections).flatMap(([, branches]) => branches);
+}
+
+/**
+ * Merge a node's branches across every run, in run order, so a branch
+ * holds its items from run 0, then run 1, and so on. Branches are matched
+ * by connection type and port index, and the result lists the types in the
+ * order they were first seen, so branch 0 belongs to whichever type a run
+ * recorded first. A branch that no run filled stays `null`.
+ *
+ * `maxPerBranch` caps how many items each merged branch collects, for
+ * callers that only show the first N and already know the totals; the
+ * cap never changes which items come first.
+ */
+export function mergeRunBranches(
+  nodeData: unknown,
+  field: RunDataField = 'data',
+  maxPerBranch = -1
+): RunBranch[] {
+  if (!Array.isArray(nodeData)) return [];
+
+  const byType = new Map<string, RunBranch[]>();
+  for (const run of nodeData) {
+    for (const [type, branches] of branchesByType(run?.[field])) {
+      let merged = byType.get(type);
+      if (!merged) {
+        merged = [];
+        byType.set(type, merged);
+      }
+      branches.forEach((items, index) => {
+        while (merged!.length <= index) merged!.push(null);
+        if (items === null) return;
+        let target = merged![index];
+        if (!Array.isArray(target)) {
+          target = [];
+          merged![index] = target;
+        }
+        const room = maxPerBranch < 0 ? items.length : Math.max(0, maxPerBranch - target.length);
+        // A loop rather than push(...items): spreading a large branch overflows the call stack.
+        for (let i = 0; i < room && i < items.length; i++) target.push(items[i]);
+      });
+    }
+  }
+
+  return [...byType.values()].flat();
+}
+
+/**
+ * Sample items from a node: its first output branch that carries any,
+ * merged across every run. Branch 0 for most nodes; a node that emitted
+ * only on a later port (an IF node's false branch) still yields a sample.
+ */
+export function sampleRunItems(nodeData: unknown, maxItems = -1): unknown[] {
+  return mergeRunBranches(nodeData, 'data', maxItems).find(branch => branch && branch.length > 0) ?? [];
+}
+
+/** Output items across every run, port and connection type, without copying anything. */
+export function countRunItems(nodeData: unknown): number {
+  if (!Array.isArray(nodeData)) return 0;
+  let count = 0;
+  for (const run of nodeData) {
+    for (const branch of extractConnectionBranches(run?.data)) count += branch?.length ?? 0;
+  }
+  return count;
+}
+
+/** The first item any run produced, without merging everything to find it. */
+export function firstRunItem(nodeData: unknown, field: RunDataField = 'data'): unknown {
+  if (!Array.isArray(nodeData)) return undefined;
+  for (const run of nodeData) {
+    for (const branch of extractConnectionBranches(run?.[field])) {
+      if (branch && branch.length > 0) return branch[0];
+    }
+  }
+  return undefined;
+}
+
+/** Whether any run recorded an output branch, even an empty one, as opposed to `null` ports only. */
+export function hasRunOutputData(nodeData: unknown): boolean {
+  if (!Array.isArray(nodeData)) return false;
+  return nodeData.some(run => extractConnectionBranches(run?.data).some(Array.isArray));
+}
+
+/** The latest `startTime` across a node's runs, 0 when none reported one. */
+export function latestStartTime(nodeData: unknown): number {
+  if (!Array.isArray(nodeData)) return 0;
+  let latest = 0;
+  for (const run of nodeData) {
+    if (typeof run?.startTime === 'number' && run.startTime > latest) latest = run.startTime;
+  }
+  return latest;
+}
+
+/** Total `executionTime` across every run, or undefined when no run reported one. */
+export function totalExecutionTime(nodeData: unknown): number | undefined {
+  if (!Array.isArray(nodeData)) return undefined;
+  let total: number | undefined;
+  for (const run of nodeData) {
+    if (typeof run?.executionTime === 'number') total = (total ?? 0) + run.executionTime;
+  }
+  return total;
+}
+
+/**
+ * The error from a node's runs, if any. A node invoked several times
+ * fails on only one of them, and the last failing run is the one that
+ * stopped the branch, so it wins over any earlier error.
+ */
+export function getRunError(nodeData: unknown): any {
+  if (!Array.isArray(nodeData)) return undefined;
+
+  let found: any;
+  for (const run of nodeData) {
+    if (run?.error) {
+      found = run.error;
+    }
+  }
+  return found;
+}

--- a/src/types/n8n-api.ts
+++ b/src/types/n8n-api.ts
@@ -598,9 +598,16 @@ export interface FilteredNodeData {
   status: 'success' | 'error';
   error?: string;
   data?: {
-    input?: any[][];
-    output?: any[][];
+    /** Branches are `null` where n8n recorded no data on that port. */
+    input?: Array<any[] | null>;
+    output?: Array<any[] | null>;
     metadata: {
+      totalItems: number;
+      itemsShown: number;
+      truncated: boolean;
+    };
+    /** In summary and filtered modes, with `input`: inputs obey the same item limit, since AI sub-nodes fill them with whole prompts. */
+    inputMetadata?: {
       totalItems: number;
       itemsShown: number;
       truncated: boolean;

--- a/tests/unit/services/error-execution-processor.test.ts
+++ b/tests/unit/services/error-execution-processor.test.ts
@@ -956,3 +956,123 @@ describe('ErrorExecutionProcessor - Performance', () => {
     expect(result.upstreamContext?.dataStructure).toBeDefined();
   });
 });
+
+/**
+ * Multi-run node tests
+ *
+ * A node invoked more than once within a single execution (e.g. an AI
+ * Agent's Chat Model, called once to decide to call a tool and again to
+ * produce the final answer) gets one runData array entry per invocation.
+ * Error detection and item sampling must look across every run, not just
+ * the first.
+ */
+describe('ErrorExecutionProcessor - multi-run nodes', () => {
+  function twoRunUpstreamNode() {
+    return [
+      {
+        startTime: Date.now() - 2000,
+        executionTime: 500,
+        data: { ai_languageModel: [[{ json: { text: 'first turn' } }]] },
+      },
+      {
+        startTime: Date.now() - 1000,
+        executionTime: 1200,
+        data: { ai_languageModel: [[{ json: { text: 'second turn' } }]] },
+      },
+    ];
+  }
+
+  it('should merge upstream context items across all runs (heuristic path, no workflow)', () => {
+    const execution = createMockExecution({
+      runData: {
+        'Upstream': twoRunUpstreamNode(),
+        'Error Node': createErrorNodeData(),
+      },
+    });
+
+    const result = processErrorExecution(execution);
+
+    expect(result.upstreamContext?.itemCount).toBe(2);
+    expect(result.upstreamContext?.sampleItems).toHaveLength(2);
+    expect((result.upstreamContext?.sampleItems?.[0] as any)?.json?.text).toBe('first turn');
+    expect((result.upstreamContext?.sampleItems?.[1] as any)?.json?.text).toBe('second turn');
+  });
+
+  it('should merge upstream context items across all runs (workflow path)', () => {
+    const execution = createMockExecution({
+      runData: {
+        'Upstream': twoRunUpstreamNode(),
+        'Error Node': createErrorNodeData(),
+      },
+    });
+
+    const workflow = createMockWorkflow({
+      connections: {
+        'Upstream': { main: [[{ node: 'Error Node', type: 'main', index: 0 }]] },
+      },
+      nodes: [
+        { name: 'Upstream', type: 'n8n-nodes-base.test' },
+        { name: 'Error Node', type: 'n8n-nodes-base.test' },
+      ],
+    });
+
+    const result = processErrorExecution(execution, { workflow });
+
+    expect(result.upstreamContext?.itemCount).toBe(2);
+    expect(result.upstreamContext?.sampleItems).toHaveLength(2);
+  });
+
+  it('should detect an error on a non-first run as an additional error', () => {
+    const nodeData = twoRunUpstreamNode();
+    (nodeData[1] as any).error = { message: 'Second run failed' };
+
+    const execution = createMockExecution({
+      runData: {
+        'Trigger': createSuccessfulNodeData(1),
+        'Multi-run Node': nodeData,
+        'Error Node': createErrorNodeData(),
+      },
+    });
+
+    const result = processErrorExecution(execution);
+
+    expect(result.additionalErrors).toContainEqual({
+      nodeName: 'Multi-run Node',
+      message: 'Second run failed',
+    });
+  });
+
+  it('should detect a primary error on a non-first run of the failing node', () => {
+    const nodeData = twoRunUpstreamNode();
+    (nodeData[1] as any).error = { message: 'Failed on second invocation', name: 'NodeOperationError' };
+
+    const execution = createMockExecution({
+      errorNode: 'Multi-run Error Node',
+      errorMessage: 'Failed on second invocation',
+      runData: {
+        'Trigger': createSuccessfulNodeData(1),
+        'Multi-run Error Node': nodeData,
+      },
+      hasExecutionError: false, // force fallback to node-level runData error
+    });
+
+    const result = processErrorExecution(execution);
+
+    expect(result.primaryError.message).toBe('Failed on second invocation');
+  });
+
+  it('should count itemCount across all runs in the execution path', () => {
+    const execution = createMockExecution({
+      runData: {
+        'Multi-run Node': twoRunUpstreamNode(),
+        'Error Node': createErrorNodeData(),
+      },
+    });
+
+    const result = processErrorExecution(execution, { includeExecutionPath: true });
+    const step = result.executionPath?.find(p => p.nodeName === 'Multi-run Node');
+
+    expect(step?.itemCount).toBe(2);
+    expect(step?.status).toBe('success');
+  });
+});

--- a/tests/unit/services/execution-processor.test.ts
+++ b/tests/unit/services/execution-processor.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { countRunItems, firstRunItem, mergeRunBranches, sampleRunItems, totalExecutionTime } from '@/services/execution-run-data';
 import {
   generatePreview,
   filterExecutionData,
@@ -791,7 +792,7 @@ describe('ExecutionProcessor - AI Agent sub-node connection types', () => {
     expect(nodeData?.data?.input?.[0]?.[0]?.json?.messages?.[0]).toBe('System: hi');
   });
 
-  it('should not conflate ai_* and main data when both happen to be present', () => {
+  it('counts both connection types when a run populates more than one', () => {
     const execution = createMockExecution({
       nodeData: {
         'Mixed Node': [
@@ -852,7 +853,7 @@ describe('ExecutionProcessor - multi-run nodes', () => {
 
     const result = filterExecutionData(execution, { mode: 'full' });
     const nodeData = result.nodes?.['Chat Model'];
-    const flat = nodeData?.data?.output.flat() ?? [];
+    const flat = nodeData?.data?.output?.flat() ?? [];
 
     expect(nodeData?.itemsOutput).toBe(2);
     expect(flat).toHaveLength(2);
@@ -867,7 +868,7 @@ describe('ExecutionProcessor - multi-run nodes', () => {
 
     const result = filterExecutionData(execution, { mode: 'filtered', itemsLimit: 1 });
     const nodeData = result.nodes?.['Chat Model'];
-    const flat = nodeData?.data?.output.flat() ?? [];
+    const flat = nodeData?.data?.output?.flat() ?? [];
 
     expect(nodeData?.itemsOutput).toBe(2);
     expect(nodeData?.data?.metadata.truncated).toBe(true);
@@ -912,5 +913,97 @@ describe('ExecutionProcessor - multi-run nodes', () => {
 
     expect(preview.nodes['Chat Model'].itemCounts.output).toBe(1);
     expect(preview.nodes['Chat Model'].dataStructure).toHaveProperty('json');
+  });
+});
+
+describe('execution-run-data helpers', () => {
+  const run = (data: Record<string, unknown>, executionTime?: number) => ({ startTime: 0, executionTime, data });
+
+  it('keeps branches of different connection types apart across runs', () => {
+    const merged = mergeRunBranches([
+      run({ main: [[{ json: { a: 1 } }]], ai_tool: [[{ json: { b: 2 } }]] }),
+      run({ ai_tool: [[{ json: { c: 3 } }]] }),
+    ]);
+
+    expect(merged).toEqual([[{ json: { a: 1 } }], [{ json: { b: 2 } }, { json: { c: 3 } }]]);
+  });
+
+  it('preserves a null port and fills it from a later run', () => {
+    expect(mergeRunBranches([run({ main: [[{ json: { a: 1 } }], null] })])).toEqual([[{ json: { a: 1 } }], null]);
+    expect(
+      mergeRunBranches([run({ main: [null, null] }), run({ main: [null, [{ json: { b: 2 } }]] })])
+    ).toEqual([null, [{ json: { b: 2 } }]]);
+  });
+
+  it('caps each merged branch without changing which items come first', () => {
+    const merged = mergeRunBranches(
+      [run({ main: [[1, 2, 3]] }), run({ main: [[4, 5]] })],
+      'data',
+      4
+    );
+
+    expect(merged).toEqual([[1, 2, 3, 4]]);
+  });
+
+  it('merges a branch too large to spread into a call', () => {
+    const big = Array.from({ length: 200_000 }, (_, i) => i);
+
+    expect(mergeRunBranches([run({ main: [big] }), run({ main: [big] })])[0]).toHaveLength(400_000);
+  });
+
+  it('counts every port and type, and samples from the first branch that has items', () => {
+    const runs = [
+      run({ main: [[{ json: { a: 1 } }]], ai_tool: [[{ json: { b: 2 } }]] }),
+      run({ ai_tool: [[{ json: { c: 3 } }]] }),
+    ];
+    expect(countRunItems(runs)).toBe(3);
+    expect(sampleRunItems(runs)).toEqual([{ json: { a: 1 } }]);
+
+    // An IF node that only emitted on its false branch still counts and yields a sample
+    const ifNode = [run({ main: [[], [{ json: { no: true } }]] })];
+    expect(countRunItems(ifNode)).toBe(1);
+    expect(sampleRunItems(ifNode)).toEqual([{ json: { no: true } }]);
+  });
+
+  it('finds the first item without merging and sums execution time across runs', () => {
+    const runs = [run({ main: [null, []] }, 500), run({ ai_tool: [[{ json: { x: 1 } }]] }, 1200)];
+
+    expect(firstRunItem(runs)).toEqual({ json: { x: 1 } });
+    expect(totalExecutionTime(runs)).toBe(1700);
+    expect(totalExecutionTime([run({ main: [[]] })])).toBeUndefined();
+  });
+});
+
+describe('ExecutionProcessor - input truncation', () => {
+  it('applies the item limit to inputs and reports their own metadata', () => {
+    const prompts = Array.from({ length: 5 }, (_, i) => ({ json: { prompt: `turn ${i}` } }));
+    const execution = createMockExecution({
+      nodeData: {
+        'Chat Model': [
+          { startTime: 0, executionTime: 1, inputOverride: { ai_languageModel: [prompts] }, data: { ai_languageModel: [[{ json: { text: 'a' } }]] } },
+        ],
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'filtered', itemsLimit: 2, includeInputData: true });
+    const node = result.nodes?.['Chat Model'];
+
+    expect(node?.data?.input).toEqual([prompts.slice(0, 2)]);
+    expect(node?.data?.inputMetadata).toEqual({ totalItems: 5, itemsShown: 2, truncated: true });
+    expect(node?.itemsInput).toBe(5);
+    expect(result.summary?.hasMoreData).toBe(true);
+  });
+});
+
+describe('ExecutionProcessor - structure-only mode with no items', () => {
+  it('does not report more data for a node that produced nothing', () => {
+    const execution = createMockExecution({
+      nodeData: { Empty: [{ startTime: 0, executionTime: 1, data: { main: [[]] } }] },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'filtered', itemsLimit: 0 });
+
+    expect(result.nodes?.Empty?.data?.metadata).toEqual({ totalItems: 0, itemsShown: 0, truncated: false });
+    expect(result.summary?.hasMoreData).toBe(false);
   });
 });

--- a/tests/unit/services/execution-processor.test.ts
+++ b/tests/unit/services/execution-processor.test.ts
@@ -815,3 +815,102 @@ describe('ExecutionProcessor - AI Agent sub-node connection types', () => {
     expect(nodeData?.itemsOutput).toBe(2);
   });
 });
+
+/**
+ * Multi-run node tests
+ *
+ * A node invoked more than once within a single execution (e.g. an AI
+ * Agent's Chat Model, called once to decide to call a tool and again to
+ * produce the final answer) gets one runData array entry per invocation.
+ * itemsInput/itemsOutput already summed across every run; the returned
+ * data itself must too, in run order.
+ */
+describe('ExecutionProcessor - multi-run nodes', () => {
+  function twoRunChatModel() {
+    return [
+      {
+        startTime: Date.now(),
+        executionTime: 500,
+        data: {
+          ai_languageModel: [[{ json: { text: 'first turn: deciding to call a tool', tokenUsage: { completionTokens: 56 } } }]],
+        },
+      },
+      {
+        startTime: Date.now() + 500,
+        executionTime: 1200,
+        data: {
+          ai_languageModel: [[{ json: { text: 'second turn: the real answer', tokenUsage: { completionTokens: 800 } } }]],
+        },
+      },
+    ];
+  }
+
+  it('should return items from every run, not just the first, in full mode', () => {
+    const execution = createMockExecution({
+      nodeData: { 'Chat Model': twoRunChatModel() },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'full' });
+    const nodeData = result.nodes?.['Chat Model'];
+    const flat = nodeData?.data?.output.flat() ?? [];
+
+    expect(nodeData?.itemsOutput).toBe(2);
+    expect(flat).toHaveLength(2);
+    expect(flat[0]?.json?.text).toBe('first turn: deciding to call a tool');
+    expect(flat[1]?.json?.text).toBe('second turn: the real answer');
+  });
+
+  it('should truncate across all runs in flat run order for summary/filtered mode', () => {
+    const execution = createMockExecution({
+      nodeData: { 'Chat Model': twoRunChatModel() },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'filtered', itemsLimit: 1 });
+    const nodeData = result.nodes?.['Chat Model'];
+    const flat = nodeData?.data?.output.flat() ?? [];
+
+    expect(nodeData?.itemsOutput).toBe(2);
+    expect(nodeData?.data?.metadata.truncated).toBe(true);
+    expect(flat).toHaveLength(1);
+    expect(flat[0]?.json?.text).toBe('first turn: deciding to call a tool');
+  });
+
+  it('should merge inputOverride across all runs too', () => {
+    const nodeData = twoRunChatModel();
+    (nodeData[0] as any).inputOverride = { ai_languageModel: [[{ json: { prompt: 'prompt 1' } }]] };
+    (nodeData[1] as any).inputOverride = { ai_languageModel: [[{ json: { prompt: 'prompt 2' } }]] };
+
+    const execution = createMockExecution({ nodeData: { 'Chat Model': nodeData } });
+    const result = filterExecutionData(execution, { mode: 'full', includeInputData: true });
+    const flatInput = result.nodes?.['Chat Model']?.data?.input?.flat() ?? [];
+
+    expect(flatInput).toHaveLength(2);
+    expect(flatInput[0]?.json?.prompt).toBe('prompt 1');
+    expect(flatInput[1]?.json?.prompt).toBe('prompt 2');
+  });
+
+  it('should detect an error on a non-first run', () => {
+    const nodeData = twoRunChatModel();
+    (nodeData[0] as any).error = undefined;
+    (nodeData[1] as any).error = { message: 'The AI model returned an empty response', name: 'NodeOperationError' };
+
+    const execution = createMockExecution({ nodeData: { 'Output Parser': nodeData } });
+    const result = filterExecutionData(execution, { mode: 'summary' });
+    const nodeResult = result.nodes?.['Output Parser'];
+
+    expect(nodeResult?.status).toBe('error');
+    expect(nodeResult?.error).toBe('The AI model returned an empty response');
+  });
+
+  it('should sample the first available item across runs in preview mode', () => {
+    const nodeData = twoRunChatModel();
+    // First run has no output at all; only the second run does.
+    (nodeData[0] as any).data = { ai_languageModel: [[]] };
+
+    const execution = createMockExecution({ nodeData: { 'Chat Model': nodeData } });
+    const { preview } = generatePreview(execution);
+
+    expect(preview.nodes['Chat Model'].itemCounts.output).toBe(1);
+    expect(preview.nodes['Chat Model'].dataStructure).toHaveProperty('json');
+  });
+});

--- a/tests/unit/services/execution-processor.test.ts
+++ b/tests/unit/services/execution-processor.test.ts
@@ -342,7 +342,9 @@ describe('ExecutionProcessor - Filtering', () => {
           {
             startTime: Date.now(),
             executionTime: 100,
-            inputData: [[{ json: { input: 'test' } }]],
+            inputOverride: {
+              main: [[{ json: { input: 'test' } }]],
+            },
             data: {
               main: [[{ json: { output: 'result' } }]],
             },
@@ -370,7 +372,9 @@ describe('ExecutionProcessor - Filtering', () => {
           {
             startTime: Date.now(),
             executionTime: 100,
-            inputData: [[{ json: { input: 'test' } }]],
+            inputOverride: {
+              main: [[{ json: { input: 'test' } }]],
+            },
             data: {
               main: [[{ json: { output: 'result' } }]],
             },
@@ -661,5 +665,153 @@ describe('ExecutionProcessor - Summary Statistics', () => {
     const result = filterExecutionData(execution, { mode: 'summary' });
 
     expect(result.summary?.totalItems).toBe(18);
+  });
+});
+
+/**
+ * AI Agent sub-node connection type tests
+ *
+ * LangChain AI Agent sub-nodes (Chat Model, Output Parser, Tool, Memory,
+ * Embeddings, etc.) connect to their parent Agent node via special `ai_*`
+ * connection types instead of `main`. Their task data therefore lives at
+ * `run.data.ai_languageModel`, `run.data.ai_outputParser`, `run.data.ai_tool`,
+ * etc. rather than `run.data.main`.
+ */
+describe('ExecutionProcessor - AI Agent sub-node connection types', () => {
+  it('should extract itemsOutput from ai_languageModel connection data', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'OpenAI Chat Model': [
+          {
+            startTime: Date.now(),
+            executionTime: 850,
+            data: {
+              ai_languageModel: [[{ json: { response: { generations: [[{ text: 'hi' }]] }, tokenUsage: { totalTokens: 42 } } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'full' });
+    const nodeData = result.nodes?.['OpenAI Chat Model'];
+
+    expect(nodeData?.itemsOutput).toBe(1);
+    expect(nodeData?.data?.output?.[0]?.[0]?.json?.tokenUsage?.totalTokens).toBe(42);
+  });
+
+  it('should extract itemsOutput from ai_outputParser connection data', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'Structured Output Parser': [
+          {
+            startTime: Date.now(),
+            executionTime: 5,
+            data: {
+              ai_outputParser: [[{ json: { output: { category: 'buyer_request' } } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'summary' });
+    const nodeData = result.nodes?.['Structured Output Parser'];
+
+    expect(nodeData?.itemsOutput).toBe(1);
+    expect(nodeData?.data?.output?.[0]?.[0]?.json?.output?.category).toBe('buyer_request');
+  });
+
+  it('should extract itemsOutput from ai_tool connection data', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'HTTP Request Tool': [
+          {
+            startTime: Date.now(),
+            executionTime: 200,
+            data: {
+              ai_tool: [[{ json: { result: 'tool output' } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'filtered', itemsLimit: -1 });
+    const nodeData = result.nodes?.['HTTP Request Tool'];
+
+    expect(nodeData?.itemsOutput).toBe(1);
+    expect(nodeData?.data?.output?.[0]?.[0]?.json?.result).toBe('tool output');
+  });
+
+  it('should include ai_* nodes in preview mode item counts and structure', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'OpenAI Chat Model': [
+          {
+            startTime: Date.now(),
+            executionTime: 850,
+            data: {
+              ai_languageModel: [[{ json: { tokenUsage: { totalTokens: 10 } } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const { preview } = generatePreview(execution);
+    const nodePreview = preview.nodes['OpenAI Chat Model'];
+
+    expect(nodePreview.itemCounts.output).toBe(1);
+    expect(nodePreview.dataStructure).toHaveProperty('json');
+  });
+
+  it('should extract input data from inputOverride for ai_* connection types', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'OpenAI Chat Model': [
+          {
+            startTime: Date.now(),
+            executionTime: 850,
+            inputOverride: {
+              ai_languageModel: [[{ json: { messages: ['System: hi'] } }]],
+            },
+            data: {
+              ai_languageModel: [[{ json: { tokenUsage: { totalTokens: 10 } } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'full', includeInputData: true });
+    const nodeData = result.nodes?.['OpenAI Chat Model'];
+
+    expect(nodeData?.itemsInput).toBe(1);
+    expect(nodeData?.data?.input?.[0]?.[0]?.json?.messages?.[0]).toBe('System: hi');
+  });
+
+  it('should not conflate ai_* and main data when both happen to be present', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'Mixed Node': [
+          {
+            startTime: Date.now(),
+            executionTime: 10,
+            data: {
+              main: [[{ json: { a: 1 } }]],
+              ai_tool: [[{ json: { b: 2 } }]],
+            },
+          },
+        ],
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'full' });
+    const nodeData = result.nodes?.['Mixed Node'];
+
+    // Both branches should be counted/included since a node's task data
+    // could in principle populate more than one connection type.
+    expect(nodeData?.itemsOutput).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

Takes over #965 by @JohanDuque. Before this change the execution processors behind `n8n_executions` read only `runData[node][0].data.main`, so LangChain AI sub-nodes (Chat Model, Tool, Memory, Output Parser), whose task data lives under `ai_*` connection types, showed no items, and a node invoked more than once in an execution (an agent's model, called once per tool round) lost every run after the first.

## What changed

- `src/services/execution-run-data.ts` (new): shared helpers for n8n's `runData` shape. Items are merged across runs keyed by connection type and port index, so runs that populate different types (`main`, `ai_tool`) stay apart; a port n8n recorded as `null` stays `null`; appending uses a loop (spreading a 150k-item branch overflowed the call stack); `maxPerBranch` bounds the merge; `firstRunItem`, `countRunItems` and `totalExecutionTime` read without copying.
- `src/services/execution-processor.ts`: `summary`/`filtered` modes merge only up to the item limit and pass the counts to `truncateItems`; inputs (`includeInputData`) are truncated with the same limit and described by a new `data.inputMetadata`; `preview` reports the last failing run's error like the other modes; `executionTime` is the sum across runs.
- `src/services/error-execution-processor.ts`: upstream context, execution path and additional errors use the same helpers, so `error` mode sees AI sub-nodes; sampling merges only the samples it returns.
- `src/types/n8n-api.ts`: branches typed `Array<any[] | null>`, `inputMetadata` added. Plain single-run `main` nodes return the same shape as before.
- Version 2.80.1, changelog entry.

## Review

Code-simplifier pass, Opus code-reviewer (two rounds), and Codex (two rounds). The first round found the call-stack overflow, unbounded merging and unbounded inputs, the connection-type conflation and the null-port shape change; all fixed. Second round: Opus MERGE, Codex's two remaining Mediums (count/merge consistency, error-mode sampling cost) fixed with a test pinning `countRunItems` to the branch `mergeRunItems` returns.

## Credits

- @JohanDuque for the fix and tests in #965.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)
