### PR TITLE
README: context-cost badge (2,636 tokens, measured)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Tests](https://img.shields.io/badge/tests-6524%20passing-brightgreen.svg)](https://github.com/czlonkowski/n8n-mcp/actions)
 [![n8n version](https://img.shields.io/badge/n8n-2.37.2-orange.svg)](https://github.com/n8n-io/n8n)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io%2Fczlonkowski%2Fn8n--mcp-green.svg)](https://github.com/czlonkowski/n8n-mcp/pkgs/container/n8n-mcp)
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fn8n-mcp.json)](https://athakur3.github.io/mcp-context-cost/servers/n8n-mcp.html)
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/n8n-mcp?referralCode=n8n-mcp)
 
 A Model Context Protocol (MCP) server that provides AI assistants with comprehensive access to n8n node documentation, properties, and operations. Deploy in minutes to give Claude and other AI assistants deep knowledge about n8n's 2,691 workflow automation nodes (832 core + 1,859 community).


### PR DESCRIPTION
This adds one badge to the README: what n8n-mcp's tool schemas cost in context tokens — **2,636 tokens** across 7 tools (o200k_base over the canonical `tools/list` bytes), which is the "light" band, i.e. good news for your users.

Where it comes from: it is one of 106 MCP servers measured on a rotation in credential-free Docker. Every number is backed by the raw capture, its SHA-256 and the exact launch command; your page has the per-tool breakdown and the history line: https://athakur3.github.io/mcp-context-cost/servers/n8n-mcp.html · method: https://github.com/athakur3/mcp-context-cost/blob/main/docs/METHODOLOGY.md

The badge JSON is regenerated each time the server is re-measured (about every six weeks), so it follows your releases, and it links to the measurement rather than to a landing page. Anyone can re-derive the number:

    npx -y mcp-context-cost verify --remote https://raw.githubusercontent.com/athakur3/mcp-context-cost/main/results/n8n-mcp/measurement.json

Since this repo runs CI on pull requests: the same measurement is a five-line Action that fails a PR adding more schema cost than you meant to ship, with the per-tool diff (https://github.com/athakur3/mcp-context-cost/blob/main/examples/server-author-ci.yml). Separate PR if wanted; this one is just the badge.

If you'd rather host the badge JSON yourselves, that's a one-line change here. Happy to adjust the placement or close this if it isn't wanted. Disclosure: I maintain mcp-context-cost.
