### PR TITLE
Validate versioned workflows against their own node schemas

### DIFF
--- a/src/services/workflow-validator.ts
+++ b/src/services/workflow-validator.ts
@@ -653,10 +653,16 @@ export class WorkflowValidator {
           '@version': node.typeVersion || 1,
           ...node.parameters
         };
+        const versionProperties = nodeInfo.isVersioned && node.typeVersion != null
+          ? this.nodeRepository.getNodeVersion(normalizedType, String(node.typeVersion))?.propertiesSchema
+          : null;
+        const properties = versionProperties && nodeInfo.isToolVariant
+          ? [...nodeInfo.properties.filter((property: any) => property.name === 'toolDescription'), ...versionProperties]
+          : versionProperties || nodeInfo.properties;
         const nodeValidation = this.nodeValidator.validateWithMode(
           node.type,
           paramsWithVersion,
-          nodeInfo.properties || [],
+          properties || [],
           'operation',
           profile as any
         );

--- a/tests/unit/services/workflow-validator-version-schema.test.ts
+++ b/tests/unit/services/workflow-validator-version-schema.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EnhancedConfigValidator } from '@/services/enhanced-config-validator';
+import { WorkflowValidator } from '@/services/workflow-validator';
+import type { NodeRepository } from '@/database/node-repository';
+
+vi.mock('@/utils/logger');
+
+describe('WorkflowValidator version-specific schemas', () => {
+  it('validates a Notion 2.2 database page against its own schema', async () => {
+    const title = {
+      displayName: 'Title',
+      name: 'title',
+      type: 'string',
+      default: '',
+      required: true,
+      displayOptions: { show: { resource: ['databasePage'], operation: ['create'] } },
+    };
+    const properties = [
+      { displayName: 'Resource', name: 'resource', type: 'options', default: 'page' },
+      { displayName: 'Operation', name: 'operation', type: 'options', default: 'create', displayOptions: { show: { resource: ['databasePage'] } } },
+      title,
+    ];
+    const repository = {
+      getAllNodes: vi.fn(() => []),
+      getNode: vi.fn((type: string) => type === 'nodes-base.manualTrigger'
+        ? { nodeType: type, displayName: 'Manual Trigger', package: 'n8n-nodes-base', isTrigger: true, isVersioned: false, outputs: ['main'], properties: [] }
+        : { nodeType: type, displayName: 'Notion', package: 'n8n-nodes-base', version: 3, isVersioned: true, outputs: ['main'], properties }),
+      getNodeVersion: vi.fn(() => ({ propertiesSchema: properties.map(property => property === title ? { ...property, required: false } : property) })),
+    } as unknown as NodeRepository;
+    const validator = new WorkflowValidator(repository, EnhancedConfigValidator);
+    const workflow = {
+      name: 'notion-title-expression-repro',
+      nodes: [
+        { parameters: {}, id: 'trigger', name: 'Manual Trigger', type: 'n8n-nodes-base.manualTrigger', position: [0, 0], typeVersion: 1 },
+        {
+          parameters: {
+            resource: 'databasePage',
+            databaseId: { __rl: true, mode: 'list', value: '00000000-0000-0000-0000-000000000000', cachedResultName: 'example-db' },
+            propertiesUi: { propertyValues: [
+              { key: 'URL|url', urlValue: "={{ 'https://example.com' + $json.path }}" },
+              { key: 'title|title', title: '={{ $json.title }}' },
+              { key: 'abstract|rich_text', textContent: '={{ $json.abstract }}' },
+            ] },
+            options: {},
+          },
+          id: 'notion',
+          name: 'Store Page',
+          type: 'n8n-nodes-base.notion',
+          position: [220, 0],
+          typeVersion: 2.2,
+        },
+      ],
+      connections: { 'Manual Trigger': { main: [[{ node: 'Store Page', type: 'main', index: 0 }]] } },
+    };
+
+    const result = await validator.validateWorkflow(workflow as any, { profile: 'runtime' });
+
+    expect(result.errors).toEqual([]);
+    expect(repository.getNodeVersion).toHaveBeenCalledWith('nodes-base.notion', '2.2');
+  });
+
+  it('preserves Tool variant properties in historical schemas', async () => {
+    const historicalProperties = [
+      { displayName: 'Resource', name: 'resource', type: 'options', default: 'event' },
+    ];
+    const repository = {
+      getAllNodes: vi.fn(() => []),
+      getNode: vi.fn((type: string) => ({
+        nodeType: type,
+        displayName: 'Google Calendar Tool',
+        package: 'n8n-nodes-base',
+        version: 1.4,
+        isVersioned: true,
+        isToolVariant: true,
+        toolVariantOf: 'nodes-base.googleCalendar',
+        outputs: ['ai_tool'],
+        properties: [
+          { displayName: 'Tool Description', name: 'toolDescription', type: 'string', default: '' },
+          ...historicalProperties,
+        ],
+      })),
+      getNodeVersion: vi.fn(() => ({ propertiesSchema: historicalProperties })),
+    } as unknown as NodeRepository;
+    const validator = new WorkflowValidator(repository, EnhancedConfigValidator);
+    const workflow = {
+      name: 'tool-variant-version-repro',
+      nodes: [{
+        parameters: {
+          toolDescription: 'Look up calendar events',
+          resource: 'event',
+        },
+        id: 'calendar-tool',
+        name: 'Google Calendar Tool',
+        type: 'n8n-nodes-base.googleCalendarTool',
+        position: [0, 0],
+        typeVersion: 1.3,
+      }],
+      connections: {},
+    };
+
+    const result = await validator.validateWorkflow(workflow as any, { profile: 'strict' });
+
+    expect(result.warnings.some(warning => warning.message.includes("Property 'toolDescription' won't be used"))).toBe(false);
+    expect(repository.getNodeVersion).toHaveBeenCalledWith('nodes-base.googleCalendarTool', '1.3');
+  });
+
+  it('falls back to the latest schema when an exact version is unavailable', async () => {
+    const properties = [
+      { displayName: 'Current Field', name: 'currentField', type: 'string', default: '', required: true },
+    ];
+    const repository = {
+      getAllNodes: vi.fn(() => []),
+      getNode: vi.fn((type: string) => ({
+        nodeType: type,
+        displayName: 'Versioned Node',
+        package: 'n8n-nodes-base',
+        version: 2,
+        isVersioned: true,
+        outputs: ['main'],
+        properties,
+      })),
+      getNodeVersion: vi.fn(() => null),
+    } as unknown as NodeRepository;
+    const validator = new WorkflowValidator(repository, EnhancedConfigValidator);
+    const workflow = {
+      name: 'missing-version-schema-repro',
+      nodes: [{
+        parameters: {},
+        id: 'versioned-node',
+        name: 'Versioned Node',
+        type: 'n8n-nodes-base.versionedNode',
+        position: [0, 0],
+        typeVersion: 1,
+      }],
+      connections: {},
+    };
+
+    const result = await validator.validateWorkflow(workflow as any, { profile: 'runtime' });
+
+    expect(result.errors.some(error => error.message.includes("Required property 'Current Field' cannot be empty"))).toBe(true);
+    expect(repository.getNodeVersion).toHaveBeenCalledWith('nodes-base.versionedNode', '1');
+  });
+});


