### PR TITLE
fix: do not invent Unknown error on successful executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`n8n_executions` `mode=error` no longer invents "Unknown error" on a successful run** ([#1065](https://github.com/czlonkowski/n8n-mcp/issues/1065)). When the execution has no `resultData.error` and no node-level error, error mode now reports `success: true` with a "nothing to diagnose" note instead of blaming the last node.
+
 ## [2.82.1] - 2026-09-03
 
 ### Fixed

--- a/src/services/error-execution-processor.ts
+++ b/src/services/error-execution-processor.ts
@@ -91,6 +91,31 @@ export function processErrorExecution(
   const runData = resultData?.runData as Record<string, any> || {};
   const lastNode = resultData?.lastNodeExecuted;
 
+  if (!hasDiagnosableError(error, runData)) {
+    const executionPath = includeExecutionPath
+      ? buildObservedExecutionPath(runData)
+      : undefined;
+    return {
+      success: true,
+      primaryError: {
+        message: 'No error found in this execution',
+        errorType: 'None',
+        nodeName: lastNode || '',
+        nodeType: '',
+      },
+      executionPath,
+      suggestions: [
+        {
+          type: 'investigate',
+          title: 'Nothing to diagnose',
+          description:
+            'This execution has no error payload and no node-level error. Use summary or filtered mode to inspect outputs, or pick an execution whose status is error.',
+          confidence: 'high',
+        },
+      ],
+    };
+  }
+
   // 1. Extract primary error info
   const primaryError = extractPrimaryError(error, lastNode, runData, includeStackTrace);
 
@@ -123,6 +148,48 @@ export function processErrorExecution(
     additionalErrors: additionalErrors.length > 0 ? additionalErrors : undefined,
     suggestions: suggestions.length > 0 ? suggestions : undefined
   };
+}
+
+/**
+ * True when there is a real error payload or a node-level error.
+ * A successful execution with only lastNodeExecuted must not invent one.
+ */
+function hasDiagnosableError(
+  error: Record<string, unknown> | undefined,
+  runData: Record<string, any>
+): boolean {
+  if (error && (error.message || error.node || error.stack || error.name)) {
+    return true;
+  }
+  for (const data of Object.values(runData)) {
+    if (getRunError(data)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Path of nodes that actually ran, with their real status.
+ * Does not mark the last node as failed.
+ */
+function buildObservedExecutionPath(
+  runData: Record<string, any>
+): ErrorAnalysis['executionPath'] {
+  const nodesByTime = Object.entries(runData)
+    .map(([name, data]) => ({
+      name,
+      data: data as any[],
+      startTime: latestStartTime(data),
+    }))
+    .sort((a, b) => a.startTime - b.startTime);
+
+  return nodesByTime.map(({ name, data }) => ({
+    nodeName: name,
+    status: getRunError(data) ? 'error' : 'success',
+    itemCount: countRunItems(data),
+    executionTime: totalExecutionTime(data),
+  }));
 }
 
 /**

--- a/src/types/n8n-api.ts
+++ b/src/types/n8n-api.ts
@@ -619,6 +619,12 @@ export interface FilteredNodeData {
 
 // Error Mode Types
 export interface ErrorAnalysis {
+  /**
+   * True when error mode was requested but the execution has no error to
+   * diagnose (status success, no resultData.error, no node-level error).
+   */
+  success?: boolean;
+
   // Primary error information
   primaryError: {
     message: string;

--- a/tests/unit/services/error-execution-processor.test.ts
+++ b/tests/unit/services/error-execution-processor.test.ts
@@ -176,6 +176,28 @@ function createMockWorkflow(options?: {
  * Core Functionality Tests
  */
 describe('ErrorExecutionProcessor - Core Functionality', () => {
+  it('should not invent Unknown error on a successful execution (#1065)', () => {
+    const execution = createMockExecution({
+      errorNode: 'Last Node',
+      hasExecutionError: false,
+      runData: {
+        Trigger: createSuccessfulNodeData(1),
+        'Process Data': createSuccessfulNodeData(5),
+        'Last Node': createSuccessfulNodeData(2),
+      },
+    });
+    execution.status = ExecutionStatus.SUCCESS;
+
+    const result = processErrorExecution(execution, { includeExecutionPath: true });
+
+    expect(result.success).toBe(true);
+    expect(result.primaryError.message).toBe('No error found in this execution');
+    expect(result.primaryError.errorType).toBe('None');
+    expect(result.primaryError.nodeName).toBe('Last Node');
+    expect(result.executionPath?.every(step => step.status !== 'error')).toBe(true);
+    expect(result.suggestions?.[0].title).toBe('Nothing to diagnose');
+  });
+
   it('should extract primary error information', () => {
     const execution = createMockExecution({
       errorNode: 'HTTP Request',


### PR DESCRIPTION
## Bug

`n8n_executions` with `mode=error` on an execution whose top-level status is success still built an error analysis. `extractPrimaryError` fell back to the last node and the string `Unknown error`, and `buildExecutionPath` marked that node as failed. Maintainers hit this live on n8n 2.37.7 (issue #1065).

## Fix

If there is no `resultData.error` and no node-level error, error mode now returns `success: true`, a `None` primary error that says there is nothing to diagnose, and an execution path that keeps real node statuses.

## Tests

Unit test covers a successful three-node execution: no invented error, no error status on the path, `Nothing to diagnose` suggestion.

Closes #1065