### PR TITLE
Keep catalog reads scoped to the request instance

### DIFF
--- a/src/mcp/handlers-official-tools.ts
+++ b/src/mcp/handlers-official-tools.ts
@@ -170,10 +170,13 @@ export async function handleListCatalog(args: unknown, context?: InstanceContext
     return { success: false, code: 'INVALID_ARGS', error: parsed.error.issues.map(i => `${i.path.join('.') || 'input'}: ${i.message}`).join('; ') };
   }
   const { kind, query, limit } = parsed.data;
-  const api = getN8nApiClient(context);
-  if (!api) return { success: false, code: 'NOT_CONFIGURED', error: 'n8n API not configured. Set N8N_API_URL and N8N_API_KEY.' };
 
   if (kind === 'tags') {
+    if (!publicApiMatchesContext(context)) {
+      return { success: false, kind, code: 'NOT_CONFIGURED', error: PUBLIC_API_CONTEXT_HINT } as McpToolResponse;
+    }
+    const api = getN8nApiClient(context);
+    if (!api) return { success: false, kind, code: 'NOT_CONFIGURED', error: 'n8n API not configured. Set N8N_API_URL and N8N_API_KEY.' } as McpToolResponse;
     try {
       const tags = (await api.listTags({ limit: 250 })).data.map(t => ({ id: String(t.id), name: t.name }));
       return { success: true, kind, backend: 'public-api', data: { items: filterItems(tags, query, limit) } } as McpToolResponse;

--- a/tests/unit/mcp/handlers-official-tools.test.ts
+++ b/tests/unit/mcp/handlers-official-tools.test.ts
@@ -5,6 +5,7 @@ vi.mock('@/mcp/official-mcp-access', async (orig) => ({ ...(await orig<any>()), 
 const api = vi.hoisted(() => ({ getN8nApiClient: vi.fn() }));
 vi.mock('@/mcp/handlers-n8n-manager', () => ({ getN8nApiClient: api.getN8nApiClient }));
 import { handleExploreNodeResources, handleListCatalog, callOfficialTool, resolveProjectChoices } from '@/mcp/handlers-official-tools';
+import { PUBLIC_API_CONTEXT_HINT } from '@/services/mcp-exposure';
 import { N8nApiError } from '@/utils/n8n-errors';
 import { N8nOfficialMcpClient } from '@/services/n8n-official-mcp-client';
 import { startFakeOfficialMcp, FakeOfficialMcp, FakeTool } from '../../helpers/fake-official-mcp-server';
@@ -173,6 +174,28 @@ describe('handleListCatalog', () => {
     api.getN8nApiClient.mockReturnValue({ listTags: vi.fn().mockResolvedValue({ data: [{ id: 't1', name: 'Prod' }, { id: 't2', name: 'staging' }, { id: 't3', name: 'Production' }] }) });
     const r = await handleListCatalog({ kind: 'tags', query: 'prod', limit: 1 });
     expect(r).toMatchObject({ success: true, kind: 'tags', backend: 'public-api', data: { items: [{ id: 't1', name: 'Prod' }] } });
+  });
+  it('does not fall back to the environment API for tags on a url + token context', async () => {
+    api.getN8nApiClient.mockReturnValue({ listTags: vi.fn() });
+
+    const r = await handleListCatalog(
+      { kind: 'tags' },
+      { n8nApiUrl: 'https://other.test.com', n8nMcpAccessToken: 'tok' }
+    );
+
+    expect(api.getN8nApiClient).not.toHaveBeenCalled();
+    expect(r).toMatchObject({ success: false, code: 'NOT_CONFIGURED', error: PUBLIC_API_CONTEXT_HINT });
+  });
+  it('uses the context-specific hint when projects have no matching client', async () => {
+    api.getN8nApiClient.mockReturnValue(null);
+    access.getOfficialMcpClient.mockReturnValue(null);
+
+    const r = await handleListCatalog(
+      { kind: 'projects' },
+      { n8nApiUrl: 'https://other.test.com', n8nMcpAccessToken: 'tok' }
+    );
+
+    expect(r).toMatchObject({ success: false, code: 'NOT_CONFIGURED', error: PUBLIC_API_CONTEXT_HINT });
   });
   it('rejects unknown kinds', async () => {
     expect(await handleListCatalog({ kind: 'users' })).toMatchObject({ success: false, code: 'INVALID_ARGS' });


### PR DESCRIPTION
## Problem / Context

A request context containing an n8n URL and MCP token but no Public API key is authoritative for the official MCP client. The catalog handler still resolved the Public API client before branching, so tag reads could fall back to the operator's environment instance. The same early lookup replaced the shared same-instance hint with a generic configuration error for project requests without an environment client.

Fixes https://github.com/czlonkowski/n8n-mcp/issues/1034

## Fix / Changes

- Refuse tag reads with the shared context hint before resolving any Public API client.
- Resolve the Public API client only inside the tags branch.
- Let project requests continue through the existing project resolver and its official-MCP fallback.
- Cover both residual context shapes with handler regressions.

## User impact

Per-request catalog calls no longer read tags from a different environment-configured n8n instance, and project failures consistently explain that `x-n8n-key` must accompany `x-n8n-url`.

## Verification

- New focused regressions failed on current upstream `main`: the environment API getter was called for tags, and projects returned the generic setup error.
- `npx vitest run tests/unit/mcp/handlers-official-tools.test.ts --reporter=dot` — 39 passed.
- Relevant handler, exposure, and official-MCP integration selection — 66 passed, 2 environment-gated tests skipped.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- `npm run test:unit` executed the full unit set but did not exit on this Windows host after emitting all files; unrelated existing failures were confined to unavailable SQLite FTS5, POSIX shell/path assumptions, and Windows symlink privileges.

Conceived by Romuald Członkowski - https://aiadvisors.pl/en