### PR TITLE
fix: harden the workflow write path (node allowlist, settings retry, rollback verification) (v2.81.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.81.0] - 2026-09-03
+
+### Added
+
+- **Workflow writes retry without the settings an n8n instance rejects as unknown.** Settings are forwarded untouched on purpose, because the bundled settings table trails n8n's releases and a property dropped up front is dropped silently. The cost was that a setting the instance's write schema does not accept failed the whole write with `request/body/settings must NOT have additional properties`, a message that never names the key, which is what users hit when a GET echoes a property such as `timeSavedMode` that their n8n version stores but does not accept on PUT ([#1017](https://github.com/czlonkowski/n8n-mcp/pull/1017)). The API client now retries without candidates in a fixed order: keys absent from the settings table first, together, then known keys from newest to oldest; keys that predate n8n 1.119.0 are never dropped, since instances that old still report their version and are filtered precisely. Each dropped key is reported in the tool response `warnings` and remembered for the client's lifetime so later writes skip the probe. `timeSavedMode` itself stays writable: n8n 2.36 accepts and echoes it, so marking it derived would have dropped a real setting on current instances.
+
+### Fixed
+
+- **Node properties that n8n echoes on GET but rejects on PUT are stripped before a write** ([#983](https://github.com/czlonkowski/n8n-mcp/pull/983)). n8n's node schema is `additionalProperties: false`, and a GET can carry `issues`, `runIndex` or `data`, so a round trip failed with `request/body/nodes/0 must NOT have additional properties`. `cleanWorkflowForCreate` and `cleanWorkflowForUpdate` now keep only the properties of the node schema; the allowlist is derived from that schema, so it cannot drift from it. `onError` and `webhookId` were missing from the schema and are accepted.
+- **A rollback that n8n persisted before rejecting is no longer reported as failed** ([#979](https://github.com/czlonkowski/n8n-mcp/pull/979)). n8n's public API can commit workflow content and then throw on a later check, so `n8n_update_partial_workflow` could warn that a workflow was left broken when it had in fact been restored. After a rollback PUT throws, the handler re-reads the workflow and compares the writable fields with the pre-update snapshot; a match is reported as `rollbackVerifiedAfterError: true`. Webhook ids generated for the comparison are ignored; ids the workflow already carried are compared.
+- **Engine health check reported a hard-coded version** ([#908](https://github.com/czlonkowski/n8n-mcp/pull/908)). `N8NMCPEngine.healthCheck()` returned `2.24.1` regardless of the installed version; it now reports the package version. The HTTP server's response logging reads `writableEnded` instead of the deprecated `finished`.
+
+### Changed
+
+- Round-trip tests for GET→UPDATE workflow writes ([#925](https://github.com/czlonkowski/n8n-mcp/pull/925), [#433](https://github.com/czlonkowski/n8n-mcp/issues/433)): unit tests for the cleaners and integration tests against a live instance for the spread-a-GET-into-an-update patterns the n8n API is particular about.
+
 ## [2.80.1] - 2026-09-03
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.80.1",
+  "version": "2.81.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.80.1",
+      "version": "2.81.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.80.1",
+  "version": "2.81.0",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.80.1",
+  "version": "2.81.0",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/scripts/check-settings-drift.ts
+++ b/scripts/check-settings-drift.ts
@@ -108,6 +108,7 @@ export function parseSchemaProperties(
   const names = new Set<string>();
   let keyIndent: number | null = null;
   let current: string | null = null;
+  let readOnlyIndent: number | null = null;
 
   for (let i = propertiesIndex + 1; i < lines.length; i++) {
     const line = lines[i];
@@ -117,16 +118,19 @@ export function parseSchemaProperties(
 
     if (keyIndent === null) keyIndent = indent;
     if (indent !== keyIndent) {
-      // nested schema of the property above; `readOnly: true` there marks a GET-only property
-      if (current && line.trim() === 'readOnly: true') readOnly?.add(current);
+      // Directly under the property above, `readOnly: true` marks a GET-only property. Deeper
+      // lines belong to a sub-schema and say nothing about the property itself.
+      if (current && indent > keyIndent && line.trim() === 'readOnly: true' && readOnlyIndent === indent) {
+        readOnly?.add(current);
+      }
       continue;
     }
 
     const match = line.trim().match(/^([A-Za-z][A-Za-z0-9_]*):/);
-    if (match) {
-      names.add(match[1]);
-      current = match[1];
-    }
+    current = match ? match[1] : null;
+    if (match) names.add(match[1]);
+    // The property's own attributes sit one level in; measured from the next line, not assumed.
+    readOnlyIndent = lines.slice(i + 1).find(next => next.trim() !== '')?.match(/^\s*/)?.[0].length ?? null;
   }
 
   if (names.size === 0) {

--- a/scripts/check-settings-drift.ts
+++ b/scripts/check-settings-drift.ts
@@ -21,9 +21,12 @@ import {
   WORKFLOW_SETTINGS_PROPERTIES,
   type SettingsVersion,
 } from '../src/constants/workflow-settings';
+import { WRITABLE_NODE_PROPERTIES } from '../src/services/n8n-validation';
 
 const SCHEMA_PATH = 'dist/public-api/v1/openapi.yml';
 const SCHEMA_NAME = 'workflowSettings';
+/** The node schema is `additionalProperties: false` too; cleanNodeForApi strips to WRITABLE_NODE_PROPERTIES. */
+const NODE_SCHEMA_NAME = 'node';
 const ENTITY_INTERFACE = 'IWorkflowSettings';
 
 function resolveVersion(): string {
@@ -70,13 +73,17 @@ const indentOf = (line: string): number => line.length - line.trimStart().length
  * this cannot find throws, which is the point - a silently empty result would read as "no
  * drift".
  */
-export function parseSchemaProperties(yaml: string): Set<string> {
+export function parseSchemaProperties(
+  yaml: string,
+  schemaName = SCHEMA_NAME,
+  readOnly?: Set<string>
+): Set<string> {
   const lines = yaml.split('\n');
 
-  const schemaIndex = lines.findIndex(line => new RegExp(`^\\s+${SCHEMA_NAME}:\\s*$`).test(line));
+  const schemaIndex = lines.findIndex(line => new RegExp(`^\\s+${schemaName}:\\s*$`).test(line));
   if (schemaIndex === -1) {
     throw new Error(
-      `No "${SCHEMA_NAME}:" schema in ${SCHEMA_PATH}. n8n may have renamed it - check the spec.`
+      `No "${schemaName}:" schema in ${SCHEMA_PATH}. n8n may have renamed it - check the spec.`
     );
   }
   const schemaIndent = indentOf(lines[schemaIndex]);
@@ -94,12 +101,13 @@ export function parseSchemaProperties(yaml: string): Set<string> {
     }
   }
   if (propertiesIndex === -1) {
-    throw new Error(`"${SCHEMA_NAME}" has no properties block in ${SCHEMA_PATH}`);
+    throw new Error(`"${schemaName}" has no properties block in ${SCHEMA_PATH}`);
   }
 
   const propertiesIndent = indentOf(lines[propertiesIndex]);
   const names = new Set<string>();
   let keyIndent: number | null = null;
+  let current: string | null = null;
 
   for (let i = propertiesIndex + 1; i < lines.length; i++) {
     const line = lines[i];
@@ -108,16 +116,37 @@ export function parseSchemaProperties(yaml: string): Set<string> {
     if (indent <= propertiesIndent) break;
 
     if (keyIndent === null) keyIndent = indent;
-    if (indent !== keyIndent) continue; // nested schema of the property above
+    if (indent !== keyIndent) {
+      // nested schema of the property above; `readOnly: true` there marks a GET-only property
+      if (current && line.trim() === 'readOnly: true') readOnly?.add(current);
+      continue;
+    }
 
     const match = line.trim().match(/^([A-Za-z][A-Za-z0-9_]*):/);
-    if (match) names.add(match[1]);
+    if (match) {
+      names.add(match[1]);
+      current = match[1];
+    }
   }
 
   if (names.size === 0) {
-    throw new Error(`Parsed zero properties from "${SCHEMA_NAME}" - the spec format changed`);
+    throw new Error(`Parsed zero properties from "${schemaName}" - the spec format changed`);
   }
   return names;
+}
+
+/**
+ * Node-level drift: properties the node write schema accepts that cleanNodeForApi would strip,
+ * and properties we send that the schema no longer lists. Read-only ones (createdAt, updatedAt)
+ * are rejected on write, so stripping them is correct and they are not reported.
+ */
+export function diffNodeProperties(yaml: string): { missing: string[]; removed: string[] } {
+  const readOnly = new Set<string>();
+  const schema = parseSchemaProperties(yaml, NODE_SCHEMA_NAME, readOnly);
+  return {
+    missing: [...schema].filter(name => !readOnly.has(name) && !WRITABLE_NODE_PROPERTIES.has(name)),
+    removed: [...WRITABLE_NODE_PROPERTIES].filter(name => !schema.has(name)),
+  };
 }
 
 /**
@@ -426,7 +455,9 @@ async function main(): Promise<void> {
     }
   }
 
-  const schemaProperties = parseSchemaProperties(await fetchSchemaFile(version));
+  const schemaYaml = await fetchSchemaFile(version);
+  const schemaProperties = parseSchemaProperties(schemaYaml);
+  const nodeDrift = diffNodeProperties(schemaYaml);
 
   const { missing, removed, ahead, entityOnly, unhandledEntityOnly, publishedEntityOnly } =
     diffSettingsProperties(schemaProperties, entityProperties, parseVersion(version));
@@ -443,13 +474,26 @@ async function main(): Promise<void> {
     console.log(`ℹ️  ${entityOnly.length} entity-only, stripped on write (expected): ${entityOnly.join(', ')}\n`);
   }
 
+  if (nodeDrift.missing.length > 0) {
+    console.error(`❌ ${nodeDrift.missing.length} node property/properties in n8n's write schema that cleanNodeForApi strips:`);
+    for (const name of nodeDrift.missing) console.error(`   + ${name}`);
+    console.error('\n   Add each to workflowNodeObjectSchema in src/services/n8n-validation.ts.\n');
+  }
+  if (nodeDrift.removed.length > 0) {
+    console.error(`❌ ${nodeDrift.removed.length} node property/properties we send that n8n's write schema no longer lists:`);
+    for (const name of nodeDrift.removed) console.error(`   - ${name}`);
+    console.error('\n   Remove them from workflowNodeObjectSchema once no supported version accepts them.\n');
+  }
+
   if (
     missing.length === 0 &&
     removed.length === 0 &&
     unhandledEntityOnly.length === 0 &&
-    publishedEntityOnly.length === 0
+    publishedEntityOnly.length === 0 &&
+    nodeDrift.missing.length === 0 &&
+    nodeDrift.removed.length === 0
   ) {
-    console.log('✅ No drift - src/constants/workflow-settings.ts matches n8n.');
+    console.log('✅ No drift - src/constants/workflow-settings.ts and the node schema match n8n.');
     return;
   }
 

--- a/src/database/shared-database.ts
+++ b/src/database/shared-database.ts
@@ -7,8 +7,6 @@
  *
  * Memory impact: Reduces per-session memory from ~900MB to near-zero by sharing
  * a single ~68MB database connection across all sessions.
- *
- * See shared-database implementation for memory optimization details.
  */
 
 import path from 'path';

--- a/src/database/shared-database.ts
+++ b/src/database/shared-database.ts
@@ -8,7 +8,7 @@
  * Memory impact: Reduces per-session memory from ~900MB to near-zero by sharing
  * a single ~68MB database connection across all sessions.
  *
- * Issue: https://github.com/czlonkowski/n8n-mcp/issues/XXX
+ * See shared-database implementation for memory optimization details.
  */
 
 import path from 'path';

--- a/src/http-server-single-session.ts
+++ b/src/http-server-single-session.ts
@@ -1630,7 +1630,7 @@ export class SingleSessionHTTPServer {
       logger.info('POST /mcp request completed - checking response status', {
         responseHeadersSent: res.headersSent,
         responseStatusCode: res.statusCode,
-        responseFinished: res.finished
+        responseFinished: res.writableEnded
       });
     });
     

--- a/src/mcp-engine.ts
+++ b/src/mcp-engine.ts
@@ -8,6 +8,7 @@
 import { Request, Response } from 'express';
 import { SingleSessionHTTPServer } from './http-server-single-session';
 import { logger } from './utils/logger';
+import { PROJECT_VERSION } from './utils/version';
 import { InstanceContext } from './types/instance-context';
 import { SessionState } from './types/session-state';
 import type { AdditionalTool } from './types/additional-tools';
@@ -105,7 +106,7 @@ export class N8NMCPEngine {
           total: Math.round(memoryUsage.heapTotal / 1024 / 1024),
           unit: 'MB'
         },
-        version: '2.24.1'
+        version: PROJECT_VERSION
       };
     } catch (error) {
       logger.error('Health check failed:', error);
@@ -114,7 +115,7 @@ export class N8NMCPEngine {
         uptime: 0,
         sessionActive: false,
         memoryUsage: { used: 0, total: 0, unit: 'MB' },
-        version: '2.24.1'
+        version: PROJECT_VERSION
       };
     }
   }

--- a/src/mcp/handlers-workflow-diff.ts
+++ b/src/mcp/handlers-workflow-diff.ts
@@ -5,7 +5,8 @@
 
 import { z } from 'zod';
 import { randomUUID } from 'crypto';
-import { McpToolResponse } from '../types/n8n-api';
+import { isDeepStrictEqual } from 'node:util';
+import { McpToolResponse, Workflow } from '../types/n8n-api';
 import { WorkflowDiffRequest, WorkflowDiffOperation, WorkflowDiffValidationError } from '../types/workflow-diff';
 import { WorkflowDiffEngine } from '../services/workflow-diff-engine';
 import { getN8nApiClient } from './handlers-n8n-manager';
@@ -48,28 +49,26 @@ function compareVersions(
   return 'unknown';
 }
 
-// Deterministic serialisation so two workflows that differ only in key order compare equal.
-function stableStringify(value: unknown): string {
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
-  if (value && typeof value === 'object') {
-    const entries = Object.keys(value as Record<string, unknown>)
-      .sort()
-      .map(key => `${JSON.stringify(key)}:${stableStringify((value as Record<string, unknown>)[key])}`);
-    return `{${entries.join(',')}}`;
+// The shape an update would send, for comparing two reads of the same workflow. Cloned because
+// cleanWorkflowForUpdate() mutates: it assigns a random webhookId to webhook nodes that lack one,
+// which is also why that field is dropped here. Without both, every workflow containing a webhook
+// node would compare unequal to itself.
+function writableShape(workflow: Workflow): Record<string, unknown> {
+  const cleaned = cleanWorkflowForUpdate(structuredClone(workflow)) as Record<string, unknown>;
+  const nodes = cleaned.nodes;
+  if (Array.isArray(nodes)) {
+    for (const node of nodes) {
+      if (node && typeof node === 'object') delete (node as Record<string, unknown>).webhookId;
+    }
   }
-  return JSON.stringify(value) ?? 'null';
+  return cleaned;
 }
 
-// Compare only the fields an update PUT actually sends. Version identity cannot be used to verify
-// a rollback: a successful rollback writes a new version, so compareVersions() reports 'changed'
-// even when the content was fully restored.
-function sameWritableContent(a: unknown, b: unknown): boolean {
-  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') return false;
+// Compare only the fields the update allowlist accepts. Version identity cannot verify a rollback:
+// a successful rollback writes a new version, so compareVersions() reports 'changed' regardless.
+function sameWritableContent(a: Workflow, b: Workflow): boolean {
   try {
-    return (
-      stableStringify(cleanWorkflowForUpdate(a as any)) ===
-      stableStringify(cleanWorkflowForUpdate(b as any))
-    );
+    return isDeepStrictEqual(writableShape(a), writableShape(b));
   } catch {
     return false;
   }
@@ -465,11 +464,9 @@ export async function handleUpdatePartialWorkflow(
           } catch (rollbackErr) {
             rollbackErrorMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
 
-            // A rollback PUT can persist and then throw. n8n's public API commits the workflow
-            // content before it checks publish permission, so a caller allowed to edit but not to
-            // publish gets an error on a write that landed. Trusting the throw tells the user their
-            // workflow may be broken when it was in fact restored, which invites a riskier recovery
-            // than doing nothing. Verify against the server instead.
+            // n8n can persist a rollback PUT and then reject it: the public API commits workflow
+            // content before it checks publish permission. Verify against the server rather than
+            // trusting the throw, or we warn of a broken workflow that was in fact restored.
             try {
               const afterRollback = await client.getWorkflow(input.id);
               if (sameWritableContent(afterRollback, workflowBefore)) {

--- a/src/mcp/handlers-workflow-diff.ts
+++ b/src/mcp/handlers-workflow-diff.ts
@@ -12,7 +12,7 @@ import { getN8nApiClient } from './handlers-n8n-manager';
 import { N8nApiError, getUserFriendlyErrorMessage } from '../utils/n8n-errors';
 import { logger } from '../utils/logger';
 import { InstanceContext, getInstanceScopeId } from '../types/instance-context';
-import { validateWorkflowStructure } from '../services/n8n-validation';
+import { validateWorkflowStructure, cleanWorkflowForUpdate } from '../services/n8n-validation';
 import { NodeRepository } from '../database/node-repository';
 import { WorkflowVersioningService } from '../services/workflow-versioning-service';
 import { WorkflowValidator } from '../services/workflow-validator';
@@ -46,6 +46,33 @@ function compareVersions(
     return a.updatedAt === b.updatedAt ? 'same' : 'changed';
   }
   return 'unknown';
+}
+
+// Deterministic serialisation so two workflows that differ only in key order compare equal.
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    const entries = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableStringify((value as Record<string, unknown>)[key])}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+// Compare only the fields an update PUT actually sends. Version identity cannot be used to verify
+// a rollback: a successful rollback writes a new version, so compareVersions() reports 'changed'
+// even when the content was fully restored.
+function sameWritableContent(a: unknown, b: unknown): boolean {
+  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') return false;
+  try {
+    return (
+      stableStringify(cleanWorkflowForUpdate(a as any)) ===
+      stableStringify(cleanWorkflowForUpdate(b as any))
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -422,6 +449,7 @@ export async function handleUpdatePartialWorkflow(
 
           // Either persist-then-fail OR couldn't determine — attempt rollback.
           let rollbackPerformed = false;
+          let rollbackVerifiedAfterError = false;
           let rollbackErrorMessage: string | undefined;
           try {
             // No authoredGroups here: restoring the graph matters, frames do not. If the snapshot's
@@ -436,11 +464,34 @@ export async function handleUpdatePartialWorkflow(
             });
           } catch (rollbackErr) {
             rollbackErrorMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
-            logger.error('updateWorkflow failed AND rollback failed', {
-              workflowId: input.id,
-              originalError: updateError instanceof Error ? updateError.message : String(updateError),
-              rollbackError: rollbackErrorMessage,
-            });
+
+            // A rollback PUT can persist and then throw. n8n's public API commits the workflow
+            // content before it checks publish permission, so a caller allowed to edit but not to
+            // publish gets an error on a write that landed. Trusting the throw tells the user their
+            // workflow may be broken when it was in fact restored, which invites a riskier recovery
+            // than doing nothing. Verify against the server instead.
+            try {
+              const afterRollback = await client.getWorkflow(input.id);
+              if (sameWritableContent(afterRollback, workflowBefore)) {
+                rollbackPerformed = true;
+                rollbackVerifiedAfterError = true;
+                logger.warn('rollback PUT errored but content matches the prior state; treating as rolled back', {
+                  workflowId: input.id,
+                  rollbackError: rollbackErrorMessage,
+                });
+                rollbackErrorMessage = undefined;
+              }
+            } catch (verifyErr) {
+              logger.debug('post-rollback verification GET failed', verifyErr);
+            }
+
+            if (!rollbackPerformed) {
+              logger.error('updateWorkflow failed AND rollback failed', {
+                workflowId: input.id,
+                originalError: updateError instanceof Error ? updateError.message : String(updateError),
+                rollbackError: rollbackErrorMessage,
+              });
+            }
           }
 
           // Re-throw with rollback context attached so the outer N8nApiError
@@ -454,6 +505,7 @@ export async function handleUpdatePartialWorkflow(
             const augmentedDetails: Record<string, unknown> = {
               ...((updateError.details as Record<string, unknown>) ?? {}),
               rollbackPerformed,
+              ...(rollbackVerifiedAfterError ? { rollbackVerifiedAfterError: true } : {}),
               ...(folderMoveInPayload && rollbackPerformed ? { folderMoveMayHavePersisted: true } : {}),
               ...(rollbackErrorMessage ? { rollbackError: rollbackErrorMessage } : {}),
               ...(workflowBefore.versionId ? { priorVersionId: workflowBefore.versionId } : {}),

--- a/src/mcp/handlers-workflow-diff.ts
+++ b/src/mcp/handlers-workflow-diff.ts
@@ -51,14 +51,19 @@ function compareVersions(
 
 // The shape an update would send, for comparing two reads of the same workflow. Cloned because
 // cleanWorkflowForUpdate() mutates: it assigns a random webhookId to webhook nodes that lack one,
-// which is also why that field is dropped here. Without both, every workflow containing a webhook
-// node would compare unequal to itself.
+// so two reads of one workflow would otherwise compare unequal to themselves. Only those generated
+// ids are dropped; a webhookId the workflow already carried is real content and stays compared.
 function writableShape(workflow: Workflow): Record<string, unknown> {
+  const generated = new Set(
+    (workflow.nodes ?? []).filter(node => !node.webhookId).map(node => node.id),
+  );
   const cleaned = cleanWorkflowForUpdate(structuredClone(workflow)) as Record<string, unknown>;
   const nodes = cleaned.nodes;
   if (Array.isArray(nodes)) {
     for (const node of nodes) {
-      if (node && typeof node === 'object') delete (node as Record<string, unknown>).webhookId;
+      if (node && typeof node === 'object' && generated.has(node.id)) {
+        delete (node as Record<string, unknown>).webhookId;
+      }
     }
   }
   return cleaned;

--- a/src/mcp/handlers-workflow-diff.ts
+++ b/src/mcp/handlers-workflow-diff.ts
@@ -58,12 +58,9 @@ function writableShape(workflow: Workflow): Record<string, unknown> {
     (workflow.nodes ?? []).filter(node => !node.webhookId).map(node => node.id),
   );
   const cleaned = cleanWorkflowForUpdate(structuredClone(workflow)) as Record<string, unknown>;
-  const nodes = cleaned.nodes;
-  if (Array.isArray(nodes)) {
-    for (const node of nodes) {
-      if (node && typeof node === 'object' && generated.has(node.id)) {
-        delete (node as Record<string, unknown>).webhookId;
-      }
+  if (Array.isArray(cleaned.nodes)) {
+    for (const node of cleaned.nodes) {
+      if (generated.has(node.id)) delete node.webhookId;
     }
   }
   return cleaned;

--- a/src/mcp/handlers-workflow-diff.ts
+++ b/src/mcp/handlers-workflow-diff.ts
@@ -49,18 +49,20 @@ function compareVersions(
   return 'unknown';
 }
 
+// Ids of nodes that lack a webhookId in the given read. cleanWorkflowForUpdate() assigns a random
+// one to such nodes, and the server persists it, so the snapshot taken before a write and the read
+// taken after it legitimately differ there. A webhookId both reads carry is real content.
+function nodesWithoutWebhookId(workflow: Workflow): string[] {
+  return (workflow.nodes ?? []).filter(node => node.id && !node.webhookId).map(node => node.id);
+}
+
 // The shape an update would send, for comparing two reads of the same workflow. Cloned because
-// cleanWorkflowForUpdate() mutates: it assigns a random webhookId to webhook nodes that lack one,
-// so two reads of one workflow would otherwise compare unequal to themselves. Only those generated
-// ids are dropped; a webhookId the workflow already carried is real content and stays compared.
-function writableShape(workflow: Workflow): Record<string, unknown> {
-  const generated = new Set(
-    (workflow.nodes ?? []).filter(node => !node.webhookId).map(node => node.id),
-  );
+// cleanWorkflowForUpdate() mutates its input.
+function writableShape(workflow: Workflow, ignoreWebhookIdOf: Set<string>): Record<string, unknown> {
   const cleaned = cleanWorkflowForUpdate(structuredClone(workflow)) as Record<string, unknown>;
   if (Array.isArray(cleaned.nodes)) {
     for (const node of cleaned.nodes) {
-      if (generated.has(node.id)) delete node.webhookId;
+      if (ignoreWebhookIdOf.has(node.id)) delete node.webhookId;
     }
   }
   return cleaned;
@@ -68,9 +70,12 @@ function writableShape(workflow: Workflow): Record<string, unknown> {
 
 // Compare only the fields the update allowlist accepts. Version identity cannot verify a rollback:
 // a successful rollback writes a new version, so compareVersions() reports 'changed' regardless.
+// Generated webhook ids are ignored on both sides whichever read lacks them, so the outcome does
+// not depend on whether an earlier write mutated the snapshot in place.
 function sameWritableContent(a: Workflow, b: Workflow): boolean {
   try {
-    return isDeepStrictEqual(writableShape(a), writableShape(b));
+    const generated = new Set([...nodesWithoutWebhookId(a), ...nodesWithoutWebhookId(b)]);
+    return isDeepStrictEqual(writableShape(a, generated), writableShape(b, generated));
   } catch {
     return false;
   }

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -634,10 +634,10 @@ export class N8nApiClient {
     send: (body: Record<string, unknown>) => Promise<Workflow>,
     options: WorkflowWriteOptions
   ): Promise<Workflow> {
-    const remembered = [...this.rejectedSettings].filter(key => {
-      const settings = payload.settings as Record<string, unknown> | undefined;
-      return settings !== undefined && Object.prototype.hasOwnProperty.call(settings, key);
-    });
+    const settings = payload.settings as Record<string, unknown> | undefined;
+    const remembered = settings
+      ? [...this.rejectedSettings].filter(key => Object.prototype.hasOwnProperty.call(settings, key))
+      : [];
     let body = withoutSettings(payload, remembered);
     if (remembered.length > 0) options.onWarning?.(settingsRejectedWarning(remembered));
 
@@ -647,7 +647,7 @@ export class N8nApiClient {
       try {
         const result = await this.sendWorkflowWriteWithGroupFallback(body, send, options);
         if (dropped.length > 0) {
-          dropped.forEach(key => this.rejectedSettings.add(key));
+          for (const key of dropped) this.rejectedSettings.add(key);
           options.onWarning?.(settingsRejectedWarning(dropped));
         }
         return result;

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -736,8 +736,11 @@ export class N8nApiClient {
           let result: Workflow;
           try {
             result = await send(withoutNodeGroups(payload));
-          } catch {
-            throw apiError;
+          } catch (retryError) {
+            // A settings rejection on the retry is the more specific complaint, and the settings
+            // ladder around this one can act on it; anything else keeps the original.
+            const second = handleN8nApiError(retryError);
+            throw isUnknownSettingsPropertyError(second) ? second : apiError;
           }
           this.groupSupport.groups = false;
           options.onWarning?.(GROUPS_UNSUPPORTED_WARNING);

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -46,7 +46,7 @@ import {
   ProjectSummary,
   Project,
 } from '../types/n8n-api';
-import { enrichUnknownPropertyError, handleN8nApiError, logN8nError, N8nApiError, N8nValidationError } from '../utils/n8n-errors';
+import { enrichUnknownPropertyError, handleN8nApiError, isUnknownSettingsPropertyError, logN8nError, N8nApiError, N8nValidationError } from '../utils/n8n-errors';
 import { encodeApiPathSegment } from '../utils/validation-schemas';
 import { cleanWorkflowForCreate, cleanWorkflowForUpdate } from './n8n-validation';
 import {
@@ -60,6 +60,7 @@ import {
   fetchN8nVersion,
   cleanSettingsForVersion,
   getCachedVersion,
+  settingsRejectionLadder,
   versionAtLeast,
 } from './n8n-version';
 import type { PinnedAgents } from '../utils/ssrf-protection';
@@ -81,6 +82,9 @@ const GROUPS_UNSUPPORTED_WARNING =
   'This n8n version does not support canvas groups (added in 2.28); the workflow was saved without them.';
 const GROUP_DESCRIPTIONS_UNSUPPORTED_WARNING =
   'This n8n version does not support canvas group descriptions (added in 2.32); the descriptions were not saved.';
+const settingsRejectedWarning = (keys: string[]) =>
+  `This n8n version rejects the workflow settings ${keys.join(', ')}; the workflow was saved without them ` +
+  '(values already stored on the instance are unchanged). Upgrade n8n to set them.';
 
 /**
  * Statuses that mean "this instance does not serve that route". A router without the route may
@@ -128,6 +132,16 @@ function withoutNodeGroups(payload: Record<string, unknown>): Record<string, unk
   return rest;
 }
 
+/** The payload with the given settings keys removed. An emptied object gets the minimal default n8n accepts (#431). */
+function withoutSettings(payload: Record<string, unknown>, keys: Iterable<string>): Record<string, unknown> {
+  const drop = new Set(keys);
+  const settings = payload.settings as Record<string, unknown> | undefined;
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return payload;
+  const kept = Object.fromEntries(Object.entries(settings).filter(([key]) => !drop.has(key)));
+  if (Object.keys(kept).length === Object.keys(settings).length) return payload;
+  return { ...payload, settings: Object.keys(kept).length > 0 ? kept : { executionOrder: 'v1' } };
+}
+
 /** Options for workflow writes that carry canvas groups. */
 export interface WorkflowWriteOptions {
   /**
@@ -163,6 +177,8 @@ export class N8nApiClient {
    * group would permanently disable groups for the instance. Per-client, which is per-instance.
    */
   private groupSupport = { groups: true, descriptions: true };
+  /** Settings keys this instance has rejected as unknown; stripped from later writes with a warning. */
+  private rejectedSettings = new Set<string>();
   /**
    * Whether this instance is known to serve the modern publish/unpublish routes. Positive-only,
    * and per-client, which is per-instance: it is set when the instance proves the routes exist
@@ -587,7 +603,7 @@ export class N8nApiClient {
       }
     };
     try {
-      return await this.sendWorkflowWriteWithGroupFallback(payload, trackedSend, options);
+      return await this.sendWorkflowWriteWithSettingsFallback(payload, trackedSend, options);
     } catch (error) {
       const apiError = handleN8nApiError(error);
       const enriched = enrichUnknownPropertyError(apiError, sentBodies.get(apiError) ?? payload);
@@ -599,6 +615,48 @@ export class N8nApiClient {
         });
       }
       throw enriched;
+    }
+  }
+
+  /**
+   * Send a workflow write, dropping settings properties the instance rejects as unknown.
+   *
+   * Settings are forwarded untouched by default (see SETTINGS_PASS_THROUGH_FLOOR): our table
+   * trails n8n, and a property dropped up front is dropped silently. The cost of forwarding is
+   * a 400 whose AJV message names the path but not the key, so this ladder finds the key the
+   * only way it can, by retrying without candidates in the order settingsRejectionLadder gives.
+   * Every drop is reported through onWarning and remembered for this client's lifetime, so a
+   * session that has learnt the instance's schema stops paying the probe. The bound is the
+   * ladder length; a write that still fails after it surfaces the last rejection.
+   */
+  private async sendWorkflowWriteWithSettingsFallback(
+    payload: Record<string, unknown>,
+    send: (body: Record<string, unknown>) => Promise<Workflow>,
+    options: WorkflowWriteOptions
+  ): Promise<Workflow> {
+    const remembered = [...this.rejectedSettings].filter(key => {
+      const settings = payload.settings as Record<string, unknown> | undefined;
+      return settings !== undefined && Object.prototype.hasOwnProperty.call(settings, key);
+    });
+    let body = withoutSettings(payload, remembered);
+    if (remembered.length > 0) options.onWarning?.(settingsRejectedWarning(remembered));
+
+    const steps = settingsRejectionLadder(body.settings);
+    const dropped: string[] = [];
+    for (let step = 0; ; step++) {
+      try {
+        const result = await this.sendWorkflowWriteWithGroupFallback(body, send, options);
+        if (dropped.length > 0) {
+          dropped.forEach(key => this.rejectedSettings.add(key));
+          options.onWarning?.(settingsRejectedWarning(dropped));
+        }
+        return result;
+      } catch (error) {
+        const apiError = handleN8nApiError(error);
+        if (!isUnknownSettingsPropertyError(apiError) || step >= steps.length) throw apiError;
+        body = withoutSettings(body, steps[step]);
+        dropped.push(...steps[step]);
+      }
     }
   }
 

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -83,8 +83,8 @@ const GROUPS_UNSUPPORTED_WARNING =
 const GROUP_DESCRIPTIONS_UNSUPPORTED_WARNING =
   'This n8n version does not support canvas group descriptions (added in 2.32); the descriptions were not saved.';
 const settingsRejectedWarning = (keys: string[]) =>
-  `This n8n version rejects the workflow settings ${keys.join(', ')}; the workflow was saved without them ` +
-  '(values already stored on the instance are unchanged). Upgrade n8n to set them.';
+  `This n8n version rejects the workflow settings ${keys.join(', ')}; they were left out of the write ` +
+  '(on an update, the values the instance already stores are unchanged). Upgrade n8n to set them.';
 
 /**
  * Statuses that mean "this instance does not serve that route". A router without the route may

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -177,7 +177,11 @@ export class N8nApiClient {
    * group would permanently disable groups for the instance. Per-client, which is per-instance.
    */
   private groupSupport = { groups: true, descriptions: true };
-  /** Settings keys this instance has rejected as unknown; stripped from later writes with a warning. */
+  /**
+   * Settings keys this instance has rejected as unknown; stripped from later writes with a warning.
+   * Like groupSupport, remembered for the client's lifetime: an instance upgraded mid-session keeps
+   * losing the key until the client is recreated, and the warning says so on every write.
+   */
   private rejectedSettings = new Set<string>();
   /**
    * Whether this instance is known to serve the modern publish/unpublish routes. Positive-only,
@@ -625,9 +629,12 @@ export class N8nApiClient {
    * trails n8n, and a property dropped up front is dropped silently. The cost of forwarding is
    * a 400 whose AJV message names the path but not the key, so this ladder finds the key the
    * only way it can, by retrying without candidates in the order settingsRejectionLadder gives.
-   * Every drop is reported through onWarning and remembered for this client's lifetime, so a
-   * session that has learnt the instance's schema stops paying the probe. The bound is the
-   * ladder length; a write that still fails after it surfaces the last rejection.
+   * Every drop is reported through onWarning. A key dropped on its own is remembered for this
+   * client's lifetime, so a session that has learnt the instance's schema stops paying the probe;
+   * the first step drops every unknown key together, and remembering all of them would keep
+   * stripping a key the instance accepts, so that step is probed again on the next write. The
+   * ladder adds at most steps.length writes, each of which may run the group ladder in full; a
+   * write that still fails after it surfaces the last rejection.
    */
   private async sendWorkflowWriteWithSettingsFallback(
     payload: Record<string, unknown>,
@@ -647,7 +654,9 @@ export class N8nApiClient {
       try {
         const result = await this.sendWorkflowWriteWithGroupFallback(body, send, options);
         if (dropped.length > 0) {
-          for (const key of dropped) this.rejectedSettings.add(key);
+          for (const single of steps.slice(0, step).filter(keys => keys.length === 1)) {
+            this.rejectedSettings.add(single[0]);
+          }
           options.onWarning?.(settingsRejectedWarning(dropped));
         }
         return result;

--- a/src/services/n8n-validation.ts
+++ b/src/services/n8n-validation.ts
@@ -36,12 +36,20 @@ const workflowNodeObjectSchema = z.object({
   alwaysOutputData: z.boolean().optional(),
   executeOnce: z.boolean().optional(),
   webhookId: z.string().optional(),
+  customTelemetryTags: z
+    .object({ tag: z.array(z.object({ key: z.string(), value: z.string() })).optional() })
+    .optional(),
 });
 
 export const workflowNodeSchema = z.preprocess(normalizeMcpWorkflowNode, workflowNodeObjectSchema);
 
-/** Properties accepted by n8n's Public API write schema for a node. */
-const ALLOWED_NODE_PROPERTIES = new Set(Object.keys(workflowNodeObjectSchema.shape));
+/**
+ * Node properties n8n's Public API write schema accepts, taken from the zod schema above so the
+ * two cannot drift apart. n8n's node schema is `additionalProperties: false`, so a property missing
+ * here is dropped from every write; `npm run check:settings-drift` compares this set against the
+ * schema n8n ships and fails when n8n adds one.
+ */
+export const WRITABLE_NODE_PROPERTIES: ReadonlySet<string> = new Set(Object.keys(workflowNodeObjectSchema.shape));
 
 /**
  * Strip unknown properties from a single node so it conforms to n8n's write schema.
@@ -49,7 +57,7 @@ const ALLOWED_NODE_PROPERTIES = new Set(Object.keys(workflowNodeObjectSchema.sha
  * PUT/PATCH rejects with "must NOT have additional properties".
  */
 export function cleanNodeForApi(node: WorkflowNode): WorkflowNode {
-  const cleaned = Object.entries(node).filter(([key]) => ALLOWED_NODE_PROPERTIES.has(key));
+  const cleaned = Object.entries(node).filter(([key]) => WRITABLE_NODE_PROPERTIES.has(key));
   return Object.fromEntries(cleaned) as WorkflowNode;
 }
 

--- a/src/services/n8n-validation.ts
+++ b/src/services/n8n-validation.ts
@@ -27,12 +27,59 @@ export const workflowNodeSchema = z.preprocess(normalizeMcpWorkflowNode, z.objec
   notes: z.string().optional(),
   notesInFlow: z.boolean().optional(),
   continueOnFail: z.boolean().optional(),
+  onError: z.enum(['continueRegularOutput', 'continueErrorOutput', 'stopWorkflow']).optional(),
   retryOnFail: z.boolean().optional(),
   maxTries: z.number().optional(),
   waitBetweenTries: z.number().optional(),
   alwaysOutputData: z.boolean().optional(),
   executeOnce: z.boolean().optional(),
+  webhookId: z.string().optional(),
 }));
+
+/**
+ * Properties accepted by n8n's Public API write schema for a node.
+ * MUST stay in sync with `workflowNodeSchema` above.
+ * Used to strip unknown properties returned by GET that PUT/PATCH rejects.
+ */
+const ALLOWED_NODE_PROPERTIES = new Set([
+  'id',
+  'name',
+  'type',
+  'typeVersion',
+  'position',
+  'parameters',
+  'credentials',
+  'disabled',
+  'notes',
+  'notesInFlow',
+  'continueOnFail',
+  'onError',
+  'retryOnFail',
+  'maxTries',
+  'waitBetweenTries',
+  'alwaysOutputData',
+  'executeOnce',
+  'webhookId',
+]);
+
+/**
+ * Strip unknown properties from a single node so it conforms to n8n's write schema.
+ * n8n GET responses echo server-managed fields (e.g. issues, runIndex, data) that
+ * PUT/PATCH rejects with "must NOT have additional properties".
+ */
+export function cleanNodeForApi(node: WorkflowNode): WorkflowNode {
+  const cleaned: Partial<WorkflowNode> = {};
+  for (const key of Object.keys(node)) {
+    if (ALLOWED_NODE_PROPERTIES.has(key)) {
+      (cleaned as any)[key] = (node as any)[key];
+    }
+  }
+  // position is required; ensure it survives even if the set above drifts
+  if (!cleaned.position && node.position) {
+    cleaned.position = node.position;
+  }
+  return cleaned as WorkflowNode;
+}
 
 // Connection array schema used by all connection types
 const connectionArraySchema = z.array(
@@ -177,6 +224,11 @@ export function cleanWorkflowForCreate(workflow: Partial<Workflow>): Partial<Wor
 
   ensureWebhookIds(cleanedWorkflow.nodes);
 
+  // Strip unknown node properties that n8n GET echoes but PUT/PATCH rejects
+  if (cleanedWorkflow.nodes) {
+    cleanedWorkflow.nodes = cleanedWorkflow.nodes.map(cleanNodeForApi);
+  }
+
   return cleanedWorkflow;
 }
 
@@ -248,6 +300,11 @@ export function cleanWorkflowForUpdate(workflow: Workflow): Partial<Workflow> {
   }
 
   ensureWebhookIds(cleanedWorkflow.nodes as WorkflowNode[] | undefined);
+
+  // Strip unknown node properties that n8n GET echoes but PUT/PATCH rejects
+  if (cleanedWorkflow.nodes) {
+    cleanedWorkflow.nodes = (cleanedWorkflow.nodes as WorkflowNode[]).map(cleanNodeForApi);
+  }
 
   return cleanedWorkflow as Partial<Workflow>;
 }

--- a/src/services/n8n-validation.ts
+++ b/src/services/n8n-validation.ts
@@ -11,7 +11,9 @@ import {
 
 // Zod schemas for n8n API validation
 
-export const workflowNodeSchema = z.preprocess(normalizeMcpWorkflowNode, z.object({
+// The writable node shape, kept separate from the preprocess wrapper so the write allowlist
+// below can be derived from its keys instead of being maintained as a second list.
+const workflowNodeObjectSchema = z.object({
   id: z.string(),
   name: z.string(),
   type: z.string(),
@@ -34,33 +36,12 @@ export const workflowNodeSchema = z.preprocess(normalizeMcpWorkflowNode, z.objec
   alwaysOutputData: z.boolean().optional(),
   executeOnce: z.boolean().optional(),
   webhookId: z.string().optional(),
-}));
+});
 
-/**
- * Properties accepted by n8n's Public API write schema for a node.
- * MUST stay in sync with `workflowNodeSchema` above.
- * Used to strip unknown properties returned by GET that PUT/PATCH rejects.
- */
-const ALLOWED_NODE_PROPERTIES = new Set([
-  'id',
-  'name',
-  'type',
-  'typeVersion',
-  'position',
-  'parameters',
-  'credentials',
-  'disabled',
-  'notes',
-  'notesInFlow',
-  'continueOnFail',
-  'onError',
-  'retryOnFail',
-  'maxTries',
-  'waitBetweenTries',
-  'alwaysOutputData',
-  'executeOnce',
-  'webhookId',
-]);
+export const workflowNodeSchema = z.preprocess(normalizeMcpWorkflowNode, workflowNodeObjectSchema);
+
+/** Properties accepted by n8n's Public API write schema for a node. */
+const ALLOWED_NODE_PROPERTIES = new Set(Object.keys(workflowNodeObjectSchema.shape));
 
 /**
  * Strip unknown properties from a single node so it conforms to n8n's write schema.
@@ -68,17 +49,8 @@ const ALLOWED_NODE_PROPERTIES = new Set([
  * PUT/PATCH rejects with "must NOT have additional properties".
  */
 export function cleanNodeForApi(node: WorkflowNode): WorkflowNode {
-  const cleaned: Partial<WorkflowNode> = {};
-  for (const key of Object.keys(node)) {
-    if (ALLOWED_NODE_PROPERTIES.has(key)) {
-      (cleaned as any)[key] = (node as any)[key];
-    }
-  }
-  // position is required; ensure it survives even if the set above drifts
-  if (!cleaned.position && node.position) {
-    cleaned.position = node.position;
-  }
-  return cleaned as WorkflowNode;
+  const cleaned = Object.entries(node).filter(([key]) => ALLOWED_NODE_PROPERTIES.has(key));
+  return Object.fromEntries(cleaned) as WorkflowNode;
 }
 
 // Connection array schema used by all connection types

--- a/src/services/n8n-version.ts
+++ b/src/services/n8n-version.ts
@@ -276,8 +276,8 @@ const SETTINGS_LADDER_FLOOR: SettingsVersion = { major: 1, minor: 119, patch: 0 
  * Each returned step is one retry. Keys absent from our settings table go first, together: the
  * usual cause is an instance whose GET echoes a property its write schema does not accept, and
  * one we have never heard of is the likeliest candidate. Known keys follow one at a time from
- * newest to oldest, since the instance evidently predates at least one of them. Keys that
- * predate the floor are never dropped here; an instance that old is handled by version.
+ * newest to oldest, since the instance evidently predates at least one of them. Keys introduced
+ * at or before the floor are never dropped here; an instance that old is handled by version.
  */
 export function settingsRejectionLadder(settings: unknown): string[][] {
   if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return [];

--- a/src/services/n8n-version.ts
+++ b/src/services/n8n-version.ts
@@ -283,19 +283,17 @@ export function settingsRejectionLadder(settings: unknown): string[][] {
   if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return [];
   const keys = Object.keys(settings as Record<string, unknown>);
   const known = (key: string) => Object.prototype.hasOwnProperty.call(WORKFLOW_SETTINGS_PROPERTIES, key);
+  const since = (key: string) => WORKFLOW_SETTINGS_PROPERTIES[key].since;
 
-  const steps: string[][] = [];
   const unknown = keys.filter(key => !known(key));
-  if (unknown.length > 0) steps.push(unknown);
+  const newestFirst = keys
+    .filter(key => known(key) && compareVersions(since(key), SETTINGS_LADDER_FLOOR) > 0)
+    .sort((a, b) => compareVersions(since(b), since(a)));
 
-  keys
-    .filter(known)
-    .map(key => ({ key, since: WORKFLOW_SETTINGS_PROPERTIES[key].since }))
-    .filter(({ since }) => compareVersions(since, SETTINGS_LADDER_FLOOR) > 0)
-    .sort((a, b) => compareVersions(b.since, a.since))
-    .forEach(({ key }) => steps.push([key]));
-
-  return steps;
+  return [
+    ...(unknown.length > 0 ? [unknown] : []),
+    ...newestFirst.map(key => [key]),
+  ];
 }
 
 // Export version thresholds for testing

--- a/src/services/n8n-version.ts
+++ b/src/services/n8n-version.ts
@@ -263,6 +263,41 @@ export function cleanSettingsForVersion(
   return cleaned;
 }
 
+/**
+ * Instances below this version still report their version, so {@link cleanSettingsForVersion}
+ * filters for them precisely. The rejection ladder only needs to cover what arrived later.
+ */
+const SETTINGS_LADDER_FLOOR: SettingsVersion = { major: 1, minor: 119, patch: 0 };
+
+/**
+ * Which settings keys to drop, and in what order, when n8n rejects a write with
+ * `request/body/settings must NOT have additional properties` and does not name the key.
+ *
+ * Each returned step is one retry. Keys absent from our settings table go first, together: the
+ * usual cause is an instance whose GET echoes a property its write schema does not accept, and
+ * one we have never heard of is the likeliest candidate. Known keys follow one at a time from
+ * newest to oldest, since the instance evidently predates at least one of them. Keys that
+ * predate the floor are never dropped here; an instance that old is handled by version.
+ */
+export function settingsRejectionLadder(settings: unknown): string[][] {
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) return [];
+  const keys = Object.keys(settings as Record<string, unknown>);
+  const known = (key: string) => Object.prototype.hasOwnProperty.call(WORKFLOW_SETTINGS_PROPERTIES, key);
+
+  const steps: string[][] = [];
+  const unknown = keys.filter(key => !known(key));
+  if (unknown.length > 0) steps.push(unknown);
+
+  keys
+    .filter(known)
+    .map(key => ({ key, since: WORKFLOW_SETTINGS_PROPERTIES[key].since }))
+    .filter(({ since }) => compareVersions(since, SETTINGS_LADDER_FLOOR) > 0)
+    .sort((a, b) => compareVersions(b.since, a.since))
+    .forEach(({ key }) => steps.push([key]));
+
+  return steps;
+}
+
 // Export version thresholds for testing
 export const VERSION_THRESHOLDS = {
   EXECUTION_ORDER: { major: 1, minor: 37, patch: 0 },

--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -2589,7 +2589,7 @@ export class WorkflowValidator {
 
     // Access connections from the workflow structure, not the node
     // We need to access this.currentWorkflow.connections[startNode]
-    const connections = (this as any).currentWorkflow?.connections[startNode];
+    const connections = this.currentWorkflow?.connections[startNode];
     if (!connections) return false;
 
     for (const [outputType, outputs] of Object.entries(connections)) {

--- a/src/types/n8n-api.ts
+++ b/src/types/n8n-api.ts
@@ -31,6 +31,8 @@ export interface WorkflowNode {
   alwaysOutputData?: boolean;
   executeOnce?: boolean;
   webhookId?: string; // n8n assigns this for webhook/form/chat trigger nodes
+  /** Node-level telemetry tags, accepted by n8n's node write schema since 2.36. */
+  customTelemetryTags?: { tag?: Array<{ key: string; value: string }> };
 }
 
 export interface WorkflowConnection {

--- a/src/utils/n8n-errors.ts
+++ b/src/utils/n8n-errors.ts
@@ -152,6 +152,18 @@ function folderPlacementHint(error: N8nApiError): string {
  * The two shapes are matched exactly (`body must NOT` / `body/settings must NOT`) so deeper
  * paths like `body/nodes/0` — which do name their offending segment — stay untouched.
  */
+/**
+ * Whether n8n refused a workflow write because `settings` carried a property its Public API
+ * schema does not know. Matches only the settings-level path; a top-level or nested rejection
+ * (`body`, `body/nodes/0`, `body/nodeGroups/0`) is a different problem with a different fix.
+ */
+export function isUnknownSettingsPropertyError(error: unknown): boolean {
+  const apiError = error as { statusCode?: number; message?: string; details?: unknown } | null;
+  if (!apiError || apiError.statusCode !== 400) return false;
+  const haystack = `${apiError.message ?? ''} ${safeStringify(apiError.details)}`;
+  return /body\/settings must NOT have additional propert/i.test(haystack);
+}
+
 export function enrichUnknownPropertyError(
   error: N8nApiError,
   sentBody: Record<string, unknown>

--- a/src/utils/n8n-errors.ts
+++ b/src/utils/n8n-errors.ts
@@ -141,6 +141,20 @@ function folderPlacementHint(error: N8nApiError): string {
   return ' Note: workflow folder placement (parentFolderId) requires n8n 2.32 or later - retry without parentFolderId, or upgrade the instance.';
 }
 
+/** AJV's rejection of an unknown key inside `settings`, which never names the key itself. */
+const SETTINGS_ADDITIONAL_PROPERTY = /body\/settings must NOT have additional propert/i;
+
+/**
+ * Whether n8n refused a workflow write because `settings` carried a property its Public API
+ * schema does not know. Matches only the settings-level path; a top-level or nested rejection
+ * (`body`, `body/nodes/0`, `body/nodeGroups/0`) is a different problem with a different fix.
+ */
+export function isUnknownSettingsPropertyError(error: unknown): boolean {
+  const apiError = error as { statusCode?: number; message?: string; details?: unknown } | null;
+  if (!apiError || apiError.statusCode !== 400) return false;
+  return SETTINGS_ADDITIONAL_PROPERTY.test(`${apiError.message ?? ''} ${safeStringify(apiError.details)}`);
+}
+
 /**
  * When n8n rejects a workflow write with "must NOT have additional properties", the AJV
  * message names the failing path (`request/body` or `request/body/settings`) but never the
@@ -152,18 +166,6 @@ function folderPlacementHint(error: N8nApiError): string {
  * The two shapes are matched exactly (`body must NOT` / `body/settings must NOT`) so deeper
  * paths like `body/nodes/0` — which do name their offending segment — stay untouched.
  */
-/**
- * Whether n8n refused a workflow write because `settings` carried a property its Public API
- * schema does not know. Matches only the settings-level path; a top-level or nested rejection
- * (`body`, `body/nodes/0`, `body/nodeGroups/0`) is a different problem with a different fix.
- */
-export function isUnknownSettingsPropertyError(error: unknown): boolean {
-  const apiError = error as { statusCode?: number; message?: string; details?: unknown } | null;
-  if (!apiError || apiError.statusCode !== 400) return false;
-  const haystack = `${apiError.message ?? ''} ${safeStringify(apiError.details)}`;
-  return /body\/settings must NOT have additional propert/i.test(haystack);
-}
-
 export function enrichUnknownPropertyError(
   error: N8nApiError,
   sentBody: Record<string, unknown>
@@ -172,7 +174,7 @@ export function enrichUnknownPropertyError(
   const detailsStr = safeStringify(error.details);
   const haystack = `${error.message} ${detailsStr}`;
 
-  const settingsLevel = /body\/settings must NOT have additional propert/i.test(haystack);
+  const settingsLevel = SETTINGS_ADDITIONAL_PROPERTY.test(haystack);
   const bodyLevel = !settingsLevel && /body must NOT have additional propert/i.test(haystack);
   if (!settingsLevel && !bodyLevel) return error;
 

--- a/tests/integration/n8n-api/README.md
+++ b/tests/integration/n8n-api/README.md
@@ -1,0 +1,39 @@
+# n8n API Integration Tests
+
+Live tests against a real n8n instance (`N8N_API_URL` + `N8N_API_KEY`).
+
+In CI these suites run only when those secrets are configured (see `.github/workflows/test.yml`). Offline unit tests in `tests/unit/services/n8n-validation.test.ts` always cover the same cleaning rules without a live API.
+
+## n8n API quirks (workflow updates)
+
+The Public API is **asymmetric** between read and write:
+
+| Behavior | GET | PUT / PATCH |
+|----------|-----|-------------|
+| `description` | May be returned | Rejected on some versions (Issue #431) |
+| Read-only fields (`id`, `createdAt`, `updatedAt`, `versionId`, `versionCounter`, `active`, `tags`, `meta`, `staticData`, `pinData`, `nodeGroups`, …) | Returned | Rejected (`additionalProperties: false` on many versions) |
+| `settings` | Returned | Empty `{}` rejected; omit → client injects `{ executionOrder: 'v1' }` |
+
+**Common failure mode (Issue #433):**
+
+```ts
+const wf = await client.getWorkflow(id);
+await client.updateWorkflow(id, { ...wf, name: 'New' }); // must clean first
+```
+
+`N8nApiClient.updateWorkflow()` always runs `cleanWorkflowForUpdate()` (allowlist of writable top-level fields + settings filter) before sending the body. Coverage:
+
+- **Unit:** `tests/unit/services/n8n-validation.test.ts` → `cleanWorkflowForUpdate` (always in CI)
+- **Live:** `tests/integration/n8n-api/workflows/update-workflow.test.ts` → GET→UPDATE / spread / minimal / edge cases (Issue #433)
+
+## Running locally
+
+```bash
+# Unit only (no n8n required)
+npm run test:unit -- tests/unit/services/n8n-validation.test.ts
+
+# Live n8n API suites
+export N8N_API_URL=https://your-n8n.example
+export N8N_API_KEY=...
+npm run test:integration:n8n
+```

--- a/tests/integration/n8n-api/README.md
+++ b/tests/integration/n8n-api/README.md
@@ -11,7 +11,7 @@ The Public API is **asymmetric** between read and write:
 | Behavior | GET | PUT / PATCH |
 |----------|-----|-------------|
 | `description` | May be returned | Rejected on some versions (Issue #431) |
-| Read-only fields (`id`, `createdAt`, `updatedAt`, `versionId`, `versionCounter`, `active`, `tags`, `meta`, `staticData`, `pinData`, `nodeGroups`, …) | Returned | Rejected (`additionalProperties: false` on many versions) |
+| Read-only fields (`id`, `createdAt`, `updatedAt`, `versionId`, `versionCounter`, `active`, `tags`, `meta`, `staticData`, `pinData`, …) | Returned | Rejected (`additionalProperties: false` on many versions) |
 | `settings` | Returned | Empty `{}` rejected; when empty or omitted the client sends `{ executionOrder: 'v1' }` |
 
 **Common failure mode (Issue #433):**

--- a/tests/integration/n8n-api/README.md
+++ b/tests/integration/n8n-api/README.md
@@ -12,7 +12,7 @@ The Public API is **asymmetric** between read and write:
 |----------|-----|-------------|
 | `description` | May be returned | Rejected on some versions (Issue #431) |
 | Read-only fields (`id`, `createdAt`, `updatedAt`, `versionId`, `versionCounter`, `active`, `tags`, `meta`, `staticData`, `pinData`, `nodeGroups`, …) | Returned | Rejected (`additionalProperties: false` on many versions) |
-| `settings` | Returned | Empty `{}` rejected; omit → client injects `{ executionOrder: 'v1' }` |
+| `settings` | Returned | Empty `{}` rejected; when empty or omitted the client sends `{ executionOrder: 'v1' }` |
 
 **Common failure mode (Issue #433):**
 

--- a/tests/integration/n8n-api/workflows/update-workflow.test.ts
+++ b/tests/integration/n8n-api/workflows/update-workflow.test.ts
@@ -367,4 +367,299 @@ describe('Integration: handleUpdateWorkflow', () => {
       expect(actual.settings?.timezone).toBe('America/New_York');
     });
   });
+
+  // ======================================================================
+  // Issue #433 — GET→UPDATE round-trip + n8n API quirks
+  //
+  // Real-world agents and scripts commonly do:
+  //   const wf = await getWorkflow(id);
+  //   await updateWorkflow(id, { ...wf, name: 'New' });
+  //
+  // n8n's API is asymmetric:
+  // - GET returns read-only fields (id, createdAt, updatedAt, versionId,
+  //   description, active, tags, meta, staticData, pinData, …)
+  // - PUT/PATCH rejects many of those fields (additionalProperties: false
+  //   on some n8n versions; description was specifically rejected — #431)
+  // - settings is required for a stable update path; empty {} is rejected
+  //
+  // N8nApiClient.updateWorkflow() runs cleanWorkflowForUpdate() before PUT.
+  // These tests hit a live instance so regressions like #431 cannot slip by.
+  // ======================================================================
+
+  describe('GET-UPDATE Round Trip (Issue #433)', () => {
+    it('should handle a workflow returned from GET when passed straight to UPDATE', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - GET round-trip'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      // Full GET payload — includes read-only fields the PUT schema rejects
+      const fromGet = await client.getWorkflow(created.id);
+
+      // Must not throw: cleanWorkflowForUpdate strips read-only fields
+      const updated = await client.updateWorkflow(created.id, fromGet as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.name).toBe(fromGet.name);
+      expect(updated.nodes).toHaveLength(fromGet.nodes.length);
+    });
+
+    it('should handle workflow update with spread operator', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Spread operator'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const fromGet = await client.getWorkflow(created.id);
+      const newName = createTestWorkflowName('Update - Spread operator (renamed)');
+
+      // Common user pattern: spread entire GET response then override fields
+      const updated = await client.updateWorkflow(created.id, {
+        ...fromGet,
+        name: newName,
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.name).toBe(newName);
+
+      const actual = await client.getWorkflow(created.id);
+      expect(actual.name).toBe(newName);
+      expect(actual.nodes).toHaveLength(fromGet.nodes.length);
+    });
+
+    it('should handle partial settings update via nested spread', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Nested settings spread'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const fromGet = await client.getWorkflow(created.id);
+
+      const updated = await client.updateWorkflow(created.id, {
+        ...fromGet,
+        settings: {
+          ...fromGet.settings,
+          executionOrder: 'v1' as const,
+          timezone: 'UTC',
+        },
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+
+      const actual = await client.getWorkflow(created.id);
+      expect(actual.settings?.timezone).toBe('UTC');
+      expect(actual.nodes).toHaveLength(fromGet.nodes.length);
+    });
+  });
+
+  describe('n8n API Constraints (Issue #433)', () => {
+    it('should strip description on update even when present on GET / payload (Issue #431)', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Description strip'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const fromGet = await client.getWorkflow(created.id);
+
+      // description is read-only on write; client must clean it rather than 400
+      const updated = await client.updateWorkflow(created.id, {
+        ...fromGet,
+        description: 'Agent-supplied description that n8n PUT rejects',
+        name: createTestWorkflowName('Update - Description strip (ok)'),
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.name).toContain('Description strip (ok)');
+    });
+
+    it('should auto-supply settings when omitted from the update payload', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Missing settings'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const fromGet = await client.getWorkflow(created.id);
+
+      // Absolute required fields only — cleanWorkflowForUpdate adds settings defaults
+      const updated = await client.updateWorkflow(created.id, {
+        name: fromGet.name,
+        nodes: fromGet.nodes,
+        connections: fromGet.connections,
+        // deliberately no settings
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.nodes).toHaveLength(fromGet.nodes.length);
+    });
+
+    it('should handle all common read-only fields in a spread payload', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Read-only fields'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const fromGet = await client.getWorkflow(created.id);
+      const newName = createTestWorkflowName('Update - Read-only fields (cleaned)');
+
+      // Force-include fields that have historically broken updates when echoed
+      const updated = await client.updateWorkflow(created.id, {
+        ...fromGet,
+        name: newName,
+        createdAt: '2099-01-01T00:00:00.000Z',
+        updatedAt: '2099-01-01T00:00:00.000Z',
+        versionId: 'must-be-stripped',
+        versionCounter: 999,
+        active: true,
+        isArchived: false,
+        meta: { injected: true },
+        staticData: { junk: true },
+        pinData: { junk: true },
+        description: 'must-be-stripped',
+        activeVersionId: 'must-be-stripped',
+        nodeGroups: [],
+        availableInMCP: true,
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.name).toBe(newName);
+
+      const actual = await client.getWorkflow(created.id);
+      expect(actual.name).toBe(newName);
+      expect(actual.nodes).toHaveLength(fromGet.nodes.length);
+    });
+  });
+
+  describe('Minimal Updates (Issue #433)', () => {
+    it('should update with only required fields (name, nodes, connections)', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Minimal required'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const current = await client.getWorkflow(created.id);
+
+      const updated = await client.updateWorkflow(created.id, {
+        name: current.name,
+        nodes: current.nodes,
+        connections: current.connections,
+      } as any);
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.nodes).toHaveLength(current.nodes.length);
+    });
+
+    it('should update with minimal changes (rename only + required graph)', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Minimal rename'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const current = await client.getWorkflow(created.id);
+      const newName = createTestWorkflowName('Update - Minimal rename (done)');
+
+      const updated = await client.updateWorkflow(created.id, {
+        name: newName,
+        nodes: current.nodes,
+        connections: current.connections,
+      } as any);
+
+      expect(updated.name).toBe(newName);
+
+      const actual = await client.getWorkflow(created.id);
+      expect(actual.name).toBe(newName);
+      expect(actual.nodes).toHaveLength(1);
+    });
+  });
+
+  describe('Edge Cases — settings filtering (Issue #433)', () => {
+    it('should succeed when settings contain only unknown properties (defaults applied)', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Unknown settings only'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const current = await client.getWorkflow(created.id);
+
+      // Unknown settings are filtered; empty remainder → { executionOrder: 'v1' }
+      // Note: callerPolicy is now whitelisted (n8n 1.119+); use truly unknown keys.
+      const updated = await client.updateWorkflow(created.id, {
+        name: current.name,
+        nodes: current.nodes,
+        connections: current.connections,
+        settings: {
+          totallyUnknownSetting: true,
+          anotherGarbageField: 42,
+        } as any,
+      });
+
+      expect(updated.id).toBe(created.id);
+      expect(updated.nodes).toHaveLength(current.nodes.length);
+    });
+
+    it('should preserve valid settings while filtering unknown ones', async () => {
+      const created = await client.createWorkflow({
+        ...SIMPLE_WEBHOOK_WORKFLOW,
+        name: createTestWorkflowName('Update - Mixed settings filter'),
+        tags: ['mcp-integration-test'],
+      });
+      expect(created.id).toBeTruthy();
+      if (!created.id) throw new Error('Workflow ID is missing');
+      context.trackWorkflow(created.id);
+
+      const current = await client.getWorkflow(created.id);
+
+      const updated = await client.updateWorkflow(created.id, {
+        name: current.name,
+        nodes: current.nodes,
+        connections: current.connections,
+        settings: {
+          executionOrder: 'v1' as const,
+          timezone: 'Europe/Berlin',
+          totallyUnknownSetting: 'drop-me',
+        } as any,
+      });
+
+      expect(updated.id).toBe(created.id);
+
+      const actual = await client.getWorkflow(created.id);
+      expect(actual.settings?.timezone).toBe('Europe/Berlin');
+      expect((actual.settings as any)?.totallyUnknownSetting).toBeUndefined();
+    });
+  });
 });

--- a/tests/unit/mcp-engine/session-persistence.test.ts
+++ b/tests/unit/mcp-engine/session-persistence.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { N8NMCPEngine } from '../../../src/mcp-engine';
 import { SessionState } from '../../../src/types/session-state';
+import { PROJECT_VERSION } from '../../../src/utils/version';
 
 describe('N8NMCPEngine - Session Persistence', () => {
   let engine: N8NMCPEngine;
@@ -250,6 +251,12 @@ describe('N8NMCPEngine - Session Persistence', () => {
       // Note: getSessionInfo() reflects metadata, not transports
       // Restored sessions won't have transports until first request
       expect(info).toBeDefined();
+    });
+  });
+  describe('healthCheck()', () => {
+    it('reports the package version, not a hard-coded one', async () => {
+      const health = await engine.healthCheck();
+      expect(health.version).toBe(PROJECT_VERSION);
     });
   });
 });

--- a/tests/unit/mcp/handlers-workflow-diff.test.ts
+++ b/tests/unit/mcp/handlers-workflow-diff.test.ts
@@ -1182,6 +1182,53 @@ describe('handlers-workflow-diff', () => {
       });
     });
 
+    it('should treat a rollback as performed when its PUT errored but the content was restored', async () => {
+      // n8n's public API commits workflow content before it checks publish permission, so a
+      // rollback PUT can persist and then throw. Version identity cannot settle it: the restored
+      // workflow necessarily carries a new versionId, so the writable content is what must be
+      // compared. Reporting a broken workflow here invites a riskier recovery than doing nothing.
+      const before = createTestWorkflow({ versionId: 'v1' });
+      const afterPersist = createTestWorkflow({ versionId: 'v2' });
+      const afterRollback = createTestWorkflow({ versionId: 'v3' });
+      const validationError = new N8nValidationError('Invalid workflow structure', {
+        field: 'connections',
+        message: 'Invalid connection configuration',
+      });
+      const publishRefused = new N8nNotFoundError(
+        'You do not have permission to activate this workflow. Ask the owner to share it with you.',
+      );
+
+      mockApiClient.getWorkflow
+        .mockResolvedValueOnce(before)
+        .mockResolvedValueOnce(afterPersist)
+        .mockResolvedValueOnce(afterRollback);
+      mockDiffEngine.applyDiff.mockResolvedValue({
+        success: true,
+        workflow: before,
+        operationsApplied: 1,
+        message: 'Success',
+        errors: [],
+      });
+      mockApiClient.updateWorkflow
+        .mockRejectedValueOnce(validationError)
+        .mockRejectedValueOnce(publishRefused);
+
+      const result = await handleUpdatePartialWorkflow({
+        id: 'test-id',
+        operations: [{ type: 'updateNode', nodeId: 'node1', updates: {} }],
+      }, mockRepository);
+
+      expect(mockApiClient.updateWorkflow).toHaveBeenCalledTimes(2);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('workflow restored to prior state');
+      expect(result.error).not.toContain('rollback also failed');
+      expect(result.details).toMatchObject({
+        rollbackPerformed: true,
+        rollbackVerifiedAfterError: true,
+      });
+      expect(result.details).not.toHaveProperty('rollbackError');
+    });
+
     it('should handle input validation errors', async () => {
       const invalidInput = {
         id: 'test-id',

--- a/tests/unit/mcp/handlers-workflow-diff.test.ts
+++ b/tests/unit/mcp/handlers-workflow-diff.test.ts
@@ -1150,7 +1150,10 @@ describe('handlers-workflow-diff', () => {
 
       mockApiClient.getWorkflow
         .mockResolvedValueOnce(before)
-        .mockResolvedValueOnce(afterPersist);
+        .mockResolvedValueOnce(afterPersist)
+        // The post-rollback verification read fails too, so the outcome stays inconclusive and the
+        // warning stands. Explicit rather than relying on an unconfigured mock.
+        .mockRejectedValueOnce(new N8nServerError('n8n unreachable', 503));
       mockDiffEngine.applyDiff.mockResolvedValue({
         success: true,
         workflow: before,
@@ -1187,9 +1190,12 @@ describe('handlers-workflow-diff', () => {
       // rollback PUT can persist and then throw. Version identity cannot settle it: the restored
       // workflow necessarily carries a new versionId, so the writable content is what must be
       // compared. Reporting a broken workflow here invites a riskier recovery than doing nothing.
-      const before = createTestWorkflow({ versionId: 'v1' });
-      const afterPersist = createTestWorkflow({ versionId: 'v2' });
-      const afterRollback = createTestWorkflow({ versionId: 'v3' });
+      // Names differ so the fixture actually models a reverted change rather than passing on
+      // workflows that were identical all along.
+      const before = createTestWorkflow({ name: 'Original Workflow', versionId: 'v1' });
+      const attempted = createTestWorkflow({ name: 'Renamed Workflow', versionId: 'v1' });
+      const afterPersist = createTestWorkflow({ name: 'Renamed Workflow', versionId: 'v2' });
+      const afterRollback = createTestWorkflow({ name: 'Original Workflow', versionId: 'v3' });
       const validationError = new N8nValidationError('Invalid workflow structure', {
         field: 'connections',
         message: 'Invalid connection configuration',
@@ -1204,7 +1210,7 @@ describe('handlers-workflow-diff', () => {
         .mockResolvedValueOnce(afterRollback);
       mockDiffEngine.applyDiff.mockResolvedValue({
         success: true,
-        workflow: before,
+        workflow: attempted,
         operationsApplied: 1,
         message: 'Success',
         errors: [],
@@ -1215,7 +1221,7 @@ describe('handlers-workflow-diff', () => {
 
       const result = await handleUpdatePartialWorkflow({
         id: 'test-id',
-        operations: [{ type: 'updateNode', nodeId: 'node1', updates: {} }],
+        operations: [{ type: 'updateName', name: 'Renamed Workflow' }],
       }, mockRepository);
 
       expect(mockApiClient.updateWorkflow).toHaveBeenCalledTimes(2);
@@ -1227,6 +1233,117 @@ describe('handlers-workflow-diff', () => {
         rollbackVerifiedAfterError: true,
       });
       expect(result.details).not.toHaveProperty('rollbackError');
+    });
+
+    it('should still report rollback failure when the content was not restored', async () => {
+      // The verification must not turn every rollback failure into a success: if the server still
+      // holds the attempted change, the warning has to stand.
+      const before = createTestWorkflow({ name: 'Original Workflow', versionId: 'v1' });
+      const attempted = createTestWorkflow({ name: 'Renamed Workflow', versionId: 'v1' });
+      const afterPersist = createTestWorkflow({ name: 'Renamed Workflow', versionId: 'v2' });
+      const validationError = new N8nValidationError('Invalid workflow structure', {
+        field: 'connections',
+        message: 'Invalid connection configuration',
+      });
+      const rollbackFailure = new N8nServerError('n8n unreachable', 503);
+
+      mockApiClient.getWorkflow
+        .mockResolvedValueOnce(before)
+        .mockResolvedValueOnce(afterPersist)
+        .mockResolvedValueOnce(afterPersist);
+      mockDiffEngine.applyDiff.mockResolvedValue({
+        success: true,
+        workflow: attempted,
+        operationsApplied: 1,
+        message: 'Success',
+        errors: [],
+      });
+      mockApiClient.updateWorkflow
+        .mockRejectedValueOnce(validationError)
+        .mockRejectedValueOnce(rollbackFailure);
+
+      const result = await handleUpdatePartialWorkflow({
+        id: 'test-id',
+        operations: [{ type: 'updateName', name: 'Renamed Workflow' }],
+      }, mockRepository);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('rollback also failed');
+      expect(result.details).toMatchObject({
+        rollbackPerformed: false,
+        rollbackError: 'n8n unreachable',
+      });
+      expect(result.details).not.toHaveProperty('rollbackVerifiedAfterError');
+    });
+
+    it('should verify a restored workflow that contains a webhook node', async () => {
+      // Guards a subtle trap: the update allowlist assigns a random webhookId to webhook nodes that
+      // lack one, and does so in place. Comparing the raw cleaned output would mutate both reads and
+      // give each a different id, so a webhook workflow would never compare equal to itself.
+      const webhookNode = {
+        id: 'hook1',
+        name: 'Webhook',
+        type: 'n8n-nodes-base.webhook',
+        typeVersion: 2,
+        position: [0, 0],
+        parameters: { path: 'incoming' },
+      };
+      const before = createTestWorkflow({
+        name: 'Original Workflow',
+        versionId: 'v1',
+        nodes: [webhookNode],
+        connections: {},
+      });
+      const attempted = createTestWorkflow({
+        name: 'Renamed Workflow',
+        versionId: 'v1',
+        nodes: [webhookNode],
+        connections: {},
+      });
+      const afterPersist = createTestWorkflow({
+        name: 'Renamed Workflow',
+        versionId: 'v2',
+        nodes: [webhookNode],
+        connections: {},
+      });
+      const afterRollback = createTestWorkflow({
+        name: 'Original Workflow',
+        versionId: 'v3',
+        nodes: [webhookNode],
+        connections: {},
+      });
+      const validationError = new N8nValidationError('Invalid workflow structure', {
+        field: 'connections',
+        message: 'Invalid connection configuration',
+      });
+      const publishRefused = new N8nNotFoundError(
+        'You do not have permission to activate this workflow. Ask the owner to share it with you.',
+      );
+
+      mockApiClient.getWorkflow
+        .mockResolvedValueOnce(before)
+        .mockResolvedValueOnce(afterPersist)
+        .mockResolvedValueOnce(afterRollback);
+      mockDiffEngine.applyDiff.mockResolvedValue({
+        success: true,
+        workflow: attempted,
+        operationsApplied: 1,
+        message: 'Success',
+        errors: [],
+      });
+      mockApiClient.updateWorkflow
+        .mockRejectedValueOnce(validationError)
+        .mockRejectedValueOnce(publishRefused);
+
+      const result = await handleUpdatePartialWorkflow({
+        id: 'test-id',
+        operations: [{ type: 'updateName', name: 'Renamed Workflow' }],
+      }, mockRepository);
+
+      expect(result.details).toMatchObject({
+        rollbackPerformed: true,
+        rollbackVerifiedAfterError: true,
+      });
     });
 
     it('should handle input validation errors', async () => {

--- a/tests/unit/mcp/handlers-workflow-diff.test.ts
+++ b/tests/unit/mcp/handlers-workflow-diff.test.ts
@@ -1346,6 +1346,70 @@ describe('handlers-workflow-diff', () => {
       });
     });
 
+    it('should still report rollback failure when only a pre-existing webhookId differs', async () => {
+      // A webhookId the workflow already carried is real content, not a value the allowlist made up,
+      // so a change to one means the prior state was not restored. Only generated ids are ignored.
+      const hook = (webhookId: string) => ({
+        id: 'hook1',
+        name: 'Webhook',
+        type: 'n8n-nodes-base.webhook',
+        typeVersion: 2,
+        position: [0, 0],
+        parameters: { path: 'incoming' },
+        webhookId,
+      });
+      const before = createTestWorkflow({
+        name: 'Original Workflow',
+        versionId: 'v1',
+        nodes: [hook('stable-hook-id')],
+        connections: {},
+      });
+      const afterPersist = createTestWorkflow({
+        name: 'Original Workflow',
+        versionId: 'v2',
+        nodes: [hook('stable-hook-id')],
+        connections: {},
+      });
+      const afterRollback = createTestWorkflow({
+        name: 'Original Workflow',
+        versionId: 'v3',
+        nodes: [hook('replaced-hook-id')],
+        connections: {},
+      });
+      const validationError = new N8nValidationError('Invalid workflow structure', {
+        field: 'connections',
+        message: 'Invalid connection configuration',
+      });
+      const publishRefused = new N8nNotFoundError(
+        'You do not have permission to activate this workflow. Ask the owner to share it with you.',
+      );
+
+      mockApiClient.getWorkflow
+        .mockResolvedValueOnce(before)
+        .mockResolvedValueOnce(afterPersist)
+        .mockResolvedValueOnce(afterRollback);
+      mockDiffEngine.applyDiff.mockResolvedValue({
+        success: true,
+        workflow: before,
+        operationsApplied: 1,
+        message: 'Success',
+        errors: [],
+      });
+      mockApiClient.updateWorkflow
+        .mockRejectedValueOnce(validationError)
+        .mockRejectedValueOnce(publishRefused);
+
+      const result = await handleUpdatePartialWorkflow({
+        id: 'test-id',
+        operations: [{ type: 'updateName', name: 'Original Workflow' }],
+      }, mockRepository);
+
+      expect(result.error).toContain('rollback also failed');
+      expect(result.details).toMatchObject({
+        rollbackPerformed: false,
+      });
+    });
+
     it('should handle input validation errors', async () => {
       const invalidInput = {
         id: 'test-id',

--- a/tests/unit/scripts/check-settings-drift.test.ts
+++ b/tests/unit/scripts/check-settings-drift.test.ts
@@ -5,6 +5,7 @@ import {
   diffSettingsProperties,
   parseEntitySettingsProperties,
   parseSchemaProperties,
+  diffNodeProperties,
 } from '../../../scripts/check-settings-drift';
 import { WORKFLOW_SETTINGS_PROPERTIES } from '../../../src/constants/workflow-settings';
 
@@ -363,5 +364,45 @@ describe('check-settings-drift diffSettingsProperties', () => {
 
     expect(drift.ahead).toContain('engineType');
     expect(drift.entityOnly).toEqual([]);
+  });
+});
+
+describe('check-settings-drift diffNodeProperties', () => {
+  const nodeSchema = (props: string[]) =>
+    [
+      'components:',
+      '  schemas:',
+      '    node:',
+      '      type: object',
+      '      additionalProperties: false',
+      '      properties:',
+      ...props,
+      '    workflowSettings:',
+      '      type: object',
+    ].join('\n');
+
+  it('reports a writable node property the zod schema lacks, and ignores read-only ones', () => {
+    const yaml = nodeSchema([
+      '        id:',
+      '          type: string',
+      '        brandNewNodeFlag:',
+      '          type: boolean',
+      '        createdAt:',
+      '          type: string',
+      '          readOnly: true',
+    ]);
+
+    const drift = diffNodeProperties(yaml);
+
+    expect(drift.missing).toEqual(['brandNewNodeFlag']);
+    expect(drift.removed).not.toContain('id');
+    expect(drift.removed).not.toContain('createdAt');
+  });
+
+  it('reports a property we send that the schema no longer lists', () => {
+    const drift = diffNodeProperties(nodeSchema(['        id:', '          type: string']));
+
+    expect(drift.missing).toEqual([]);
+    expect(drift.removed).toContain('webhookId');
   });
 });

--- a/tests/unit/scripts/check-settings-drift.test.ts
+++ b/tests/unit/scripts/check-settings-drift.test.ts
@@ -367,6 +367,8 @@ describe('check-settings-drift diffSettingsProperties', () => {
   });
 });
 
+// The node arm has no offline counterpart to the entity-declaration test above: it runs for real
+// only inside `npm run update:n8n`, against the schema fetched for the new pin.
 describe('check-settings-drift diffNodeProperties', () => {
   const nodeSchema = (props: string[]) =>
     [
@@ -390,13 +392,21 @@ describe('check-settings-drift diffNodeProperties', () => {
       '        createdAt:',
       '          type: string',
       '          readOnly: true',
+      '        credentials:',
+      '          type: object',
+      '          properties:',
+      '            main:',
+      '              type: string',
+      '              readOnly: true',
     ]);
 
     const drift = diffNodeProperties(yaml);
 
+    // credentials is writable: the readOnly inside its sub-schema must not be attributed to it
     expect(drift.missing).toEqual(['brandNewNodeFlag']);
     expect(drift.removed).not.toContain('id');
     expect(drift.removed).not.toContain('createdAt');
+    expect(drift.removed).not.toContain('credentials');
   });
 
   it('reports a property we send that the schema no longer lists', () => {

--- a/tests/unit/services/n8n-api-client.test.ts
+++ b/tests/unit/services/n8n-api-client.test.ts
@@ -594,6 +594,120 @@ describe('N8nApiClient', () => {
     });
   });
 
+  describe('settings the instance rejects as unknown', () => {
+    // n8n's schema is additionalProperties: false, and the AJV message for a settings-level
+    // rejection never names the key. The client retries without candidates, newest first, and
+    // reports what it had to leave out.
+    const badRequest = (message: string) =>
+      createAxiosError({ message, response: { status: 400, data: { message } } });
+    const settingsRejected = () => badRequest('request/body/settings must NOT have additional properties');
+    const workflowWith = (settings: Record<string, unknown>) => ({
+      name: 'Settings',
+      nodes: [],
+      connections: {},
+      settings,
+    });
+
+    beforeEach(() => {
+      client = new N8nApiClient(defaultConfig);
+    });
+
+    it('retries without the keys it does not know before touching known ones, and warns', async () => {
+      mockAxiosInstance.put
+        .mockRejectedValueOnce(settingsRejected())
+        .mockResolvedValue({ data: { id: '123' } });
+      const warnings: string[] = [];
+
+      await client.updateWorkflow('123', workflowWith({ executionOrder: 'v1', timeSavedMode: 'fixed', mysteryKey: 1 }), {
+        onWarning: w => warnings.push(w),
+      });
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledTimes(2);
+      expect(mockAxiosInstance.put.mock.calls[1][1].settings).toEqual({ executionOrder: 'v1', timeSavedMode: 'fixed' });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('mysteryKey');
+      expect(warnings[0]).not.toContain('timeSavedMode');
+    });
+
+    it('then drops known keys one at a time from newest to oldest', async () => {
+      mockAxiosInstance.put
+        .mockRejectedValueOnce(settingsRejected())
+        .mockRejectedValueOnce(settingsRejected())
+        .mockResolvedValue({ data: { id: '123' } });
+      const warnings: string[] = [];
+
+      await client.updateWorkflow(
+        '123',
+        workflowWith({ executionOrder: 'v1', redactionPolicy: 'strict', timeSavedMode: 'fixed', mysteryKey: 1 }),
+        { onWarning: w => warnings.push(w) }
+      );
+
+      const bodies = mockAxiosInstance.put.mock.calls.map((call: any[]) => call[1].settings);
+      expect(bodies).toEqual([
+        { executionOrder: 'v1', redactionPolicy: 'strict', timeSavedMode: 'fixed', mysteryKey: 1 },
+        { executionOrder: 'v1', redactionPolicy: 'strict', timeSavedMode: 'fixed' },
+        { executionOrder: 'v1', redactionPolicy: 'strict' },
+      ]);
+      expect(warnings.join(' ')).toContain('mysteryKey, timeSavedMode');
+    });
+
+    it('remembers a rejected key and strips it from the next write without probing again', async () => {
+      mockAxiosInstance.put
+        .mockRejectedValueOnce(settingsRejected())
+        .mockResolvedValue({ data: { id: '123' } });
+      const warnings: string[] = [];
+
+      await client.updateWorkflow('123', workflowWith({ executionOrder: 'v1', mysteryKey: 1 }));
+      await client.updateWorkflow('123', workflowWith({ executionOrder: 'v1', mysteryKey: 1 }), {
+        onWarning: w => warnings.push(w),
+      });
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledTimes(3);
+      expect(mockAxiosInstance.put.mock.calls[2][1].settings).toEqual({ executionOrder: 'v1' });
+      expect(warnings.join(' ')).toContain('mysteryKey');
+    });
+
+    it('falls back to the minimal settings n8n accepts when every key was rejected', async () => {
+      mockAxiosInstance.put
+        .mockRejectedValueOnce(settingsRejected())
+        .mockResolvedValue({ data: { id: '123' } });
+
+      await client.updateWorkflow('123', workflowWith({ mysteryKey: 1 }));
+
+      expect(mockAxiosInstance.put.mock.calls[1][1].settings).toEqual({ executionOrder: 'v1' });
+    });
+
+    it('surfaces the rejection once the ladder is exhausted', async () => {
+      mockAxiosInstance.put.mockRejectedValue(settingsRejected());
+
+      await expect(
+        client.updateWorkflow('123', workflowWith({ executionOrder: 'v1', timeSavedMode: 'fixed', mysteryKey: 1 }))
+      ).rejects.toThrow(/additional properties/);
+
+      // original, without unknown keys, without timeSavedMode: three sends, then give up.
+      expect(mockAxiosInstance.put).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not retry a rejection that names a different path', async () => {
+      mockAxiosInstance.put.mockRejectedValue(badRequest('request/body/nodes/0 must NOT have additional properties'));
+
+      await expect(client.updateWorkflow('123', workflowWith({ executionOrder: 'v1', mysteryKey: 1 }))).rejects.toThrow();
+
+      expect(mockAxiosInstance.put).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies to create as well as update', async () => {
+      mockAxiosInstance.post
+        .mockRejectedValueOnce(settingsRejected())
+        .mockResolvedValue({ data: { id: '123' } });
+
+      await client.createWorkflow(workflowWith({ executionOrder: 'v1', mysteryKey: 1 }));
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledTimes(2);
+      expect(mockAxiosInstance.post.mock.calls[1][1].settings).toEqual({ executionOrder: 'v1' });
+    });
+  });
+
   describe('canvas groups (nodeGroups)', () => {
     // n8n validates canvas groups on every write, including writes unrelated to grouping, and
     // names the group it rejects. These cover the degradation ladder that keeps an unrelated edit

--- a/tests/unit/services/n8n-api-client.test.ts
+++ b/tests/unit/services/n8n-api-client.test.ts
@@ -696,6 +696,25 @@ describe('N8nApiClient', () => {
       expect(mockAxiosInstance.put).toHaveBeenCalledTimes(1);
     });
 
+    it('reaches the ladder when the settings rejection surfaces on the group ladder\'s retry', async () => {
+      // First send: groups rejected without a name. The group ladder retries without the field
+      // to confirm; that retry is refused for settings. The settings complaint must win, or the
+      // write fails with the groups error and the settings ladder never runs.
+      mockAxiosInstance.put
+        .mockRejectedValueOnce(badRequest('request/body must NOT have additional properties'))
+        .mockRejectedValueOnce(settingsRejected())
+        .mockResolvedValue({ data: { id: '123' } });
+
+      await client.updateWorkflow('123', {
+        ...workflowWith({ executionOrder: 'v1', mysteryKey: 1 }),
+        nodes: [{ id: 'a', name: 'A', type: 'n8n-nodes-base.set', typeVersion: 1, position: [0, 0], parameters: {} }],
+        nodeGroups: [{ id: 'g1', name: 'G', nodeIds: ['a'] }],
+      } as any);
+
+      const last = mockAxiosInstance.put.mock.calls.at(-1)![1];
+      expect(last.settings).toEqual({ executionOrder: 'v1' });
+    });
+
     it('applies to create as well as update', async () => {
       mockAxiosInstance.post
         .mockRejectedValueOnce(settingsRejected())

--- a/tests/unit/services/n8n-api-client.test.ts
+++ b/tests/unit/services/n8n-api-client.test.ts
@@ -667,6 +667,21 @@ describe('N8nApiClient', () => {
       expect(warnings.join(' ')).toContain('mysteryKey');
     });
 
+    it('does not remember a batch of unknown keys, since only one of them may be the culprit', async () => {
+      mockAxiosInstance.put
+        .mockRejectedValueOnce(settingsRejected())
+        .mockResolvedValue({ data: { id: '123' } });
+      const settings = { executionOrder: 'v1', mysteryKey: 1, settingAddedNextWeek: true };
+
+      await client.updateWorkflow('123', workflowWith(settings));
+      mockAxiosInstance.put.mockRejectedValueOnce(settingsRejected()).mockResolvedValue({ data: { id: '123' } });
+      await client.updateWorkflow('123', workflowWith(settings));
+
+      // 2 for the first call, 2 for the second: the batch is probed again, not stripped up front.
+      expect(mockAxiosInstance.put).toHaveBeenCalledTimes(4);
+      expect(mockAxiosInstance.put.mock.calls[2][1].settings).toEqual(settings);
+    });
+
     it('falls back to the minimal settings n8n accepts when every key was rejected', async () => {
       mockAxiosInstance.put
         .mockRejectedValueOnce(settingsRejected())
@@ -713,6 +728,8 @@ describe('N8nApiClient', () => {
 
       const last = mockAxiosInstance.put.mock.calls.at(-1)![1];
       expect(last.settings).toEqual({ executionOrder: 'v1' });
+      // The failed confirmation probe must not have latched the instance as group-less.
+      expect(last.nodeGroups).toEqual([{ id: 'g1', name: 'G', nodeIds: ['a'] }]);
     });
 
     it('applies to create as well as update', async () => {

--- a/tests/unit/services/n8n-validation.test.ts
+++ b/tests/unit/services/n8n-validation.test.ts
@@ -9,6 +9,7 @@ import {
   validateWorkflowSettings,
   cleanWorkflowForCreate,
   cleanWorkflowForUpdate,
+  cleanNodeForApi,
   validateWorkflowStructure,
   hasWebhookTrigger,
   getWebhookUrl,
@@ -441,6 +442,29 @@ describe('n8n-validation', () => {
         const cleaned = cleanWorkflowForCreate(workflow as Workflow);
         expect(cleaned.nodes![0].webhookId).toBeUndefined();
       });
+
+      it('should strip unknown node properties echoed by n8n GET', () => {
+        const workflow = workflowWithNodes([
+          {
+            id: 'n1',
+            name: 'Set',
+            type: 'n8n-nodes-base.set',
+            typeVersion: 3,
+            position: [100, 200],
+            parameters: {},
+            onError: 'continueErrorOutput',
+            issues: { parameters: { missing: true } },
+            runIndex: 0,
+          } as unknown as WorkflowNode,
+        ]);
+
+        const cleaned = cleanWorkflowForCreate(workflow as Workflow);
+        const node = cleaned.nodes![0];
+
+        expect(node.onError).toBe('continueErrorOutput');
+        expect(node).not.toHaveProperty('issues');
+        expect(node).not.toHaveProperty('runIndex');
+      });
     });
 
     describe('cleanWorkflowForUpdate', () => {
@@ -845,6 +869,100 @@ describe('n8n-validation', () => {
 
         const cleaned = cleanWorkflowForUpdate(workflow);
         expect(cleaned.nodes![0].webhookId).toBeUndefined();
+      });
+
+      it('should strip unknown node properties echoed by n8n GET (Issue #extra-node-props)', () => {
+        const workflow = workflowWithNodes([
+          {
+            id: 'n1',
+            name: 'Set',
+            type: 'n8n-nodes-base.set',
+            typeVersion: 3,
+            position: [100, 200],
+            parameters: {},
+            onError: 'continueRegularOutput',
+            // Server-managed fields echoed by GET but rejected on PUT/PATCH:
+            issues: { parameters: { missing: true } },
+            runIndex: 0,
+          } as any,
+          {
+            id: 'n2',
+            name: 'Webhook',
+            type: 'n8n-nodes-base.webhook',
+            typeVersion: 1,
+            position: [300, 200],
+            parameters: {},
+            webhookId: 'existing-wh-id',
+            // Extra echo field
+            data: { some: 'thing' },
+          } as any,
+        ]);
+
+        const cleaned = cleanWorkflowForUpdate(workflow as any);
+        const setNode = cleaned.nodes![0];
+        const webhookNode2 = cleaned.nodes![1];
+
+        // Allowed fields survive
+        expect(setNode.id).toBe('n1');
+        expect(setNode.name).toBe('Set');
+        expect(setNode.type).toBe('n8n-nodes-base.set');
+        expect(setNode.typeVersion).toBe(3);
+        expect(setNode.position).toEqual([100, 200]);
+        expect(setNode.onError).toBe('continueRegularOutput');
+
+        // Unknown echo fields are stripped
+        expect(setNode).not.toHaveProperty('issues');
+        expect(setNode).not.toHaveProperty('runIndex');
+        expect(webhookNode2).not.toHaveProperty('data');
+
+        // webhookId survives (it's in the allowlist)
+        expect(webhookNode2.webhookId).toBe('existing-wh-id');
+      });
+    });
+
+    describe('cleanNodeForApi', () => {
+      it('should keep all known node properties', () => {
+        const node: WorkflowNode = {
+          id: 'n1',
+          name: 'Test',
+          type: 'n8n-nodes-base.set',
+          typeVersion: 3,
+          position: [0, 0],
+          parameters: { key: 'val' },
+          credentials: { api: 'cred' },
+          disabled: false,
+          notes: 'note',
+          notesInFlow: true,
+          continueOnFail: true,
+          onError: 'stopWorkflow',
+          retryOnFail: true,
+          maxTries: 3,
+          waitBetweenTries: 1000,
+          alwaysOutputData: true,
+          executeOnce: false,
+          webhookId: 'wh-id',
+        };
+        const cleaned = cleanNodeForApi(node);
+        expect(cleaned).toEqual(node);
+      });
+
+      it('should strip unknown properties', () => {
+        const node = {
+          id: 'n1',
+          name: 'Test',
+          type: 'n8n-nodes-base.set',
+          typeVersion: 3,
+          position: [0, 0],
+          parameters: {},
+          issues: { error: true },
+          runIndex: 0,
+          data: { extra: true },
+        } as unknown as WorkflowNode;
+        const cleaned = cleanNodeForApi(node);
+        expect(cleaned).not.toHaveProperty('issues');
+        expect(cleaned).not.toHaveProperty('runIndex');
+        expect(cleaned).not.toHaveProperty('data');
+        expect(cleaned.id).toBe('n1');
       });
     });
   });

--- a/tests/unit/services/n8n-validation.test.ts
+++ b/tests/unit/services/n8n-validation.test.ts
@@ -964,6 +964,139 @@ describe('n8n-validation', () => {
         expect(cleaned).not.toHaveProperty('data');
         expect(cleaned.id).toBe('n1');
       });
+
+      // ====================================================================
+      // Issue #433 — GET→spread→UPDATE patterns (unit-level, always run in CI)
+      //
+      // n8n API quirks these tests lock in:
+      // - GET returns read-only fields (id, createdAt, versionId, description, …)
+      // - PUT/PATCH reject those fields (additionalProperties: false on some versions)
+      // - description is returned by GET but rejected on update (Issue #431)
+      // - empty settings {} is rejected; missing settings get { executionOrder: 'v1' }
+      // Users commonly do: updateWorkflow(id, { ...await getWorkflow(id), name: 'x' })
+      // ====================================================================
+
+      it('should clean a full GET-shaped response for safe PUT (Issue #433)', () => {
+        // Simulate the object shape returned by GET, then spread + rename
+        const getResponse = {
+          id: 'wf-abc',
+          name: 'Original Name',
+          description: 'Returned by GET but not writable on PUT',
+          nodes: [
+            {
+              id: 'webhook-1',
+              name: 'Webhook',
+              type: 'n8n-nodes-base.webhook',
+              typeVersion: 2,
+              position: [250, 300],
+              parameters: { path: 'test' },
+              webhookId: 'existing-wh',
+            },
+          ],
+          connections: {},
+          settings: { executionOrder: 'v1', timezone: 'UTC' },
+          active: false,
+          isArchived: false,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-06-01T00:00:00.000Z',
+          versionId: 'ver-123',
+          versionCounter: 9,
+          meta: { templateCredsSetupCompleted: true },
+          staticData: { 'node:Webhook': { data: 1 } },
+          pinData: {},
+          tags: [{ id: 't1', name: 'prod' }],
+          triggerCount: 1,
+          shared: [],
+          activeVersionId: 'av-1',
+          nodeGroups: [],
+          availableInMCP: false,
+        } as any;
+
+        const cleaned = cleanWorkflowForUpdate({
+          ...getResponse,
+          name: 'Renamed via spread',
+        });
+
+        expect(cleaned.name).toBe('Renamed via spread');
+        expect(cleaned.nodes).toHaveLength(1);
+        expect(cleaned.connections).toEqual({});
+        expect(cleaned.settings).toEqual({ executionOrder: 'v1', timezone: 'UTC' });
+        // nodeGroups is allowlisted for n8n 2.28+: empty array means ungroup everything
+        // and is intentionally forwarded (omitting the key would backfill stored groups).
+        expect(cleaned.nodeGroups).toEqual([]);
+
+        // Read-only / computed fields must never reach PUT
+        for (const key of [
+          'id',
+          'description',
+          'active',
+          'isArchived',
+          'createdAt',
+          'updatedAt',
+          'versionId',
+          'versionCounter',
+          'meta',
+          'staticData',
+          'pinData',
+          'tags',
+          'triggerCount',
+          'shared',
+          'activeVersionId',
+          'availableInMCP',
+        ]) {
+          expect(cleaned).not.toHaveProperty(key);
+        }
+
+        expect(Object.keys(cleaned).sort()).toEqual([
+          'connections',
+          'name',
+          'nodeGroups',
+          'nodes',
+          'settings',
+        ]);
+      });
+
+      it('should allow minimal payload (name/nodes/connections only) with settings defaults (Issue #433)', () => {
+        const cleaned = cleanWorkflowForUpdate({
+          name: 'Minimal',
+          nodes: [],
+          connections: {},
+        } as any);
+
+        expect(cleaned).toEqual({
+          name: 'Minimal',
+          nodes: [],
+          connections: {},
+          settings: { executionOrder: 'v1' },
+        });
+      });
+
+      it('should replace empty settings objects with minimal defaults (Issue #433 / #431)', () => {
+        const cleaned = cleanWorkflowForUpdate({
+          name: 'Empty Settings',
+          nodes: [],
+          connections: {},
+          settings: {},
+        } as any);
+
+        expect(cleaned.settings).toEqual({ executionOrder: 'v1' });
+      });
+
+      it('should default settings when only unknown settings properties remain (Issue #433)', () => {
+        const cleaned = cleanWorkflowForUpdate({
+          name: 'Filtered Settings',
+          nodes: [],
+          connections: {},
+          settings: {
+            totallyUnknownSetting: true,
+            anotherGarbageField: 42,
+          },
+        } as any);
+
+        expect(cleaned.settings).toEqual({ executionOrder: 'v1' });
+        expect(cleaned.settings).not.toHaveProperty('totallyUnknownSetting');
+        expect(cleaned.settings).not.toHaveProperty('anotherGarbageField');
+      });
     });
   });
 

--- a/tests/unit/services/n8n-validation.test.ts
+++ b/tests/unit/services/n8n-validation.test.ts
@@ -965,6 +965,9 @@ describe('n8n-validation', () => {
         expect(cleaned.id).toBe('n1');
       });
 
+    });
+
+    describe('GET→UPDATE round-trips (Issue #433)', () => {
       // ====================================================================
       // Issue #433 — GET→spread→UPDATE patterns (unit-level, always run in CI)
       //
@@ -1082,20 +1085,21 @@ describe('n8n-validation', () => {
         expect(cleaned.settings).toEqual({ executionOrder: 'v1' });
       });
 
-      it('should default settings when only unknown settings properties remain (Issue #433)', () => {
+      it('should forward settings properties it does not know, so a newer n8n can accept them', () => {
+        // The settings table trails n8n's releases; filtering here dropped redactionPolicy for two
+        // months. Unknown keys reach the instance, and N8nApiClient retries without them only
+        // when the instance rejects them.
         const cleaned = cleanWorkflowForUpdate({
-          name: 'Filtered Settings',
+          name: 'Forwarded Settings',
           nodes: [],
           connections: {},
           settings: {
-            totallyUnknownSetting: true,
-            anotherGarbageField: 42,
+            executionOrder: 'v1',
+            settingAddedNextWeek: true,
           },
         } as any);
 
-        expect(cleaned.settings).toEqual({ executionOrder: 'v1' });
-        expect(cleaned.settings).not.toHaveProperty('totallyUnknownSetting');
-        expect(cleaned.settings).not.toHaveProperty('anotherGarbageField');
+        expect(cleaned.settings).toEqual({ executionOrder: 'v1', settingAddedNextWeek: true });
       });
     });
   });

--- a/tests/unit/services/n8n-validation.test.ts
+++ b/tests/unit/services/n8n-validation.test.ts
@@ -871,7 +871,7 @@ describe('n8n-validation', () => {
         expect(cleaned.nodes![0].webhookId).toBeUndefined();
       });
 
-      it('should strip unknown node properties echoed by n8n GET (Issue #extra-node-props)', () => {
+      it('should strip unknown node properties echoed by n8n GET (#983)', () => {
         const workflow = workflowWithNodes([
           {
             id: 'n1',

--- a/tests/unit/services/n8n-version.test.ts
+++ b/tests/unit/services/n8n-version.test.ts
@@ -11,6 +11,7 @@ import {
   getCachedVersion,
   fetchN8nVersion,
   VERSION_THRESHOLDS,
+  settingsRejectionLadder,
 } from '@/services/n8n-version';
 import type { N8nVersionInfo } from '@/types/n8n-api';
 import type { PinnedAgents } from '@/utils/ssrf-protection';
@@ -534,5 +535,35 @@ describe('n8n-version', () => {
       expect(cleaned).not.toHaveProperty('callerPolicy');
       expect(cleaned).not.toHaveProperty('availableInMCP');
     });
+  });
+});
+
+describe('settingsRejectionLadder', () => {
+  it('drops keys outside the settings table first, together, then known keys newest first', () => {
+    const steps = settingsRejectionLadder({
+      executionOrder: 'v1',
+      callerPolicy: 'workflowsFromSameOwner',
+      customTelemetryTags: { team: 'ops' },
+      timeSavedMode: 'fixed',
+      redactionPolicy: 'strict',
+      addedLastWeek: true,
+      addedYesterday: 1,
+    });
+
+    expect(steps).toEqual([
+      ['addedLastWeek', 'addedYesterday'],
+      ['timeSavedMode'],
+      ['redactionPolicy'],
+      ['customTelemetryTags'],
+    ]);
+  });
+
+  it('never offers keys that predate 1.119.0, which version detection still covers', () => {
+    expect(settingsRejectionLadder({ executionOrder: 'v1', timezone: 'UTC', callerPolicy: 'any' })).toEqual([]);
+  });
+
+  it('is empty for missing or malformed settings', () => {
+    expect(settingsRejectionLadder(undefined)).toEqual([]);
+    expect(settingsRejectionLadder(['not', 'an', 'object'])).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Takes over five community PRs on the workflow write path, with their commits and authorship carried over, plus one maintainer change that replaces #1017.

- #983 (@blouflab): strip node properties n8n echoes on GET but rejects on PUT.
- #979 (@edward-stjohn-CoT): verify a rollback against the server before reporting it as failed.
- #925 (@Pitchfork-and-Torch): GET→UPDATE round-trip tests (#433).
- #908 (@fix2015): package version in the engine health check, `writableEnded`, a dead cast.
- Replaces #1017 (@LouisBurette): the settings-rejection retry ladder below.

## Settings the instance rejects as unknown (replaces #1017)

#1017 marked `timeSavedMode` as derived so it would be stripped from every write. Checked live against n8n 2.36.7: PUT accepts and echoes `timeSavedMode` (it validates the value against `fixed`/`dynamic`), so stripping it would drop a real setting on current instances. The 400 the reporter hit comes from an n8n whose write schema lagged its entity, and the message `request/body/settings must NOT have additional properties` never names the key.

`N8nApiClient` now wraps the existing nodeGroups ladder with a settings ladder: on that error it retries without candidates from `settingsRejectionLadder`, keys absent from the settings table first (together), then known keys newest first, never those introduced at or before n8n 1.119.0 (instances that old still report a version and are filtered precisely). Dropped keys are reported in the tool response `warnings`; a key dropped on its own is remembered for the client's lifetime, a batch is not (only one of them may be the culprit). Verified live: a create and a partial update carrying an unknown settings key both succeed with a warning naming it. Settings stay forwarded untouched by default, as before.

## Node allowlist (#983)

Verified live: n8n 2.36.7 answers `request/body/nodes/0 must NOT have additional properties` for any unknown node key and `createdAt is read-only`. The allowlist is derived from the zod node schema, and `check:settings-drift` now compares that schema against the node schema n8n ships; that check caught `customTelemetryTags`, which n8n 2.36's node schema accepts and the allowlist lacked. `onError` and `webhookId` were added to the schema.

## Rollback verification (#979)

After a rollback PUT throws, `n8n_update_partial_workflow` re-reads the workflow and compares the writable fields with the pre-update snapshot; a match is reported as `rollbackVerifiedAfterError: true`. Generated webhook ids are ignored on both reads, so the comparison does not depend on the cleaner mutating the snapshot in place.

## Review

Code-simplifier pass, Opus code-reviewer (two rounds), Codex. Findings fixed: batch memoisation of rejected keys, the node-schema drift gap above, the group ladder's confirmation retry swallowing a settings rejection (Codex), the mutation dependency in the rollback comparison, plus notes and test fixes. The one assertion in #925 that encoded the pre-2.70 settings allowlist was rewritten to assert forwarding. Version 2.81.0.

## Credits

- @blouflab (#983), @edward-stjohn-CoT (#979), @Pitchfork-and-Torch (#925), @fix2015 (#908) for the fixes and tests carried over.
- @LouisBurette (#1017) for tracking down the `timeSavedMode` rejection, and @jusched for the report that `binaryMode` failed the same way.

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)
