### PR TITLE
perf(database): shrink the node catalog by 28% with schema compression

### DIFF
--- a/MEMORY_N8N_UPDATE.md
+++ b/MEMORY_N8N_UPDATE.md
@@ -38,6 +38,13 @@ node dist/scripts/generate-community-docs.js --summary-only --skip-existing-summ
 # For vLLM with thinking models, the code auto-sends chat_template_kwargs: {enable_thinking: false}
 # Context length needed: 8K minimum (README truncated to 6000 chars, output max 2000 tokens)
 
+# Compact the final catalog after community/docs updates. This migrates any
+# legacy plain schemas, runs VACUUM, and fails if the database is >= 80 MiB.
+# npm run rebuild also performs this check automatically.
+# Migrating the bundled FTS5 catalog requires better-sqlite3; sql.js remains
+# supported for runtime reads and catalogs without FTS5.
+npm run db:compact
+
 # 7. Create feature branch
 git checkout -b update/n8n-X.X.X
 

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "test:docker:security": "./scripts/test-docker-config.sh security",
     "mine:patterns": "tsx src/scripts/mine-workflow-patterns.ts",
     "sanitize:templates": "node dist/scripts/sanitize-templates.js",
+    "db:compact": "node dist/scripts/compact-node-database.js",
     "db:rebuild": "node dist/scripts/rebuild-database.js",
     "db:init": "node -e \"new (require('./dist/services/sqlite-storage-service').SQLiteStorageService)(); console.log('Database initialized')\"",
     "docs:rebuild": "ts-node src/scripts/rebuild-database.ts",

--- a/scripts/audit-schema-coverage.ts
+++ b/scripts/audit-schema-coverage.ts
@@ -1,78 +1,48 @@
-/**
- * Database Schema Coverage Audit Script
- *
- * Audits the database to determine how many nodes have complete schema information
- * for resourceLocator mode validation. This helps assess the coverage of our
- * schema-driven validation approach.
- */
-
-import Database from 'better-sqlite3';
+/** Audit resourceLocator schema coverage in plain or compressed catalogs. */
 import path from 'path';
+import Database from 'better-sqlite3';
+import { CompressedJsonReader } from '../src/database/compressed-json';
 
-const dbPath = path.join(__dirname, '../data/nodes.db');
-const db = new Database(dbPath, { readonly: true });
+function auditSchemaCoverage() {
+  const db = new Database(path.join(__dirname, '../data/nodes.db'), { readonly: true });
+  try {
+    const reader = new CompressedJsonReader();
+    const rows = db.prepare('SELECT node_type, display_name, properties_schema FROM nodes').all() as Array<{
+      node_type: string; display_name: string; properties_schema: string;
+    }>;
+    // SQL LIKE cannot inspect a compressed schema. Use the shared decoder
+    // so this read-only audit works before and after the catalog migration.
+    const resourceLocators = rows.map(row => ({
+      ...row,
+      schema: JSON.stringify(reader.parse(row.properties_schema)),
+    })).filter(row => row.schema.includes('resourceLocator'));
+    const withModes = resourceLocators.filter(row => row.schema.includes('modes'));
+    const withoutModes = resourceLocators.filter(row => !row.schema.includes('modes'));
+    const coverage = resourceLocators.length ? withModes.length / resourceLocators.length * 100 : 0;
 
-console.log('=== Schema Coverage Audit ===\n');
+    console.log('=== Schema Coverage Audit ===\n');
+    console.log(`Nodes with resourceLocator properties: ${resourceLocators.length}`);
+    console.log(`Nodes with modes defined: ${withModes.length}`);
+    console.log('\nSample nodes WITHOUT modes (showing 10):');
+    withoutModes.slice(0, 10).forEach(row => console.log(`  - ${row.display_name} (${row.node_type})`));
+    console.log(`\nSchema coverage: ${coverage.toFixed(1)}% of resourceLocator nodes have modes defined`);
+    console.log('\nSample nodes WITH modes (showing 5):');
+    withModes.slice(0, 5).forEach(row => console.log(`  - ${row.display_name} (${row.node_type})`));
+    console.log('\n=== Summary ===');
+    console.log(`Total nodes in database: ${rows.length}`);
+    console.log(`Nodes with resourceLocator: ${resourceLocators.length}`);
+    console.log(`Nodes with complete mode schemas: ${withModes.length}`);
+    console.log(`Nodes without mode schemas: ${withoutModes.length}`);
+    console.log(`\nImplication: Schema-driven validation will apply to ${withModes.length} nodes.`);
+    console.log(`For the remaining ${withoutModes.length} nodes, validation will be skipped (graceful degradation).`);
+  } finally {
+    db.close();
+  }
+}
 
