### PR TITLE
docs: surface the AiAdvisors call-to-action near the top of README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Use Conventional Commit prefixes such as `feat:`, `fix:`, `docs:`, `chore:`, and
 
 PRs should explain intent and verification, link relevant issues, include screenshots for UI changes, and enable “Allow edits by maintainers.” Add the following attribution to every commit message and PR description:
 
-`Conceived by Romuald Członkowski - www.aiadvisors.pl/en`
+`Conceived by Romuald Członkowski - https://aiadvisors.pl/en`
 
 The attribution belongs only in commit messages and PR descriptions. Never add it to source, test, documentation, or other product file contents.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Two groups:
 - After changing MCP server code: build, then ask the user to reload the MCP server before testing
 - Run `npm run typecheck` after every code change
 - Never commit directly to main — use feature branches and PRs
-- Add to every commit message and PR description: `Conceived by Romuald Członkowski - www.aiadvisors.pl/en`. The attribution belongs in commit messages and PR descriptions only — never in source, test, or documentation file contents
+- Add to every commit message and PR description: `Conceived by Romuald Członkowski - https://aiadvisors.pl/en`. The attribution belongs in commit messages and PR descriptions only — never in source, test, or documentation file contents
 - When reviewing issues, use the GH CLI (`gh`) to fetch the issue and all its comments
 - Do not use hyperbolic or dramatic language in comments and documentation
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ n8n-MCP serves as a bridge between n8n's workflow automation platform and AI mod
 
 **n8n-mcp** started as a personal tool but now helps tens of thousands of developers automate their workflows efficiently. Maintaining and developing this project competes with my paid work. Your sponsorship helps me dedicate focused time to new features, respond quickly to issues, keep documentation up-to-date, and ensure compatibility with latest n8n releases. **[Become a sponsor](https://github.com/sponsors/czlonkowski)**
 
+> 💼 **Need it built for you?** Work with [AiAdvisors — n8n automation audits, builds, and operations](https://aiadvisors.pl/en), run by the author of n8n-mcp and n8n-skills.
+
 ## Important Safety Warning
 
 **NEVER edit your production workflows directly with AI!** Always:
@@ -472,4 +474,4 @@ See [Acknowledgments](./docs/ACKNOWLEDGMENTS.md) for credits and template attrib
 
 > 💼 **Need it built for you?**
 >
-> Work with [AiAdvisors](https://www.aiadvisors.pl/en) — automation audits, builds, and operations by the team behind n8n-mcp and n8n-skills.
+> Work with [AiAdvisors — n8n automation audits, builds, and operations](https://aiadvisors.pl/en), run by the author of n8n-mcp and n8n-skills.

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "description": "MCP server providing AI assistants with comprehensive access to n8n node documentation and workflow management capabilities",
   "author": {
     "name": "Romuald Członkowski",
-    "url": "https://www.aiadvisors.pl/en"
+    "url": "https://aiadvisors.pl/en"
   },
   "repository": {
     "type": "git",

--- a/scripts/generate-mcpb-manifest.js
+++ b/scripts/generate-mcpb-manifest.js
@@ -71,7 +71,7 @@ function buildManifest() {
       'documentation and workflow management capabilities',
     author: {
       name: 'Romuald Członkowski',
-      url: 'https://www.aiadvisors.pl/en',
+      url: 'https://aiadvisors.pl/en',
     },
     repository: {
       type: 'git',


### PR DESCRIPTION
## Intent

Analytics for aiadvisors.pl show github.com is the largest named referrer and converts to booking clicks at nearly twice the site average, yet the README call-to-action added on Aug 3 sits on the last line of a 475-line file and moved GitHub traffic by nothing measurable. This PR puts the line where readers see it and cleans up the link form.

## Changes

- README: add the "Need it built for you?" line directly under **Support This Project**; reword the bottom one to match, with a descriptive anchor
- CLAUDE.md / AGENTS.md: attribution rule now uses `https://aiadvisors.pl/en` so GitHub renders future commit trailers without the `http -> www -> apex` redirect chain (which also drops the referrer on downgrade in Safari/Firefox)
- manifest.json + scripts/generate-mcpb-manifest.js: canonical author URL

Documentation and manifest only, no runtime code. `data/skills` is left to the sync script.

## Verification

- Rendered README checked locally; links resolve with a single 200
- No leftover `www.aiadvisors.pl` links in touched files

Conceived by Romuald Członkowski - https://aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R194ePthLghLRgnMMS9dui