### PR TITLE
docs: document private network and self-signed TLS configurations

### DIFF
--- a/docs/N8N_DEPLOYMENT.md
+++ b/docs/N8N_DEPLOYMENT.md
@@ -60,7 +60,7 @@ export N8N_MODE=true
 export MCP_MODE=http                       # Required for HTTP mode
 export N8N_API_URL=http://localhost:5678  # Your n8n instance URL
 export N8N_API_KEY=your-api-key-here       # Your n8n API key
-export WEBHOOK_SECURITY_MODE=moderate      # Required when N8N_API_URL is localhost or RFC1918
+export WEBHOOK_SECURITY_MODE=moderate      # Required when N8N_API_URL is localhost (use 'permissive' for RFC1918)
 export MCP_AUTH_TOKEN=test-token-minimum-32-chars-long
 export AUTH_TOKEN=test-token-minimum-32-chars-long  # Same value as MCP_AUTH_TOKEN
 export PORT=3001
@@ -87,7 +87,7 @@ curl http://localhost:3001/mcp
 | `MCP_MODE` | Yes | Enables HTTP mode for n8n MCP Client | `http` |
 | `N8N_API_URL` | Yes* | URL of your n8n instance | `http://localhost:5678` |
 | `N8N_API_KEY` | Yes* | n8n API key for workflow management | `n8n_api_xxx...` |
-| `WEBHOOK_SECURITY_MODE` | No | SSRF gate (`strict` default, `moderate`, `permissive`). Set to `moderate` when `N8N_API_URL` is localhost or an RFC1918 host on the same network. | `moderate` |
+| `WEBHOOK_SECURITY_MODE` | No | SSRF gate (`strict` default, `moderate`, `permissive`). Set to `moderate` when `N8N_API_URL` is localhost. Set to `permissive` when `N8N_API_URL` is an RFC1918 host (e.g. `192.168.x.x`, `10.x.x.x`). | `moderate` |
 | `MCP_AUTH_TOKEN` | Yes | Authentication token for MCP requests (min 32 chars) | `secure-random-32-char-token` |
 | `AUTH_TOKEN` | Yes | **MUST match MCP_AUTH_TOKEN exactly** | `secure-random-32-char-token` |
 | `PORT` | No | Port for the HTTP server | `3000` (default) |

--- a/docs/SECURITY_HARDENING.md
+++ b/docs/SECURITY_HARDENING.md
@@ -11,6 +11,7 @@ Whoever has access to the MCP session effectively has the same privileges as the
 | `AUTH_TOKEN` | Required for HTTP mode. Use a strong random value (min 32 chars). | `openssl rand -base64 32` |
 | `DISABLED_TOOLS` | Comma-separated list of MCP tools to disable. | `n8n_create_workflow,n8n_test_workflow` |
 | `WEBHOOK_SECURITY_MODE` | SSRF gate applied to webhook trigger URLs, the n8n API client (`N8N_API_URL`), and per-request URLs from the `x-n8n-url` header. Default `strict` blocks localhost, RFC1918, other IANA special-purpose ranges that are not globally reachable (including `100.64.0.0/10` shared address space, multicast, and broadcast), and cloud metadata endpoints. Use `moderate` to allow localhost while still blocking the rest; "localhost" there means every plain localhost spelling (loopback literals plus `0.0.0.0`), so `http://localhost:5678`, `http://127.0.0.1:5678` (any address in `127.0.0.0/8`), `http://0.0.0.0:5678` and `http://[::1]:5678` are all accepted. `permissive` allows all of them except metadata; only suitable when n8n-mcp and n8n share a private Docker/Kubernetes network, or when your n8n instance is reachable only over a CGNAT-range overlay such as Tailscale. Cloud metadata endpoints (169.254.169.254, metadata.google.internal, etc.) are blocked in all modes. | `moderate` |
+| `NODE_TLS_REJECT_UNAUTHORIZED` | Node.js runtime flag. Setting `0` disables TLS certificate verification for self-signed certificates in private testing/homelab environments. **Do not use in production.** | `0` |
 
 ## Restricting Workflow Capabilities
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -215,6 +215,63 @@ If you're running n8n locally (e.g., `http://localhost:5678` or Docker), you nee
 
 > ⚠️ **Important:** Set `WEBHOOK_SECURITY_MODE=moderate` whenever `N8N_API_URL` points at localhost or `host.docker.internal`. The same SSRF gate covers webhook triggers and the n8n API client; default `strict` mode rejects loopback addresses for both. `moderate` allows localhost while still blocking RFC1918 private networks and cloud metadata.
 