-// Query 1: How many nodes have resourceLocator properties?
-const totalResourceLocator = db.prepare(`
-  SELECT COUNT(*) as count FROM nodes
-  WHERE properties_schema LIKE '%resourceLocator%'
-`).get() as { count: number };
-
-console.log(`Nodes with resourceLocator properties: ${totalResourceLocator.count}`);
-
-// Query 2: Of those, how many have modes defined?
-const withModes = db.prepare(`
-  SELECT COUNT(*) as count FROM nodes
-  WHERE properties_schema LIKE '%resourceLocator%'
-    AND properties_schema LIKE '%modes%'
-`).get() as { count: number };
-
-console.log(`Nodes with modes defined: ${withModes.count}`);
-
-// Query 3: Which nodes have resourceLocator but NO modes?
-const withoutModes = db.prepare(`
-  SELECT node_type, display_name
-  FROM nodes
-  WHERE properties_schema LIKE '%resourceLocator%'
-    AND properties_schema NOT LIKE '%modes%'
-  LIMIT 10
-`).all() as Array<{ node_type: string; display_name: string }>;
-
-console.log(`\nSample nodes WITHOUT modes (showing 10):`);
-withoutModes.forEach(node => {
-  console.log(`  - ${node.display_name} (${node.node_type})`);
-});
-
-// Calculate coverage percentage
-const coverage = totalResourceLocator.count > 0
-  ? (withModes.count / totalResourceLocator.count) * 100
-  : 0;
-
-console.log(`\nSchema coverage: ${coverage.toFixed(1)}% of resourceLocator nodes have modes defined`);
-
-// Query 4: Get some examples of nodes WITH modes for verification
-console.log('\nSample nodes WITH modes (showing 5):');
-const withModesExamples = db.prepare(`
-  SELECT node_type, display_name
-  FROM nodes
-  WHERE properties_schema LIKE '%resourceLocator%'
-    AND properties_schema LIKE '%modes%'
-  LIMIT 5
-`).all() as Array<{ node_type: string; display_name: string }>;
-
-withModesExamples.forEach(node => {
-  console.log(`  - ${node.display_name} (${node.node_type})`);
-});
-
-// Summary
-console.log('\n=== Summary ===');
-console.log(`Total nodes in database: ${db.prepare('SELECT COUNT(*) as count FROM nodes').get() as any as { count: number }.count}`);
-console.log(`Nodes with resourceLocator: ${totalResourceLocator.count}`);
-console.log(`Nodes with complete mode schemas: ${withModes.count}`);
-console.log(`Nodes without mode schemas: ${totalResourceLocator.count - withModes.count}`);
-console.log(`\nImplication: Schema-driven validation will apply to ${withModes.count} nodes.`);
-console.log(`For the remaining ${totalResourceLocator.count - withModes.count} nodes, validation will be skipped (graceful degradation).`);
-
-db.close();
+try {
+  auditSchemaCoverage();
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/scripts/benchmark-node-compression.js
+++ b/scripts/benchmark-node-compression.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Compare the four offline MCP tools against two built checkouts and their
+ * bundled catalogs. No live n8n service is used. Each sample group runs in a
+ * fresh process against a temporary database copy; alternate baseline/candidate
+ * order to reduce warm-up bias. The MCP response cache is cleared per call to
+ * exercise repository reads. Measure cold schema-cache misses separately from
+ * warm reads; SQLite pages and the JavaScript runtime are warm in both cases.
+ *
+ * node scripts/benchmark-node-compression.js /path/to/baseline /path/to/candidate
+ * Optional: BENCH_ROUNDS=5 BENCH_ITERATIONS=100 (per tool, per round).
+ */
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const { mkdtempSync, copyFileSync, rmSync, statSync } = require('node:fs');
+const { tmpdir, cpus } = require('node:os');
+const path = require('node:path');
+const { performance } = require('node:perf_hooks');
+const { createHash } = require('node:crypto');
+const { gunzipSync } = require('node:zlib');
+
+function corpus() {
+  const nodeTypes = ['httpRequest', 'slack', 'googleSheets', 'postgres', 'airtable', 'code', 'webhook', 'if', 'set', 'supabase'];
+  const nodes = nodeTypes.map(name => `nodes-base.${name}`);
+  return {
+    get_node: nodes.map(nodeType => ({ nodeType, detail: 'full', mode: 'info' })),
+    search_nodes: ['slack', 'google sheets', 'http request', 'database', 'webhook', 'airtable', 'postgres', 'send message', 'supabase', 'openai']
+      .map(query => ({ query, limit: 10, includeOperations: true })),
+    validate_node: nodes.map(nodeType => ({ nodeType, config: {}, profile: 'runtime' })),
+    validate_workflow: nodes.map((nodeType, i) => ({
+      workflow: {
+        name: `Compression benchmark ${i}`,
+        nodes: [
+          { id: 'start', name: 'Start', type: 'n8n-nodes-base.manualTrigger', typeVersion: 1, position: [0, 0], parameters: {} },
+          { id: 'action', name: 'Action', type: nodeType.replace('nodes-base.', 'n8n-nodes-base.'), typeVersion: 1, position: [200, 0], parameters: {} },
+        ],
+        connections: { Start: { main: [[{ node: 'Action', type: 'main', index: 0 }]] } },
+      },
+      options: { profile: 'runtime' },
+    })),
+  };
+}
+
+async function worker(checkout, backend) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'node-compression-bench-'));
+  const dbPath = path.join(dir, 'nodes.db');
+  copyFileSync(path.join(checkout, 'data/nodes.db'), dbPath);
+  process.env.NODE_DB_PATH = dbPath;
+  process.env.N8N_MCP_TELEMETRY_DISABLED = 'true';
+  process.env.LOG_LEVEL = 'error';
+  delete process.env.N8N_API_URL;
+  delete process.env.N8N_API_KEY;
+  delete process.env.MCP_MODE;
+  // Exercise the actual production fallback factory, including in the baseline
+  // where the sql.js factory was not exported. This worker has its own process.
+  if (backend === 'sql.js') {
+    const nativePath = require.resolve('better-sqlite3', { paths: [checkout] });
+    require(nativePath);
+    require.cache[nativePath].exports = function unavailableNativeAdapter() {
+      throw new Error('Native adapter disabled for sql.js benchmark');
+    };
+  }
+  const { N8NDocumentationMCPServer } = require(path.join(checkout, 'dist/mcp/server.js'));
+  const server = new N8NDocumentationMCPServer();
+  try {
+    await server.initialized;
+    assert.equal(server.db.constructor.name, backend === 'sql.js' ? 'SQLJSAdapter' : 'BetterSQLiteAdapter');
+    const results = {};
+    for (const [tool, cases] of Object.entries(corpus())) {
+      const call = async args => {
+        server.cache.clear();
+        return server.executeTool(tool, structuredClone(args));
+      };
+      const outputs = [];
+      for (const args of cases) outputs.push(await call(args));
+      for (let i = 0; i < 30; i++) await call(cases[i % cases.length]);
+      const measure = async cold => {
+        const samples = [];
+        for (let i = 0; i < Number(process.env.BENCH_ITERATIONS || 100); i++) {
+          // Deliberately reach into the new reader only in this benchmark.
+          // Baseline schemas are plain JSON and have no inflation cache.
+          if (cold) server.repository.schemaReader?.cache.clear();
+          const start = performance.now();
+          await call(cases[i % cases.length]);
+          samples.push(performance.now() - start);
+        }
+        samples.sort((a, b) => a - b);
+        return {
+          medianMs: samples[Math.floor(samples.length / 2)],
+          p95Ms: samples[Math.floor(samples.length * 0.95)],
+        };
+      };
+      const coldSchemaCache = await measure(true);
+      for (const args of cases) await call(args);
+      results[tool] = {
+        coldSchemaCache,
+        warmSchemaCache: await measure(false),
+        outputHash: createHash('sha256').update(JSON.stringify(outputs)).digest('hex'),
+      };
+    }
+    process.stdout.write(`${JSON.stringify(results)}\n`);
+  } finally {
+    await server.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function verifyCatalog(baseline, candidate) {
+  const Database = require(require.resolve('better-sqlite3', { paths: [candidate] }));
+  const before = new Database(path.join(baseline, 'data/nodes.db'), { readonly: true });
+  const after = new Database(path.join(candidate, 'data/nodes.db'), { readonly: true });
+  try {
+    process.stderr.write('Verifying catalog rows\n');
+    const rows = before.prepare('SELECT COUNT(*) AS count FROM nodes').get().count;
+    assert.equal(after.prepare('SELECT COUNT(*) AS count FROM nodes').get().count, rows);
+    const lookup = after.prepare('SELECT * FROM nodes WHERE node_type = ?');
+    const decode = row => ({ ...row, properties_schema: row.properties_schema === null ? null : JSON.parse(
+      row.properties_schema.startsWith('H4sI')
+        ? gunzipSync(Buffer.from(row.properties_schema, 'base64')).toString('utf8')
+        : row.properties_schema
+    ) });
+    for (const row of before.prepare('SELECT * FROM nodes ORDER BY node_type').iterate()) {
+      assert.deepEqual(decode(lookup.get(row.node_type)), decode(row),
+        `Every field of ${row.node_type} must remain semantically identical`);
+    }
+    process.stderr.write('Verifying SQLite integrity and FTS vocabulary\n');
+    for (const db of [before, after]) {
+      process.stderr.write('SQLite integrity check\n');
+      assert.deepEqual(db.prepare('PRAGMA integrity_check').all(), [{ integrity_check: 'ok' }]);
+      db.exec("CREATE VIRTUAL TABLE temp.node_vocab USING fts5vocab(main, nodes_fts, row)");
+    }
+    process.stderr.write('Comparing FTS vocabulary\n');
+    const expectedTerms = before.prepare('SELECT * FROM node_vocab ORDER BY term').iterate();
+    const actualTerms = after.prepare('SELECT * FROM node_vocab ORDER BY term').iterate();
+    try {
+      for (const expected of expectedTerms) {
+        const actual = actualTerms.next();
+        assert.equal(actual.done, false, `Missing FTS term: ${expected.term}`);
+        assert.deepEqual(actual.value, expected, `FTS vocabulary changed at term: ${expected.term}`);
+      }
+      assert.equal(actualTerms.next().done, true, 'Unexpected extra FTS terms');
+    } finally {
+      expectedTerms.return();
+      actualTerms.return();
+    }
+    return {
+      rowsVerified: rows,
+      beforeMiB: statSync(path.join(baseline, 'data/nodes.db')).size / 1024 / 1024,
+      afterMiB: statSync(path.join(candidate, 'data/nodes.db')).size / 1024 / 1024,
+      integrity: 'ok', ftsVocabulary: 'identical',
+    };
+  } finally {
+    before.close();
+    after.close();
+  }
+}
+
+function main(baseline, candidate) {
+  if (!baseline || !candidate) throw new Error('Usage: benchmark-node-compression.js BASELINE_CHECKOUT CANDIDATE_CHECKOUT');
+  baseline = path.resolve(baseline);
+  candidate = path.resolve(candidate);
+  const report = { node: process.version, platform: `${process.platform}/${process.arch}`, cpu: cpus()[0].model,
+    catalog: verifyCatalog(baseline, candidate), rounds: [] };
+  process.stderr.write('Catalog verification complete\n');
+  for (const backend of ['better-sqlite3', 'sql.js']) {
+    for (let round = 0; round < Number(process.env.BENCH_ROUNDS || 5); round++) {
+      const result = { backend, round };
+      const arms = round % 2 ? [['candidate', candidate], ['baseline', baseline]] : [['baseline', baseline], ['candidate', candidate]];
+      for (const [name, checkout] of arms) {
+        const child = spawnSync(process.execPath, [__filename, '--worker', checkout, backend], {
+          cwd: checkout, encoding: 'utf8', env: process.env, maxBuffer: 10 * 1024 * 1024, timeout: 120_000,
+        });
+        if (child.status !== 0) throw new Error(`${name}/${backend} failed: ${child.stderr}\n${child.stdout}`);
+        result[name] = JSON.parse(child.stdout.trim().split('\n').at(-1));
+      }
+      for (const tool of Object.keys(corpus())) {
+        assert.equal(result.baseline[tool].outputHash, result.candidate[tool].outputHash,
+          `${tool} responses changed on ${backend}`);
+      }
+      report.rounds.push(result);
+      process.stderr.write(`${backend} round ${round + 1} complete\n`);
+    }
+  }
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+}
+
+if (process.argv[2] === '--worker') {
+  worker(process.argv[3], process.argv[4]).catch(error => { console.error(error); process.exitCode = 1; });
+} else {
+  main(process.argv[2], process.argv[3]);
+}

--- a/src/database/compressed-json.ts
+++ b/src/database/compressed-json.ts
@@ -1,0 +1,37 @@
+import { gzipSync, gunzipSync } from 'node:zlib';
+import { LRUCache } from 'lru-cache';
+
+/** The same gzip + base64 text format used by node_versions and templates. */
+export function compressJson(value: unknown): string {
+  return gzipSync(JSON.stringify(value)).toString('base64');
+}
+
+/**
+ * Cache inflated JSON text rather than parsed objects: each caller still gets
+ * its own mutable schema, so validators cannot contaminate subsequent reads.
+ * Both the compressed key and decoded value count toward the memory bound.
+ */
+export class CompressedJsonReader {
+  private readonly cache: LRUCache<string, string>;
+
+  constructor(maxSize = 16 * 1024 * 1024) {
+    this.cache = new LRUCache<string, string>({
+      max: 256,
+      maxSize,
+      sizeCalculation: (value, key) => Buffer.byteLength(value) + Buffer.byteLength(key),
+    });
+  }
+
+  parse(stored: string): any {
+    if (!stored?.startsWith('H4sI')) return JSON.parse(stored);
+    let text = this.cache.get(stored);
+    if (text === undefined) {
+      text = gunzipSync(Buffer.from(stored, 'base64')).toString('utf8');
+      // Validate before caching; malformed JSON must never poison the cache.
+      const value = JSON.parse(text);
+      this.cache.set(stored, text);
+      return value;
+    }
+    return JSON.parse(text);
+  }
+}

--- a/src/database/database-adapter.ts
+++ b/src/database/database-adapter.ts
@@ -116,7 +116,7 @@ async function createBetterSQLiteAdapter(dbPath: string): Promise<DatabaseAdapte
 /**
  * Create sql.js adapter with persistence
  */
-async function createSQLJSAdapter(dbPath: string): Promise<DatabaseAdapter> {
+export async function createSQLJSAdapter(dbPath: string): Promise<DatabaseAdapter> {
   let initSqlJs;
   try {
     initSqlJs = require('sql.js');

--- a/src/database/node-repository.ts
+++ b/src/database/node-repository.ts
@@ -1,4 +1,4 @@
-import * as zlib from 'zlib';
+import { compressJson, CompressedJsonReader } from './compressed-json';
 import { DatabaseAdapter } from './database-adapter';
 import { ParsedNode, normalizeNodeVersion } from '../parsers/node-parser';
 import { SQLiteStorageService } from '../services/sqlite-storage-service';
@@ -25,6 +25,7 @@ export interface CommunityNodeFields {
 
 export class NodeRepository {
   private db: DatabaseAdapter;
+  private readonly schemaReader = new CompressedJsonReader();
   
   constructor(dbOrService: DatabaseAdapter | SQLiteStorageService) {
     if (dbOrService instanceof SQLiteStorageService) {
@@ -108,7 +109,7 @@ export class NodeRepository {
       node.hasToolVariant ? 1 : 0,
       node.version,
       node.documentation || null,
-      JSON.stringify(node.properties, null, 2),
+      compressJson(node.properties),
       JSON.stringify(node.operations, null, 2),
       JSON.stringify(node.credentials, null, 2),
       node.outputs ? JSON.stringify(node.outputs, null, 2) : null,
@@ -397,7 +398,7 @@ export class NodeRepository {
       toolVariantOf: row.tool_variant_of || null,
       hasToolVariant: Number(row.has_tool_variant) === 1,
       version: row.version,
-      properties: this.safeJsonParse(row.properties_schema, []),
+      properties: this.decompressJson(row.properties_schema, []),
       operations: this.safeJsonParse(row.operations, []),
       credentials: this.safeJsonParse(row.credentials_required, []),
       hasDocumentation: !!row.documentation,
@@ -883,7 +884,7 @@ export class NodeRepository {
       versionData.description || null,
       versionData.category || null,
       versionData.isCurrentMax ? 1 : 0,
-      versionData.propertiesSchema ? this.compressJson(versionData.propertiesSchema) : null,
+      versionData.propertiesSchema ? compressJson(versionData.propertiesSchema) : null,
       versionData.operations ? JSON.stringify(versionData.operations) : null,
       versionData.credentialsRequired ? JSON.stringify(versionData.credentialsRequired) : null,
       versionData.outputs ? JSON.stringify(versionData.outputs) : null,
@@ -1015,21 +1016,35 @@ export class NodeRepository {
   }
 
   /**
-   * Per-version schemas repeat most of the nodes table, so they are stored
-   * gzip-compressed and base64-encoded (the same layout templates use) to keep
-   * the bundled database small. Plain JSON is still accepted on read.
+   * Migrate legacy schemas, including preserved community nodes, in one
+   * transaction. Do not rewrite rows that are already compressed. Operations
+   * stay plain JSON because the external-content FTS5 index reads that column.
    */
-  private compressJson(value: unknown): string {
-    return zlib.gzipSync(JSON.stringify(value)).toString('base64');
+  compressNodeSchemas(): number {
+    return this.db.transaction(() => {
+      const rows = this.db.prepare(
+        'SELECT node_type, properties_schema FROM nodes WHERE properties_schema IS NOT NULL'
+      ).all() as Array<{ node_type: string; properties_schema: string }>;
+      let compressed = 0;
+      for (const row of rows) {
+        if (row.properties_schema.startsWith('H4sI')) continue;
+        // Parse strictly: a migration must fail without changing any rows if
+        // stored data is invalid, rather than silently replacing it with [].
+        try {
+          this.db.prepare('UPDATE nodes SET properties_schema = ? WHERE node_type = ?')
+            .run(compressJson(JSON.parse(row.properties_schema)), row.node_type);
+        } catch (error) {
+          throw new Error(`Could not compress schema for ${row.node_type}: ${(error as Error).message}`);
+        }
+        compressed++;
+      }
+      return compressed;
+    });
   }
 
   private decompressJson(stored: string, fallback: any): any {
-    const trimmed = stored.trimStart();
-    if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
-      return this.safeJsonParse(stored, fallback);
-    }
     try {
-      return JSON.parse(zlib.gunzipSync(Buffer.from(stored, 'base64')).toString('utf8'));
+      return this.schemaReader.parse(stored);
     } catch (error) {
       logger.warn('Failed to decompress stored schema', { error: (error as Error).message });
       return fallback;

--- a/src/database/schema-optimized.sql
+++ b/src/database/schema-optimized.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS nodes (
   is_versioned INTEGER DEFAULT 0,
   version TEXT,
   documentation TEXT,
-  properties_schema TEXT,
+  properties_schema TEXT, -- gzip + base64 JSON; legacy plain JSON accepted on read
   operations TEXT,
   credentials_required TEXT,
   -- New columns for source code storage

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS nodes (
   has_tool_variant INTEGER DEFAULT 0, -- For base nodes: 1 if Tool variant exists
   version TEXT,
   documentation TEXT,
-  properties_schema TEXT,
+  properties_schema TEXT, -- gzip + base64 JSON; legacy plain JSON accepted on read
   operations TEXT,
   credentials_required TEXT,
   outputs TEXT, -- JSON array of output definitions

--- a/src/scripts/compact-node-database.ts
+++ b/src/scripts/compact-node-database.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { createDatabaseAdapter, DatabaseAdapter } from '../database/database-adapter';
+import { NodeRepository } from '../database/node-repository';
+
+const MAX_DATABASE_BYTES = 80 * 1024 * 1024;
+
+/** Compact preserved rows as well as newly rebuilt nodes before publishing. */
+export function compactNodeDatabase(db: DatabaseAdapter): { compressed: number; bytes: number } {
+  const compressed = new NodeRepository(db).compressNodeSchemas();
+  db.exec('VACUUM');
+  // Query SQLite itself: sql.js persists its in-memory database on close, so
+  // stat-ing the file before close would report the previous size.
+  const { bytes } = db.prepare(
+    'SELECT page_count * page_size AS bytes FROM pragma_page_count(), pragma_page_size()'
+  ).get() as { bytes: number };
+  if (bytes >= MAX_DATABASE_BYTES) {
+    throw new Error(`Node database is ${(bytes / 1024 / 1024).toFixed(2)} MiB after VACUUM; must be under 80 MiB before publishing`);
+  }
+  return { compressed, bytes };
+}
+
+if (require.main === module) {
+  (async () => {
+    const db = await createDatabaseAdapter(process.env.NODE_DB_PATH || './data/nodes.db');
+    try {
+      const result = compactNodeDatabase(db);
+      console.log(`Compressed ${result.compressed} schemas; database is ${(result.bytes / 1024 / 1024).toFixed(2)} MiB after VACUUM`);
+    } finally {
+      db.close();
+    }
+  })().catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/src/scripts/rebuild-optimized.ts
+++ b/src/scripts/rebuild-optimized.ts
@@ -7,6 +7,7 @@ import { createDatabaseAdapter } from '../database/database-adapter';
 import { N8nNodeLoader } from '../loaders/node-loader';
 import { NodeParser } from '../parsers/node-parser';
 import { DocsMapper } from '../mappers/docs-mapper';
+import { compressJson } from '../database/compressed-json';
 import { NodeRepository } from '../database/node-repository';
 import { assertCoreNodesPresent } from './core-node-check';
 import * as fs from 'fs';
@@ -177,7 +178,7 @@ async function rebuildOptimized() {
         nodeData.isVersioned ? 1 : 0,
         nodeData.version,
         nodeData.documentation,
-        JSON.stringify(nodeData.properties),
+        compressJson(nodeData.properties),
         JSON.stringify(nodeData.operations),
         JSON.stringify(nodeData.credentialsRequired),
         nodeData.nodeSourceCode,

--- a/src/scripts/rebuild.ts
+++ b/src/scripts/rebuild.ts
@@ -10,6 +10,7 @@ import { DocsMapper } from '../mappers/docs-mapper';
 import { NodeRepository } from '../database/node-repository';
 import { ToolVariantGenerator } from '../services/tool-variant-generator';
 import { TemplateSanitizer } from '../utils/template-sanitizer';
+import { compactNodeDatabase } from './compact-node-database';
 import { assertCoreNodesPresent } from './core-node-check';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -215,10 +216,6 @@ async function rebuild() {
   console.log(`   Tool Variants: ${stats.toolVariants}`);
   console.log(`   Version rows: ${stats.versionRows}`);
 
-  // Deleting and re-inserting every core node leaves free pages behind;
-  // reclaim them so the committed file reflects its content.
-  db.exec('VACUUM');
-
   // Every node with version rows must mark exactly one current version
   const inconsistent = db.prepare(`
     SELECT node_type FROM node_versions GROUP BY node_type HAVING SUM(is_current_max) != 1
@@ -259,9 +256,13 @@ async function rebuild() {
     console.log('   No templates found in database');
   }
   
+  try {
+    const { compressed, bytes } = compactNodeDatabase(db);
+    console.log(`   Compressed ${compressed} preserved schemas; database: ${(bytes / 1024 / 1024).toFixed(2)} MiB`);
+  } finally {
+    db.close();
+  }
   console.log('\n✨ Rebuild complete!');
-  
-  db.close();
 }
 
 // Expected minimum based on n8n v1.123.4 AI-capable nodes

--- a/tests/integration/database/node-schema-compression.test.ts
+++ b/tests/integration/database/node-schema-compression.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { gunzipSync } from 'node:zlib';
+import { createDatabaseAdapter, createSQLJSAdapter, DatabaseAdapter } from '../../../src/database/database-adapter';
+import { NodeRepository } from '../../../src/database/node-repository';
+import { compactNodeDatabase } from '../../../src/scripts/compact-node-database';
+import { ParsedNode } from '../../../src/parsers/node-parser';
+
+const node: ParsedNode = {
+  nodeType: 'nodes-base.schemaCompression', packageName: 'n8n-nodes-base',
+  displayName: 'Schema Compression', description: 'Test catalog entry',
+  category: 'transform', style: 'programmatic', version: '1',
+  isAITool: true, isTrigger: false, isWebhook: false, isVersioned: false,
+  properties: [{ name: 'resource', type: 'options', options: [{ name: '文書', value: 'document' }] }],
+  operations: [{ name: 'uniquesearchoperation', displayName: 'Unique Search Operation' }],
+  credentials: [],
+};
+
+for (const backend of ['better-sqlite3', 'sql.js'] as const) {
+  describe(`node schema compression (${backend})`, () => {
+    let dir: string;
+    let db: DatabaseAdapter;
+    let repository: NodeRepository;
+    let closed: boolean;
+    const open = backend === 'sql.js' ? createSQLJSAdapter : createDatabaseAdapter;
+
+    beforeEach(async () => {
+      dir = mkdtempSync(path.join(tmpdir(), 'node-schema-compression-'));
+      db = await open(path.join(dir, 'nodes.db'));
+      closed = false;
+      // A missing native binding must not silently turn this into a fallback test.
+      expect(db.constructor.name).toBe(backend === 'sql.js' ? 'SQLJSAdapter' : 'BetterSQLiteAdapter');
+      let schema = readFileSync(path.join(__dirname, '../../..', 'src/database/schema.sql'), 'utf8');
+      if (backend === 'sql.js') {
+        // The shipped sql.js build has no FTS5, just as in normal fallback mode.
+        schema = schema.replace(/-- FTS5 full-text search index for nodes[\s\S]*?-- Templates table/, '-- Templates table');
+      }
+      db.exec(schema);
+      repository = new NodeRepository(db);
+    });
+
+    afterEach(() => {
+      if (!closed) db?.close();
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('stores compressed schemas with searchable plain operations and reads them losslessly', () => {
+      repository.saveNode(node);
+      const row = db.prepare('SELECT * FROM nodes WHERE node_type = ?').get(node.nodeType);
+      expect(JSON.parse(gunzipSync(Buffer.from(row.properties_schema, 'base64')).toString('utf8'))).toEqual(node.properties);
+      expect(JSON.parse(row.operations)).toEqual(node.operations);
+      expect(repository.getNode(node.nodeType).properties).toEqual(node.properties);
+      expect(repository.getNodeOperations(node.nodeType)).toEqual(node.operations);
+      expect(repository.getNodesByCategory('transform')[0].properties).toEqual(node.properties);
+    });
+
+    it('reads old plain schemas and returns fresh objects even after cache hits', () => {
+      repository.saveNode(node);
+      repository.getNode(node.nodeType).properties[0].options[0].value = 'mutated';
+      expect(repository.getNode(node.nodeType).properties).toEqual(node.properties);
+      db.prepare('UPDATE nodes SET properties_schema = ? WHERE node_type = ?')
+        .run(JSON.stringify([{ name: 'legacy' }]), node.nodeType);
+      expect(repository.getNode(node.nodeType).properties).toEqual([{ name: 'legacy' }]);
+    });
+
+    it('does not serve stale schemas after upserts or rolled-back writes', () => {
+      repository.saveNode(node);
+      repository.getNode(node.nodeType);
+      expect(() => repository.transaction(() => {
+        repository.saveNode({ ...node, properties: [{ name: 'rolledBack' }] });
+        expect(repository.getNode(node.nodeType).properties).toEqual([{ name: 'rolledBack' }]);
+        throw new Error('rollback');
+      })).toThrow('rollback');
+      expect(repository.getNode(node.nodeType).properties).toEqual(node.properties);
+      repository.saveNode({ ...node, properties: [{ name: 'updated' }] });
+      expect(repository.getNode(node.nodeType).properties).toEqual([{ name: 'updated' }]);
+    });
+
+    it('migrates core and preserved community schemas once and persists them after VACUUM', async () => {
+      repository.saveNode(node);
+      repository.saveNode({ ...node, nodeType: 'community.node', isCommunity: true });
+      db.prepare('UPDATE nodes SET properties_schema = ?').run(JSON.stringify(node.properties));
+      const result = compactNodeDatabase(db);
+      expect(result.compressed).toBe(2);
+      expect(compactNodeDatabase(db).compressed).toBe(0);
+      db.close();
+      closed = true;
+      expect(statSync(path.join(dir, 'nodes.db')).size).toBe(result.bytes);
+      db = await open(path.join(dir, 'nodes.db'));
+      closed = false;
+      repository = new NodeRepository(db);
+      expect(repository.getNode(node.nodeType).properties).toEqual(node.properties);
+      expect(repository.getNode('community.node').properties).toEqual(node.properties);
+      expect(db.prepare('PRAGMA integrity_check').get()).toEqual({ integrity_check: 'ok' });
+    });
+
+    it('rolls back the whole migration if a legacy schema is invalid', () => {
+      repository.saveNode(node);
+      repository.saveNode({ ...node, nodeType: 'community.invalid', isCommunity: true });
+      db.prepare('UPDATE nodes SET properties_schema = ? WHERE node_type = ?').run('[]', node.nodeType);
+      db.prepare('UPDATE nodes SET properties_schema = ? WHERE node_type = ?').run('broken', 'community.invalid');
+      expect(() => repository.compressNodeSchemas()).toThrow('community.invalid');
+      expect(db.prepare('SELECT properties_schema FROM nodes WHERE node_type = ?').get(node.nodeType).properties_schema).toBe('[]');
+    });
+
+    it('retains fallback behavior for null and malformed stored schemas', () => {
+      repository.saveNode(node);
+      for (const stored of [null, 'broken', 'H4sIbroken']) {
+        db.prepare('UPDATE nodes SET properties_schema = ? WHERE node_type = ?').run(stored, node.nodeType);
+        expect(repository.getNode(node.nodeType).properties).toEqual(stored === null ? null : []);
+      }
+    });
+
+    if (backend === 'better-sqlite3') {
+      it('rejects a catalog that still exceeds the size budget after VACUUM', () => {
+        db.exec('CREATE TABLE padding (payload BLOB)');
+        db.exec('INSERT INTO padding VALUES (zeroblob(80 * 1024 * 1024))');
+        expect(() => compactNodeDatabase(db)).toThrow('must be under 80 MiB before publishing');
+      });
+
+      it('preserves operation-only FTS matches across migration and index rebuild', () => {
+        repository.saveNode(node);
+        db.prepare('UPDATE nodes SET properties_schema = ?').run(JSON.stringify(node.properties));
+        const search = () => db.prepare('SELECT node_type FROM nodes_fts WHERE nodes_fts MATCH ?')
+          .all('operations:uniquesearchoperation');
+        expect(search()).toEqual([{ node_type: node.nodeType }]);
+        compactNodeDatabase(db);
+        expect(search()).toEqual([{ node_type: node.nodeType }]);
+        db.prepare("INSERT INTO nodes_fts(nodes_fts) VALUES('rebuild')").run();
+        expect(search()).toEqual([{ node_type: node.nodeType }]);
+      });
+    }
+  });
+}

--- a/tests/unit/database/compressed-json.test.ts
+++ b/tests/unit/database/compressed-json.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as zlib from 'node:zlib';
+import { compressJson, CompressedJsonReader } from '../../../src/database/compressed-json';
+
+vi.mock('node:zlib', async importOriginal => {
+  const actual = await importOriginal<typeof import('node:zlib')>();
+  return { ...actual, gunzipSync: vi.fn(actual.gunzipSync) };
+});
+
+describe('CompressedJsonReader', () => {
+  it.each([[], [{ name: '名', options: [{ value: '🚀' }] }], { nested: [null, true, 1] }, null])(
+    'round-trips JSON without changing its value: %j', value => {
+      expect(new CompressedJsonReader().parse(compressJson(value))).toEqual(value);
+    }
+  );
+
+  it.each(['[]', '  {"properties": []}', 'null', '0', 'true', '"text"'])(
+    'continues to accept legacy plain JSON: %s', stored => {
+      expect(new CompressedJsonReader().parse(stored)).toEqual(JSON.parse(stored));
+      expect(zlib.gunzipSync).not.toHaveBeenCalled();
+    }
+  );
+
+  it('inflates once but returns independent nested objects on every read', () => {
+    const reader = new CompressedJsonReader();
+    const stored = compressJson([{ options: [{ value: 'original' }] }]);
+    reader.parse(stored)[0].options[0].value = 'mutated';
+    expect(reader.parse(stored)).toEqual([{ options: [{ value: 'original' }] }]);
+    expect(zlib.gunzipSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts the least recently read schema when the byte budget is exceeded', () => {
+    const values = ['first', 'second', 'third'].map(name => JSON.stringify({ name }));
+    const stored = values.map(value => compressJson(JSON.parse(value)));
+    const reader = new CompressedJsonReader(2 * Math.max(...stored.map((key, i) =>
+      Buffer.byteLength(key) + Buffer.byteLength(values[i]))));
+    reader.parse(stored[0]);
+    reader.parse(stored[1]);
+    reader.parse(stored[0]); // keep first, evict second
+    reader.parse(stored[2]);
+    reader.parse(stored[0]);
+    expect(zlib.gunzipSync).toHaveBeenCalledTimes(3);
+    reader.parse(stored[1]);
+    expect(zlib.gunzipSync).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not cache a schema larger than the byte budget', () => {
+    const reader = new CompressedJsonReader(10);
+    const stored = compressJson([{ description: 'large'.repeat(100) }]);
+    expect(reader.parse(stored)).toEqual(reader.parse(stored));
+    expect(zlib.gunzipSync).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(['H4sIbroken', 'invalid json', zlib.gzipSync('not json').toString('base64')])(
+    'rejects invalid stored data: %s', stored => {
+      expect(() => new CompressedJsonReader().parse(stored)).toThrow();
+    }
+  );
+});

--- a/tests/unit/database/node-repository-core.test.ts
+++ b/tests/unit/database/node-repository-core.test.ts
@@ -1,3 +1,4 @@
+import { gzipSync, gunzipSync } from 'node:zlib';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NodeRepository } from '../../../src/database/node-repository';
 import { DatabaseAdapter, PreparedStatement, RunResult } from '../../../src/database/database-adapter';
@@ -116,7 +117,7 @@ describe('NodeRepository - Core Functionality', () => {
         0, // hasToolVariant
         '1.0',
         'HTTP Request documentation',
-        JSON.stringify([{ name: 'url', type: 'string' }], null, 2),
+        gzipSync(JSON.stringify([{ name: 'url', type: 'string' }])).toString('base64'),
         JSON.stringify([{ name: 'execute', displayName: 'Execute' }], null, 2),
         JSON.stringify([{ name: 'httpBasicAuth' }], null, 2),
         null, // outputs
@@ -404,7 +405,7 @@ describe('NodeRepository - Core Functionality', () => {
       const runCall = stmt?.run.mock.lastCall;
       const savedProperties = runCall?.[15]; // was 12, now 15 after 3 new columns
 
-      expect(savedProperties).toBe(JSON.stringify(largeProperties, null, 2));
+      expect(JSON.parse(gunzipSync(Buffer.from(savedProperties!, 'base64')).toString('utf8'))).toEqual(largeProperties);
     });
     
     it('should handle boolean conversion for integer fields', () => {

--- a/tests/unit/database/node-repository-outputs.test.ts
+++ b/tests/unit/database/node-repository-outputs.test.ts
@@ -1,3 +1,4 @@
+import { gzipSync } from 'node:zlib';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NodeRepository } from '@/database/node-repository';
 import { DatabaseAdapter } from '@/database/database-adapter';
@@ -88,7 +89,7 @@ describe('NodeRepository - Outputs Handling', () => {
         0, // hasToolVariant
         '3', // version
         null, // documentation
-        JSON.stringify([], null, 2), // properties
+        gzipSync('[]').toString('base64'), // properties
         JSON.stringify([], null, 2), // operations
         JSON.stringify([], null, 2), // credentials
         JSON.stringify(outputs, null, 2), // outputs

--- a/tests/unit/services/property-filter-dynamic-options.test.ts
+++ b/tests/unit/services/property-filter-dynamic-options.test.ts
@@ -1,3 +1,4 @@
+import { CompressedJsonReader } from '../../../src/database/compressed-json';
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -79,7 +80,7 @@ describe('PropertyFilter essentials for nodes-base.slack (real database)', () =>
     try {
       const row = db.prepare("SELECT properties_schema FROM nodes WHERE node_type = 'nodes-base.slack'").get() as { properties_schema: string } | undefined;
       expect(row).toBeDefined();
-      const props = JSON.parse(row!.properties_schema);
+      const props = new CompressedJsonReader().parse(row!.properties_schema);
       const schemaNames = new Set(props.map((p: any) => p.name));
 
       // ESSENTIAL_PROPERTIES is a private static field; reach in for this


### PR DESCRIPTION
## Problem and result

The bundled catalog was 98.30 MiB after VACUUM, leaving little room for the next n8n update. This compresses `nodes.properties_schema` as gzip/base64 and brings the committed database to **70.48 MiB (28.3% smaller)** without removing nodes or documentation. All 2,691 node rows remain semantically identical, SQLite integrity checks pass, and the complete FTS vocabulary and document frequencies match the original.

Closes #1067.

## Approach

- Accept both legacy plain JSON and compressed schemas. Cache inflated JSON text with a 16 MiB / 256-entry LRU and parse fresh objects for each caller, preserving mutation isolation and transaction rollback behavior.
- Keep `operations` as plain JSON: it is an indexed external-content FTS5 column, so compressing it would change search/index-rebuild semantics. Schema compression alone meets the requested size target.
- Compress new writes and transactionally migrate preserved community rows. `npm run rebuild` and `npm run db:compact` VACUUM the result and reject catalogs at or above 80 MiB. The update guide includes the final compaction check.
- Adapt the read-only schema audit and optimized writer to the new representation. The bundled binary is a lossless migration of the existing catalog; no unrelated regenerated node/documentation changes are included.

## Validation

- Typecheck and production build pass.
- 30 new regression cases cover compression, plain compatibility, bounded cache eviction, independent returned objects, upserts/rollback, persisted migrations, malformed input, the size gate, and operation-only FTS search before/after index rebuild.
- Unit suite: **6,298 passed, 35 skipped**. Coverage run including the new adapter integration cases: **6,312 passed, 35 skipped**; lines/statements 84.90%, branches 86.23%, functions 85.99%.
- Offline integration suite: **525 passed, 47 skipped**. Live n8n tests were not run.
- A full `npm run rebuild` on a separate catalog copy completed at **70.07 MiB**, including migration of 1,859 preserved community schemas.
- Runtime responses were checked using the actual bundled database with both better-sqlite3 and sql.js. Migration/write tests cover both adapters, using an FTS-free schema for sql.js. Migrating/rebuilding the bundled FTS catalog requires better-sqlite3, since the shipped sql.js build has no FTS5.

## Performance

`scripts/benchmark-node-compression.js` compares two built checkouts using temporary catalog copies, alternating process order over five rounds. Each tool has ten input cases and 100 timed calls per round/arm/backend. Response caches are cleared per call; schema-cache hits and misses are measured separately. Every response hash matches. Baseline is `c4a2f69`, measured on Apple M4 / Node 22.23.2.

Median warm-cache latency across rounds, in milliseconds:

| Backend | Tool | Before | After |
| --- | --- | ---: | ---: |
| better-sqlite3 | get_node | 0.411 | 0.342 |
| better-sqlite3 | search_nodes | 0.692 | 0.308 |
| better-sqlite3 | validate_node | 0.169 | 0.161 |
| better-sqlite3 | validate_workflow | 0.373 | 0.362 |
| sql.js | get_node | 0.498 | 0.408 |
| sql.js | search_nodes | 1.971 | 1.658 |
| sql.js | validate_node | 0.217 | 0.185 |
| sql.js | validate_workflow | 0.481 | 0.434 |

Cold schema-cache misses add about 10 microseconds for native `validate_node` (0.172→0.182 ms) and 19 microseconds for native `validate_workflow` (0.380→0.399 ms). Cold sql.js `validate_workflow` adds about 5 microseconds (0.497→0.502 ms); the remaining measured cold medians were lower. These are local corpus measurements, not a guarantee for every node/workload.

## CI status

The Docker publication jobs stop at `docker/login-action` with `Username and password required`, before building an image ([Docker workflow](https://github.com/czlonkowski/n8n-mcp/actions/runs/34027624963), [n8n image workflow](https://github.com/czlonkowski/n8n-mcp/actions/runs/34027625034)). Fork PRs do not receive those publishing credentials. The [Test Suite](https://github.com/czlonkowski/n8n-mcp/actions/runs/34027625027) is green, including unit coverage, the Docker test-image build, offline integration, lint/type checks, and CJS runtime checks. The fresh-install dependency check, secret scan, and Codecov patch check also pass.

Conceived by Romuald Członkowski - https://aiadvisors.pl/en
