### PR TITLE
fix(telemetry): stop replaying timed-out mutation batches from the dead letter queue (v2.82.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.82.1] - 2026-09-03
+
+### Fixed
+
+- **A workflow mutation whose telemetry insert timed out is no longer replayed from the dead letter queue.** The client-side timeout is a race, not an abort, so the insert usually committed after it fired; the batch was then parked and re-sent on every later flush, which wrote the same rows once a minute for as long as the process lived. In the 24 hours before this fix, 15 installations produced 84% of all `workflow_mutations` rows this way. A failed mutation batch is now counted as dropped and the remaining batches still get their single attempt; events and workflow snapshots keep the retry path. The telemetry database drops a second row for the same mutation `session_id` as well, which covers processes still running older versions.
+
 ## [2.82.0] - 2026-09-03
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-mcp",
-  "version": "2.82.0",
+  "version": "2.82.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-mcp",
-      "version": "2.82.0",
+      "version": "2.82.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp",
-  "version": "2.82.0",
+  "version": "2.82.1",
   "description": "Integration between n8n workflow automation and Model Context Protocol (MCP)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.runtime.json
+++ b/package.runtime.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-mcp-runtime",
-  "version": "2.82.0",
+  "version": "2.82.1",
   "description": "n8n MCP Server Runtime Dependencies Only",
   "private": true,
   "dependencies": {

--- a/src/telemetry/batch-processor.ts
+++ b/src/telemetry/batch-processor.ts
@@ -52,7 +52,7 @@ export class TelemetryBatchProcessor {
     rateLimitHits: 0
   };
   private flushTimes: number[] = [];
-  private deadLetterQueue: (TelemetryEvent | WorkflowTelemetry | WorkflowMutationRecord)[] = [];
+  private deadLetterQueue: (TelemetryEvent | WorkflowTelemetry)[] = [];
   private readonly maxDeadLetterSize = 100;
   // Track event listeners for proper cleanup to prevent memory leaks
   private eventListeners: {
@@ -335,6 +335,7 @@ export class TelemetryBatchProcessor {
     try {
       // Batch mutations
       const batches = this.createBatches(mutations, TELEMETRY_CONFIG.MAX_BATCH_SIZE);
+      let allBatchesSent = true;
 
       for (let batchIndex = 0; batchIndex < batches.length; batchIndex++) {
         const batch = batches[batchIndex];
@@ -366,14 +367,19 @@ export class TelemetryBatchProcessor {
           this.metrics.eventsTracked += batch.length;
           this.metrics.batchesSent++;
         } else {
-          const unsent = this.addUnsentBatchesToDeadLetterQueue(batches, batchIndex);
-          this.metrics.eventsFailed += unsent.itemCount;
-          this.metrics.batchesFailed += unsent.batchCount;
-          return false;
+          // A mutation batch that failed here is dropped, never parked in the
+          // dead letter queue. The timeout in executeWithTimeout is a race, so
+          // the insert usually commits after it fires; replaying the batch on
+          // every later flush wrote the same rows once a minute for days. The
+          // remaining batches are independent and still get their attempt.
+          this.metrics.eventsFailed += batch.length;
+          this.metrics.eventsDropped += batch.length;
+          this.metrics.batchesFailed++;
+          allBatchesSent = false;
         }
       }
 
-      return true;
+      return allBatchesSent;
     } catch (error) {
       logger.error('Failed to flush mutations with details:', {
         errorMsg: error instanceof Error ? error.message : String(error),
@@ -455,7 +461,7 @@ export class TelemetryBatchProcessor {
    * Preserve the failed batch and every later batch that was not attempted.
    */
   private addUnsentBatchesToDeadLetterQueue<
-    T extends TelemetryEvent | WorkflowTelemetry | WorkflowMutationRecord
+    T extends TelemetryEvent | WorkflowTelemetry
   >(batches: T[][], failedBatchIndex: number): { itemCount: number; batchCount: number } {
     const unsentBatches = batches.slice(failedBatchIndex);
     const unsentItems = unsentBatches.flat();
@@ -470,7 +476,7 @@ export class TelemetryBatchProcessor {
   /**
    * Add failed items to dead letter queue
    */
-  private addToDeadLetterQueue(items: (TelemetryEvent | WorkflowTelemetry | WorkflowMutationRecord)[]): void {
+  private addToDeadLetterQueue(items: (TelemetryEvent | WorkflowTelemetry)[]): void {
     for (const item of items) {
       this.deadLetterQueue.push(item);
 
@@ -496,13 +502,11 @@ export class TelemetryBatchProcessor {
 
     const events: TelemetryEvent[] = [];
     const workflows: WorkflowTelemetry[] = [];
-    const mutations: WorkflowMutationRecord[] = [];
 
-    // Separate events, workflows, and mutations
+    // Separate events and workflows. Mutations are never parked here: a
+    // replayed mutation duplicates a row that most likely already exists.
     for (const item of this.deadLetterQueue) {
-      if ('workflowHashBefore' in item) {
-        mutations.push(item as WorkflowMutationRecord);
-      } else if ('workflow_hash' in item) {
+      if ('workflow_hash' in item) {
         workflows.push(item as WorkflowTelemetry);
       } else {
         events.push(item as TelemetryEvent);
@@ -518,9 +522,6 @@ export class TelemetryBatchProcessor {
     }
     if (workflows.length > 0) {
       await this.flushWorkflows(workflows);
-    }
-    if (mutations.length > 0) {
-      await this.flushMutations(mutations);
     }
   }
 

--- a/tests/unit/telemetry/telemetry-processing.test.ts
+++ b/tests/unit/telemetry/telemetry-processing.test.ts
@@ -370,16 +370,42 @@ describe('TelemetryBatchProcessor', () => {
       );
     });
 
-    it('should retain every unattempted mutation batch after a failure', async () => {
+    it('should drop a failed mutation batch, send the rest, and never retry it', async () => {
       const mutations = Array.from({ length: 60 }, (_, index) =>
         createMutationRecord(index)
       );
+      const insert = vi.fn()
+        .mockResolvedValueOnce(createMockSupabaseResponse(new Error('First batch timed out')))
+        .mockResolvedValue(createMockSupabaseResponse());
+      vi.mocked(mockSupabase.from).mockImplementation((requestedTable) => ({
+        insert: requestedTable === 'workflow_mutations'
+          ? insert
+          : vi.fn().mockResolvedValue(createMockSupabaseResponse()),
+        url: { href: '' },
+        headers: {},
+        select: vi.fn(),
+        upsert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn()
+      } as any));
 
-      await expectAllUnsentBatchesRetried(
-        'workflow_mutations',
-        mutations.length,
-        () => batchProcessor.flush(undefined, undefined, mutations)
-      );
+      await batchProcessor.flush(undefined, undefined, mutations);
+
+      // Both batches were attempted once: the second batch is independent of the first.
+      expect(insert).toHaveBeenCalledTimes(2);
+      expect(insert.mock.calls[1][0]).toHaveLength(10);
+      expect(batchProcessor.getMetrics()).toMatchObject({
+        eventsTracked: 10,
+        eventsFailed: 50,
+        eventsDropped: 50,
+        batchesSent: 1,
+        batchesFailed: 1,
+        deadLetterQueueSize: 0,
+      });
+
+      // A later healthy flush must not replay the failed batch.
+      await batchProcessor.flush([]);
+      expect(insert).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -569,7 +595,7 @@ describe('TelemetryBatchProcessor', () => {
       expect(metrics.eventsDropped).toBe(50);
     });
 
-    it('should retry failed workflow mutations through the mutation table', async () => {
+    it('should not park a failed workflow mutation in the dead letter queue', async () => {
       const errorResponse = createMockSupabaseResponse(new Error('Temporary mutation error'));
       const mutationInsert = vi.fn()
         .mockResolvedValueOnce(errorResponse)
@@ -612,14 +638,19 @@ describe('TelemetryBatchProcessor', () => {
       };
 
       await batchProcessor.flush(undefined, undefined, [mutation]);
-      expect(batchProcessor.getMetrics().deadLetterQueueSize).toBe(1);
+      expect(batchProcessor.getMetrics()).toMatchObject({
+        eventsFailed: 1,
+        eventsDropped: 1,
+        batchesFailed: 1,
+        deadLetterQueueSize: 0,
+      });
 
+      // The insert may have committed despite the reported failure, so a
+      // replay would duplicate the row. Nothing is sent again.
       await batchProcessor.flush([]);
 
-      expect(mutationInsert).toHaveBeenCalledTimes(2);
+      expect(mutationInsert).toHaveBeenCalledTimes(1);
       expect(eventInsert).not.toHaveBeenCalled();
-      expect(mockSupabase.from).toHaveBeenNthCalledWith(1, 'workflow_mutations');
-      expect(mockSupabase.from).toHaveBeenNthCalledWith(2, 'workflow_mutations');
       expect(mutationInsert).toHaveBeenLastCalledWith([
         expect.objectContaining({
           user_id: 'user1',
@@ -627,7 +658,6 @@ describe('TelemetryBatchProcessor', () => {
           workflow_hash_after: 'hash2'
         })
       ]);
-      expect(batchProcessor.getMetrics().deadLetterQueueSize).toBe(0);
     });
 
     it('should handle mixed events and workflows in dead letter queue', async () => {


### PR DESCRIPTION
## Summary

A workflow mutation whose telemetry insert timed out was parked in the dead letter queue and re-sent on every later flush. The client-side timeout is a `Promise.race`, not an abort, so the insert had usually committed: the replay wrote the same rows once a minute for as long as the process lived. In the 24 hours to 2026-09-03 12:55 UTC, 15 installations produced 123,728 of 148,108 `workflow_mutations` rows from 475 real mutations.

## Changes

- `flushMutations` counts a failed batch as failed and dropped and moves on to the next batch instead of parking the failed batch plus every unattempted one. Events and workflow snapshots keep the dead-letter retry path.
- `processDeadLetterQueue` no longer has a mutation branch; the queue's type excludes `WorkflowMutationRecord`.
- Tests: the two cases that asserted a mutation retry now assert the opposite, and that later batches of the same flush are still attempted.
- Version 2.82.1, changelog entry.


## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run tests/unit/telemetry/` (315 passed, 2 skipped)
- [ ] CI

Conceived by Romuald Członkowski - www.aiadvisors.pl/en

🤖 Generated with [Claude Code](https://claude.com/claude-code)