+### Private Network Instances & Self-Signed Certificates
+
+If your n8n instance is hosted on a private network (e.g., a local Proxmox LXC container, home server, or VM with an RFC1918 address like `192.168.x.x`, `10.x.x.x`, or `172.16-31.x.x`), `WEBHOOK_SECURITY_MODE=moderate` is not sufficient because it continues to block private IP subnets.
+
+To allow connections to private-network instances, use `WEBHOOK_SECURITY_MODE=permissive`.
+
+Additionally, if your private n8n instance serves HTTPS with a **self-signed certificate**, Node.js will reject the TLS handshake by default with `DEPTH_ZERO_SELF_SIGNED_CERT` or `UNABLE_TO_VERIFY_LEAF_SIGNATURE`. You can set `NODE_TLS_REJECT_UNAUTHORIZED=0` to permit self-signed certificates in your local test environment.
+
+#### Claude Code / Claude Desktop Configuration (`npx` / `node`)
+
+```json
+{
+  "mcpServers": {
+    "n8n-mcp": {
+      "command": "npx",
+      "args": ["n8n-mcp"],
+      "env": {
+        "MCP_MODE": "stdio",
+        "LOG_LEVEL": "error",
+        "DISABLE_CONSOLE_OUTPUT": "true",
+        "N8N_API_URL": "https://192.168.1.50:5678",
+        "N8N_API_KEY": "your-api-key",
+        "WEBHOOK_SECURITY_MODE": "permissive",
+        "NODE_TLS_REJECT_UNAUTHORIZED": "0"
+      }
+    }
+  }
+}
+```
+
+#### Docker Configuration
+
+```json
+{
+  "mcpServers": {
+    "n8n-mcp": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm", "--init",
+        "-e", "MCP_MODE=stdio",
+        "-e", "LOG_LEVEL=error",
+        "-e", "DISABLE_CONSOLE_OUTPUT=true",
+        "-e", "N8N_API_URL=https://192.168.1.50:5678",
+        "-e", "N8N_API_KEY=your-api-key",
+        "-e", "WEBHOOK_SECURITY_MODE=permissive",
+        "-e", "NODE_TLS_REJECT_UNAUTHORIZED=0",
+        "ghcr.io/czlonkowski/n8n-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+> ⚠️ **Security Warning:**
+> - `WEBHOOK_SECURITY_MODE=permissive` allows loopback and RFC1918 private subnets (cloud metadata endpoints like `169.254.169.254` remain blocked).
+> - `NODE_TLS_REJECT_UNAUTHORIZED=0` disables TLS certificate verification globally for the Node.js process. Only use this for internal lab, self-hosted testing, or non-production environments.
+
 **Important:** The `-i` flag is required for MCP stdio communication.
 
 > 🔧 If you encounter any issues with Docker, check our [Docker Troubleshooting Guide](./DOCKER_TROUBLESHOOTING.md).


### PR DESCRIPTION
## Description

This PR addresses and resolves #832 by documenting how to connect `n8n-mcp` to self-hosted n8n instances on private networks (RFC1918) and instances using self-signed TLS certificates.

### Changes Included:
- **`docs/SELF_HOSTING.md`**:
  - Clarified that `WEBHOOK_SECURITY_MODE=moderate` only permits loopback addresses and still blocks RFC1918 subnets (`192.168.x.x`, `10.x.x.x`, etc.).
  - Documented `WEBHOOK_SECURITY_MODE=permissive` for private networks (e.g. Proxmox LXC containers, VMs, home servers).
  - Documented `NODE_TLS_REJECT_UNAUTHORIZED=0` for allowing self-signed certificates in non-production/lab environments.
  - Added full configuration examples for both Claude Code / Claude Desktop (`npx` / `node`) and Docker.
  - Added appropriate security warnings regarding `NODE_TLS_REJECT_UNAUTHORIZED=0`.
- **`docs/N8N_DEPLOYMENT.md`**:
  - Corrected description of `WEBHOOK_SECURITY_MODE` in the setup commands and reference table to clarify that `moderate` is for loopback/localhost and `permissive` is required for RFC1918.
- **`docs/SECURITY_HARDENING.md`**:
  - Added `NODE_TLS_REJECT_UNAUTHORIZED` to the hardening table.

Fixes #832

Conceived by Romuald Członkowski - https://aiadvisors.pl/en