### PR DESCRIPTION
## Context

Notion 3 made the database-page `title` field required. Workflows saved with Notion 2.2 were still being validated against that latest schema, so a valid nested title expression produced `Required property 'Title' cannot be empty`.

Review also exposed a related path: persisted `*Tool` variants resolve version rows through their base node, whose historical schema does not contain the generated `toolDescription` property.

Fixes https://github.com/czlonkowski/n8n-mcp/issues/1037

## Changes

- resolve versioned node properties from the workflow node's `typeVersion`
- preserve the generated `toolDescription` property when a Tool variant uses its base node's historical schema
- fall back to the latest schema when an exact version row is unavailable
- cover the Notion 2.2, Google Calendar Tool 1.3 strict-profile, and missing-version paths

## User impact

Older versioned nodes are validated against the schema they actually execute with, including stored Tool variants, while current nodes retain their existing validation.

## Verification

- Tool-variant regression test failed before the fix with `Property 'toolDescription' won't be used - not visible with current settings`
- Local validator/repository suite: 374 tests passed
- Local `npm run typecheck`, `npm run build`, and `git diff upstream/main...HEAD --check`: passed
- GitHub Actions: unit coverage, offline integration tests, lint, typecheck, CommonJS runtime, secret scan, and Codecov patch coverage passed
- Docker publish jobs stopped at registry login because fork PRs do not receive the repository credentials

Conceived by Romuald Członkowski - https://aiadvisors.pl/en