### PR TITLE
fix: recognise the unknown-settings wording n8n 2.37 uses on create (v2.81.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.81.1] - 2026-09-03
+
+### Fixed
+
+- **Unknown-settings retry also recognises the wording n8n 2.37 uses on create.** n8n 2.37 validates `POST /workflows` with a different validator, which rejects an unknown settings key as `request/body/settings Unrecognized key(s) in object: 'key'` instead of AJV's `must NOT have additional properties`; `PUT` keeps the AJV wording. The retry added in 2.81.0 matched only the AJV text, so on 2.37 a create carrying such a key still failed with the 400. Both wordings are recognised now, and because the new one names the keys, the client drops exactly those in a single retry and remembers them, instead of probing candidates one at a time. The canvas-group fallback and the error enrichment for unnamed rejections accept the new wording as well.
+
 ## [2.81.0] - 2026-09-03
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.81.0",
+  "version": "2.81.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.81.0",
+      "version": "2.81.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.81.0",
+  "version": "2.81.1",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.81.0",
+  "version": "2.81.1",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -651,7 +651,10 @@ export class N8nApiClient {
 
     const steps = settingsRejectionLadder(body.settings);
     const dropped: string[] = [];
-    const certain: string[] = [];
+    // Keys n8n itself named are proven. A ladder guess is proven only if the write succeeded
+    // right after it and it dropped a single key; earlier guesses may have been innocent.
+    const namedByN8n: string[] = [];
+    let lastGuess: string[] = [];
     // Bound: a retry either consumes a ladder step or removes a named key, so both counts cap it.
     const settingsKeys = () => Object.keys((body.settings as object | undefined) ?? {});
     const maxSettingsRetries = steps.length + settingsKeys().length;
@@ -659,6 +662,7 @@ export class N8nApiClient {
       try {
         const result = await this.sendWorkflowWriteWithGroupFallback(body, send, options);
         if (dropped.length > 0) {
+          const certain = lastGuess.length === 1 ? [...namedByN8n, ...lastGuess] : namedByN8n;
           for (const key of certain) this.rejectedSettings.add(key);
           options.onWarning?.(settingsRejectedWarning(dropped));
         }
@@ -666,15 +670,23 @@ export class N8nApiClient {
       } catch (error) {
         const apiError = handleN8nApiError(error);
         if (!isUnknownSettingsPropertyError(apiError) || retries++ >= maxSettingsRetries) throw apiError;
-        // A wording that names the keys settles the matter in one retry and each key is
-        // certain; the AJV wording does not, so the ladder guesses one step at a time and
-        // only a step that dropped a single key is certain. Only keys actually in the payload
-        // count; a name n8n reports that is not there would be a retry without progress.
+        // A wording that names the keys settles the matter in one retry; the AJV wording does
+        // not, so the ladder guesses one step at a time. Only keys still in the payload count:
+        // a name n8n reports that is not there, or a ladder step already emptied by a named
+        // retry, would be a retry without progress.
         const present = new Set(settingsKeys());
         const named = unknownSettingsKeysNamedBy(apiError).filter(key => present.has(key));
-        const drop = named.length > 0 ? named : step < steps.length ? steps[step++] : [];
+        let drop = named;
+        while (drop.length === 0 && step < steps.length) {
+          drop = steps[step++].filter(key => present.has(key));
+        }
         if (drop.length === 0) throw apiError;
-        if (named.length > 0 || drop.length === 1) certain.push(...drop);
+        if (named.length > 0) {
+          namedByN8n.push(...named);
+          lastGuess = [];
+        } else {
+          lastGuess = drop;
+        }
         body = withoutSettings(body, drop);
         dropped.push(...drop);
       }

--- a/src/services/n8n-api-client.ts
+++ b/src/services/n8n-api-client.ts
@@ -46,7 +46,7 @@ import {
   ProjectSummary,
   Project,
 } from '../types/n8n-api';
-import { enrichUnknownPropertyError, handleN8nApiError, isUnknownSettingsPropertyError, logN8nError, N8nApiError, N8nValidationError } from '../utils/n8n-errors';
+import { enrichUnknownPropertyError, handleN8nApiError, isUnknownSettingsPropertyError, logN8nError, N8nApiError, N8nValidationError, unknownSettingsKeysNamedBy } from '../utils/n8n-errors';
 import { encodeApiPathSegment } from '../utils/validation-schemas';
 import { cleanWorkflowForCreate, cleanWorkflowForUpdate } from './n8n-validation';
 import {
@@ -629,12 +629,13 @@ export class N8nApiClient {
    * trails n8n, and a property dropped up front is dropped silently. The cost of forwarding is
    * a 400 whose AJV message names the path but not the key, so this ladder finds the key the
    * only way it can, by retrying without candidates in the order settingsRejectionLadder gives.
-   * Every drop is reported through onWarning. A key dropped on its own is remembered for this
-   * client's lifetime, so a session that has learnt the instance's schema stops paying the probe;
-   * the first step drops every unknown key together, and remembering all of them would keep
-   * stripping a key the instance accepts, so that step is probed again on the next write. The
-   * ladder adds at most steps.length writes, each of which may run the group ladder in full; a
-   * write that still fails after it surfaces the last rejection.
+   * n8n answers in one of two wordings. The zod one (create on n8n 2.37+) names the keys, so
+   * they are dropped in a single retry and remembered. The AJV one does not, so the ladder
+   * guesses one step at a time; only a step that dropped a single key is remembered, since the
+   * first step drops every unknown key together and remembering all of them would keep stripping
+   * a key the instance accepts. Every drop is reported through onWarning. The loop adds at most
+   * steps.length plus one write per settings key, each of which may run the group ladder in
+   * full; a write that still fails after that surfaces the last rejection.
    */
   private async sendWorkflowWriteWithSettingsFallback(
     payload: Record<string, unknown>,
@@ -650,21 +651,32 @@ export class N8nApiClient {
 
     const steps = settingsRejectionLadder(body.settings);
     const dropped: string[] = [];
-    for (let step = 0; ; step++) {
+    const certain: string[] = [];
+    // Bound: a retry either consumes a ladder step or removes a named key, so both counts cap it.
+    const settingsKeys = () => Object.keys((body.settings as object | undefined) ?? {});
+    const maxSettingsRetries = steps.length + settingsKeys().length;
+    for (let step = 0, retries = 0; ; ) {
       try {
         const result = await this.sendWorkflowWriteWithGroupFallback(body, send, options);
         if (dropped.length > 0) {
-          for (const single of steps.slice(0, step).filter(keys => keys.length === 1)) {
-            this.rejectedSettings.add(single[0]);
-          }
+          for (const key of certain) this.rejectedSettings.add(key);
           options.onWarning?.(settingsRejectedWarning(dropped));
         }
         return result;
       } catch (error) {
         const apiError = handleN8nApiError(error);
-        if (!isUnknownSettingsPropertyError(apiError) || step >= steps.length) throw apiError;
-        body = withoutSettings(body, steps[step]);
-        dropped.push(...steps[step]);
+        if (!isUnknownSettingsPropertyError(apiError) || retries++ >= maxSettingsRetries) throw apiError;
+        // A wording that names the keys settles the matter in one retry and each key is
+        // certain; the AJV wording does not, so the ladder guesses one step at a time and
+        // only a step that dropped a single key is certain. Only keys actually in the payload
+        // count; a name n8n reports that is not there would be a retry without progress.
+        const present = new Set(settingsKeys());
+        const named = unknownSettingsKeysNamedBy(apiError).filter(key => present.has(key));
+        const drop = named.length > 0 ? named : step < steps.length ? steps[step++] : [];
+        if (drop.length === 0) throw apiError;
+        if (named.length > 0 || drop.length === 1) certain.push(...drop);
+        body = withoutSettings(body, drop);
+        dropped.push(...drop);
       }
     }
   }

--- a/src/services/node-groups.ts
+++ b/src/services/node-groups.ts
@@ -412,7 +412,9 @@ export function classifyGroupError(error: unknown): GroupErrorClassification {
   // pathless one, this returns `schema-field` as a CANDIDATE: the caller retries without the field
   // and only records the instance as lacking it if that retry actually succeeds. That keeps an
   // unrelated unknown property from disabling groups for an instance that supports them.
-  if (/must NOT have additional propert/i.test(haystack)) {
+  // n8n 2.37+ validates create with zod, whose wording is `Unrecognized key(s) in object: 'x'`;
+  // the path prefix is the same, so both wordings classify alike.
+  if (/must NOT have additional propert|Unrecognized key\(s\) in object/i.test(haystack)) {
     const nested = /request\/body\/([A-Za-z0-9_]+)/.exec(haystack);
     if (nested) {
       // A path INTO nodeGroups means a group object carries a key this n8n has no schema for —

--- a/src/utils/n8n-errors.ts
+++ b/src/utils/n8n-errors.ts
@@ -223,22 +223,21 @@ export function enrichUnknownPropertyError(
         : undefined;
 
   const parts: string[] = [];
-  if (settingsLevel) {
+  if (named) {
+    // Nothing to inventory or report: n8n said which key it refused.
+    parts.push(`n8n identified the rejected property: ${named}.`);
+  } else if (settingsLevel) {
     const settings = sentBody.settings;
     const sentKeys =
       settings && typeof settings === 'object' && !Array.isArray(settings)
         ? Object.keys(settings)
         : [];
     parts.push(`Settings keys sent: ${sentKeys.join(', ') || '(none)'}.`);
-    if (named) {
-      parts.push(`n8n identified the rejected property: ${named}.`);
-    } else {
-      const unknown = sentKeys.filter(
-        key => !Object.prototype.hasOwnProperty.call(WORKFLOW_SETTINGS_PROPERTIES, key)
-      );
-      if (unknown.length > 0) {
-        parts.push(`Not in n8n-mcp's known settings table: ${unknown.join(', ')}.`);
-      }
+    const unknown = sentKeys.filter(
+      key => !Object.prototype.hasOwnProperty.call(WORKFLOW_SETTINGS_PROPERTIES, key)
+    );
+    if (unknown.length > 0) {
+      parts.push(`Not in n8n-mcp's known settings table: ${unknown.join(', ')}.`);
     }
     parts.push(
       'This usually means the instance stores a setting its Public API write schema rejects ' +
@@ -247,9 +246,6 @@ export function enrichUnknownPropertyError(
     );
   } else {
     parts.push(`Top-level keys sent: ${Object.keys(sentBody).join(', ') || '(none)'}.`);
-    if (named) {
-      parts.push(`n8n identified the rejected property: ${named}.`);
-    }
     parts.push(
       "One of these keys is not accepted by this instance's Public API write schema. " +
         'Please report the offending key at https://github.com/czlonkowski/n8n-mcp/issues.'

--- a/src/utils/n8n-errors.ts
+++ b/src/utils/n8n-errors.ts
@@ -141,7 +141,6 @@ function folderPlacementHint(error: N8nApiError): string {
   return ' Note: workflow folder placement (parentFolderId) requires n8n 2.32 or later - retry without parentFolderId, or upgrade the instance.';
 }
 
-/** AJV's rejection of an unknown key inside `settings`, which never names the key itself. */
 /**
  * n8n rejects an unknown settings key in one of two wordings, depending on the endpoint and
  * version: AJV's `request/body/settings must NOT have additional properties` (update, and
@@ -161,11 +160,6 @@ const parseUnrecognizedKeys = (haystack: string, path: string): string[] => {
 };
 
 /**
- * Whether n8n refused a workflow write because `settings` carried a property its Public API
- * schema does not know. Matches only the settings-level path; a top-level or nested rejection
- * (`body`, `body/nodes/0`, `body/nodeGroups/0`) is a different problem with a different fix.
- */
-/**
  * The settings keys an unknown-key rejection names, when the wording names them (zod).
  * Empty for the AJV wording, which leaves the caller to find the key by retrying.
  */
@@ -176,6 +170,11 @@ export function unknownSettingsKeysNamedBy(error: unknown): string[] {
   return parseUnrecognizedKeys(haystack, 'body/settings');
 }
 
+/**
+ * Whether n8n refused a workflow write because `settings` carried a property its Public API
+ * schema does not know, in either wording. Matches only the settings-level path; a top-level or
+ * nested rejection (`body`, `body/nodes/0`, `body/nodeGroups/0`) is a different problem.
+ */
 export function isUnknownSettingsPropertyError(error: unknown): boolean {
   const apiError = error as { statusCode?: number; message?: string; details?: unknown } | null;
   if (!apiError || apiError.statusCode !== 400) return false;

--- a/src/utils/n8n-errors.ts
+++ b/src/utils/n8n-errors.ts
@@ -142,13 +142,40 @@ function folderPlacementHint(error: N8nApiError): string {
 }
 
 /** AJV's rejection of an unknown key inside `settings`, which never names the key itself. */
-const SETTINGS_ADDITIONAL_PROPERTY = /body\/settings must NOT have additional propert/i;
+/**
+ * n8n rejects an unknown settings key in one of two wordings, depending on the endpoint and
+ * version: AJV's `request/body/settings must NOT have additional properties` (update, and
+ * create before n8n 2.37) which never names the key, and zod's
+ * `request/body/settings Unrecognized key(s) in object: 'a', 'b'` (create on n8n 2.37+),
+ * which does.
+ */
+const SETTINGS_ADDITIONAL_PROPERTY = /body\/settings (?:must NOT have additional propert|Unrecognized key\(s\) in object)/i;
+// Captures only the quoted list, at the given path; the same message is usually echoed inside
+// the details JSON, and a nodes-level rejection can sit in the same text as a settings-level one.
+const unrecognizedKeysAt = (path: string) =>
+  new RegExp(`${path} Unrecognized key\\(s\\) in object: ((?:'[^']*'(?:,\\s*)?)+)`, 'i');
+const parseUnrecognizedKeys = (haystack: string, path: string): string[] => {
+  const named = unrecognizedKeysAt(path).exec(haystack);
+  if (!named) return [];
+  return [...new Set(Array.from(named[1].matchAll(/'([^']+)'/g), match => match[1]))];
+};
 
 /**
  * Whether n8n refused a workflow write because `settings` carried a property its Public API
  * schema does not know. Matches only the settings-level path; a top-level or nested rejection
  * (`body`, `body/nodes/0`, `body/nodeGroups/0`) is a different problem with a different fix.
  */
+/**
+ * The settings keys an unknown-key rejection names, when the wording names them (zod).
+ * Empty for the AJV wording, which leaves the caller to find the key by retrying.
+ */
+export function unknownSettingsKeysNamedBy(error: unknown): string[] {
+  if (!isUnknownSettingsPropertyError(error)) return [];
+  const apiError = error as { message?: string; details?: unknown };
+  const haystack = `${apiError.message ?? ''} ${safeStringify(apiError.details)}`;
+  return parseUnrecognizedKeys(haystack, 'body/settings');
+}
+
 export function isUnknownSettingsPropertyError(error: unknown): boolean {
   const apiError = error as { statusCode?: number; message?: string; details?: unknown } | null;
   if (!apiError || apiError.statusCode !== 400) return false;
@@ -175,7 +202,8 @@ export function enrichUnknownPropertyError(
   const haystack = `${error.message} ${detailsStr}`;
 
   const settingsLevel = SETTINGS_ADDITIONAL_PROPERTY.test(haystack);
-  const bodyLevel = !settingsLevel && /body must NOT have additional propert/i.test(haystack);
+  const bodyLevel =
+    !settingsLevel && /body (?:must NOT have additional propert|Unrecognized key\(s\) in object)/i.test(haystack);
   if (!settingsLevel && !bodyLevel) return error;
 
   // Some n8n versions do name the property in the AJV error params — surface it when it is
@@ -185,10 +213,14 @@ export function enrichUnknownPropertyError(
     detailsStr.matchAll(/"additionalProperty"\s*:\s*"([^"]+)"/g),
     match => match[1]
   );
+  // The zod wording (n8n 2.37+ on create) names the keys in the message itself.
+  const zodNamed = parseUnrecognizedKeys(haystack, settingsLevel ? 'body/settings' : 'body');
   const named =
     namedMatches.length > 0 && namedMatches.every(name => name === namedMatches[0])
       ? namedMatches[0]
-      : undefined;
+      : zodNamed.length > 0
+        ? zodNamed.join(', ')
+        : undefined;
 
   const parts: string[] = [];
   if (settingsLevel) {

--- a/tests/unit/services/n8n-api-client.test.ts
+++ b/tests/unit/services/n8n-api-client.test.ts
@@ -750,6 +750,25 @@ describe('N8nApiClient', () => {
       expect(warnings.join(' ')).toContain('mysteryKey, timeSavedMode');
     });
 
+    it('remembers only what n8n named or the single guess the success followed', async () => {
+      // The AJV ladder first guesses mysteryKey (the only unknown key) and is still rejected;
+      // n8n then names redactionPolicy, and the write succeeds without it.
+      mockAxiosInstance.put
+        .mockRejectedValueOnce(badRequest('request/body/settings must NOT have additional properties'))
+        .mockRejectedValueOnce(badRequest("request/body/settings Unrecognized key(s) in object: 'redactionPolicy'"))
+        .mockResolvedValue({ data: { id: '123' } });
+      const settings = { executionOrder: 'v1', timeSavedMode: 'fixed', mysteryKey: 1, redactionPolicy: 'strict' };
+
+      await client.updateWorkflow('123', workflowWith(settings));
+      await client.updateWorkflow('123', workflowWith(settings));
+
+      // Only redactionPolicy is remembered: n8n named it. mysteryKey was a guess the success did
+      // not follow, so it is sent again rather than stripped on suspicion.
+      expect(mockAxiosInstance.put).toHaveBeenCalledTimes(4);
+      const secondWriteBody = mockAxiosInstance.put.mock.calls[3][1];
+      expect(secondWriteBody.settings).toEqual({ executionOrder: 'v1', timeSavedMode: 'fixed', mysteryKey: 1 });
+    });
+
     it('ignores a named key that is not in the payload and falls back to the ladder', async () => {
       mockAxiosInstance.post
         .mockRejectedValueOnce(badRequest("request/body/settings Unrecognized key(s) in object: 'notSent'"))

--- a/tests/unit/services/n8n-api-client.test.ts
+++ b/tests/unit/services/n8n-api-client.test.ts
@@ -732,6 +732,38 @@ describe('N8nApiClient', () => {
       expect(last.nodeGroups).toEqual([{ id: 'g1', name: 'G', nodeIds: ['a'] }]);
     });
 
+    it('drops exactly the keys n8n names when the rejection names them (n8n 2.37 create wording)', async () => {
+      mockAxiosInstance.post
+        .mockRejectedValueOnce(badRequest("request/body/settings Unrecognized key(s) in object: 'mysteryKey', 'timeSavedMode'"))
+        .mockResolvedValue({ data: { id: '123' } });
+      const warnings: string[] = [];
+      const settings = { executionOrder: 'v1', redactionPolicy: 'strict', timeSavedMode: 'fixed', mysteryKey: 1 };
+
+      await client.createWorkflow(workflowWith(settings), { onWarning: w => warnings.push(w) });
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: '124' } });
+      await client.createWorkflow(workflowWith(settings));
+
+      // One retry without both named keys, redactionPolicy untouched; both remembered as certain.
+      expect(mockAxiosInstance.post).toHaveBeenCalledTimes(3);
+      expect(mockAxiosInstance.post.mock.calls[1][1].settings).toEqual({ executionOrder: 'v1', redactionPolicy: 'strict' });
+      expect(mockAxiosInstance.post.mock.calls[2][1].settings).toEqual({ executionOrder: 'v1', redactionPolicy: 'strict' });
+      expect(warnings.join(' ')).toContain('mysteryKey, timeSavedMode');
+    });
+
+    it('ignores a named key that is not in the payload and falls back to the ladder', async () => {
+      mockAxiosInstance.post
+        .mockRejectedValueOnce(badRequest("request/body/settings Unrecognized key(s) in object: 'notSent'"))
+        .mockResolvedValue({ data: { id: '123' } });
+      const warnings: string[] = [];
+
+      await client.createWorkflow(workflowWith({ executionOrder: 'v1', mysteryKey: 1 }), { onWarning: w => warnings.push(w) });
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledTimes(2);
+      expect(mockAxiosInstance.post.mock.calls[1][1].settings).toEqual({ executionOrder: 'v1' });
+      expect(warnings.join(' ')).toContain('mysteryKey');
+      expect(warnings.join(' ')).not.toContain('notSent');
+    });
+
     it('applies to create as well as update', async () => {
       mockAxiosInstance.post
         .mockRejectedValueOnce(settingsRejected())

--- a/tests/unit/services/node-groups.test.ts
+++ b/tests/unit/services/node-groups.test.ts
@@ -396,3 +396,18 @@ describe('node-groups', () => {
     });
   });
 });
+
+describe('classifyGroupError with the zod wording (n8n 2.37 create)', () => {
+  const err = (message: string) => ({ statusCode: 400, message });
+
+  it('treats an unnamed top-level rejection as the field candidate', async () => {
+    const { classifyGroupError } = await import('../../../src/services/node-groups');
+    expect(classifyGroupError(err("request/body Unrecognized key(s) in object: 'nodeGroups'")).kind).toBe('schema-field');
+  });
+
+  it('treats a rejection inside a group as the description case, and other paths as unrelated', async () => {
+    const { classifyGroupError } = await import('../../../src/services/node-groups');
+    expect(classifyGroupError(err("request/body/nodeGroups/0 Unrecognized key(s) in object: 'description'")).kind).toBe('schema-description');
+    expect(classifyGroupError(err("request/body/settings Unrecognized key(s) in object: 'x'")).kind).toBe('unrelated');
+  });
+});

--- a/tests/unit/utils/n8n-errors.test.ts
+++ b/tests/unit/utils/n8n-errors.test.ts
@@ -431,3 +431,49 @@ describe('Error message integration', () => {
     expect(noExecutionMessage).toContain("mode='preview'");
   });
 });
+
+describe('unknownSettingsKeysNamedBy', () => {
+  const load = () => import('../../../src/utils/n8n-errors');
+
+  it('parses the keys from the zod wording n8n 2.37 uses on create', async () => {
+    const { unknownSettingsKeysNamedBy, isUnknownSettingsPropertyError } = await load();
+    const error = { statusCode: 400, message: "request/body/settings Unrecognized key(s) in object: 'a', 'b_c'" };
+
+    expect(isUnknownSettingsPropertyError(error)).toBe(true);
+    expect(unknownSettingsKeysNamedBy(error)).toEqual(['a', 'b_c']);
+  });
+
+  it('reads only the settings-level list when a nodes-level rejection sits in the same text', async () => {
+    const { unknownSettingsKeysNamedBy } = await load();
+    const error = {
+      statusCode: 400,
+      message: "request/body/nodes/0 Unrecognized key(s) in object: 'foo', request/body/settings Unrecognized key(s) in object: 'bar'",
+    };
+
+    expect(unknownSettingsKeysNamedBy(error)).toEqual(['bar']);
+  });
+
+  it('names the key in the enriched top-level message instead of asking for a report', async () => {
+    const { enrichUnknownPropertyError, N8nApiError } = await load();
+    const error = new N8nApiError("request/body Unrecognized key(s) in object: 'foo'", 400);
+
+    const enriched = enrichUnknownPropertyError(error, { name: 'x', foo: 1 });
+
+    expect(enriched.message).toContain('n8n identified the rejected property: foo');
+  });
+
+  it('does not double the keys when the details echo the same message', async () => {
+    const { unknownSettingsKeysNamedBy } = await load();
+    const message = "request/body/settings Unrecognized key(s) in object: 'a', 'b'";
+
+    expect(unknownSettingsKeysNamedBy({ statusCode: 400, message, details: { message } })).toEqual(['a', 'b']);
+  });
+
+  it('names nothing for the AJV wording, and rejects other paths and statuses', async () => {
+    const { unknownSettingsKeysNamedBy, isUnknownSettingsPropertyError } = await load();
+
+    expect(unknownSettingsKeysNamedBy({ statusCode: 400, message: 'request/body/settings must NOT have additional properties' })).toEqual([]);
+    expect(isUnknownSettingsPropertyError({ statusCode: 400, message: "request/body/nodes/0 Unrecognized key(s) in object: 'foo'" })).toBe(false);
+    expect(isUnknownSettingsPropertyError({ statusCode: 500, message: "request/body/settings Unrecognized key(s) in object: 'a'" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #1059. Live testing v2.81.0 against n8n 2.37.7 showed that `POST /workflows` now validates with zod and rejects an unknown settings key as `request/body/settings Unrecognized key(s) in object: 'key'`, while `PUT` keeps AJV's `request/body/settings must NOT have additional properties`. The retry ladder recognised only the AJV wording, so on 2.37 a create carrying such a key still failed with the 400 (update worked).

## What changed

- `src/utils/n8n-errors.ts`: `isUnknownSettingsPropertyError` accepts both wordings; new `unknownSettingsKeysNamedBy` parses the quoted key list, anchored to the `body/settings` path and deduplicated (the message is usually echoed in the error details); `enrichUnknownPropertyError` names the key for a top-level zod rejection instead of asking the user to report it.
- `src/services/n8n-api-client.ts`: when the rejection names keys, the client drops exactly the ones present in the payload in a single retry and remembers them; the AJV ladder is unchanged; the loop is bounded by ladder steps plus settings keys.
- `src/services/node-groups.ts`: `classifyGroupError` accepts the new wording; the nested-path extraction is the same.
- Tests for both wordings, the details echo, a nodes-level rejection sitting in the same text, a named key absent from the payload, and the group classifier.
- Version 2.81.1, changelog entry.

Verified live on n8n 2.37.7 through the built server: a create with two unknown settings keys, stray node properties and `timeSavedMode` succeeds with one warning naming the two keys; `timeSavedMode` is kept; a partial update carrying an unknown key succeeds with its warning.

## Review

Opus code-reviewer (findings adopted: path-anchored capture, payload intersection, wider retry bound, enrichment naming, docblock) and Codex.

Conceived by Romuald Członkowski - https://aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)
