### PR TITLE
fix: fall back to summary for successful error-mode requests

### DIFF
--- a/src/services/error-execution-processor.ts
+++ b/src/services/error-execution-processor.ts
@@ -136,7 +136,10 @@ function extractPrimaryError(
 ): ErrorAnalysis['primaryError'] {
   // Error info from resultData.error
   const errorNode = error?.node as Record<string, unknown> | undefined;
-  const nodeName = (errorNode?.name as string) || lastNode || 'Unknown';
+  const failedNode = !error
+    ? Object.keys(runData).find(name => getRunError(runData[name]))
+    : undefined;
+  const nodeName = (errorNode?.name as string) || failedNode || lastNode || 'Unknown';
 
   // Also check runData for node-level errors
   const nodeRunData = runData[nodeName];

--- a/src/services/execution-processor.ts
+++ b/src/services/execution-processor.ts
@@ -350,7 +350,12 @@ export function filterExecutionData(
   options: ExecutionFilterOptions,
   workflow?: Workflow
 ): FilteredExecutionResponse {
-  const mode = options.mode || 'summary';
+  const mode = options.mode === 'error'
+    && execution.status === ExecutionStatus.SUCCESS
+    && !execution.data?.resultData?.error
+    && !Object.values(execution.data?.resultData?.runData || {}).some(getRunError)
+    ? 'summary'
+    : options.mode || 'summary';
 
   // Validate and bound itemsLimit
   let itemsLimit = options.itemsLimit !== undefined ? options.itemsLimit : 2;

--- a/tests/unit/services/execution-processor.test.ts
+++ b/tests/unit/services/execution-processor.test.ts
@@ -508,8 +508,9 @@ describe('ExecutionProcessor - Edge Cases', () => {
       stoppedAt: '2024-01-01T10:00:05.000Z',
     };
 
-    const result = filterExecutionData(execution, { mode: 'summary' });
+    const result = filterExecutionData(execution, { mode: 'error' });
 
+    expect(result.mode).toBe('summary');
     expect(result.summary?.totalNodes).toBe(0);
     expect(result.summary?.executedNodes).toBe(0);
   });

--- a/tests/unit/services/execution-processor.test.ts
+++ b/tests/unit/services/execution-processor.test.ts
@@ -443,6 +443,24 @@ describe('ExecutionProcessor - Modes', () => {
     expect(result.nodes?.['HTTP Request']).toBeDefined();
   });
 
+  it('should keep error mode for successful executions with a node error', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'Failed Node': createNodeData(1, true),
+        'Later Node': createNodeData(1),
+      },
+    });
+    execution.data!.resultData!.lastNodeExecuted = 'Later Node';
+
+    const result = filterExecutionData(execution, { mode: 'error' });
+
+    expect(result.mode).toBe('error');
+    expect(result.errorInfo?.primaryError).toMatchObject({
+      nodeName: 'Failed Node',
+      message: 'Node error',
+    });
+  });
+
   it('should handle filtered mode', () => {
     const execution = createMockExecution({
       nodeData: {

--- a/tests/unit/services/execution-processor.test.ts
+++ b/tests/unit/services/execution-processor.test.ts
@@ -429,6 +429,20 @@ describe('ExecutionProcessor - Modes', () => {
     expect(result.nodes?.['HTTP Request']?.data?.metadata.itemsShown).toBe(2);
   });
 
+  it('should fall back to summary mode for successful executions requested in error mode', () => {
+    const execution = createMockExecution({
+      nodeData: {
+        'HTTP Request': createNodeData(2),
+      },
+    });
+
+    const result = filterExecutionData(execution, { mode: 'error' });
+
+    expect(result.mode).toBe('summary');
+    expect(result.errorInfo).toBeUndefined();
+    expect(result.nodes?.['HTTP Request']).toBeDefined();
+  });
+
   it('should handle filtered mode', () => {
     const execution = createMockExecution({
       nodeData: {


### PR DESCRIPTION
## Context

`n8n_executions` passed successful executions into the error processor when callers requested `mode=error`. With no error to inspect, the processor fell back to the last node and reported an invented `Unknown error`.

Fixes #1065

## Changes

- Fall back to the existing summary mode only when a successful execution has neither a top-level error nor a node-run error.
- Reuse the existing multi-run error lookup so genuine node errors still enter error mode.
- Select the actual failed node when a later successful node was recorded as last executed.
- Add regressions for clean successful executions and successful executions with node-run errors.

## User impact

Successful executions requested in error mode now return their normal summary instead of identifying the last node as failed. Successful executions with node-run errors still report the actual failed node.

## Verification

- `npm run lint` — passed.
- `npm run build` — passed.
- GitHub test, CJS runtime, result publishing, Codecov, and secret scanning — passed. The two Docker publishing workflows stop at registry login because fork pull requests do not receive repository secrets; no image build runs.
- `npm test -- --run --coverage.enabled=false tests/unit/services/execution-processor.test.ts tests/unit/services/error-execution-processor.test.ts` — 2 files passed, 101 tests passed.
- `npm run test:unit -- --coverage.enabled false` — attempted; the touched suite passed, while the broader run retained Windows/base failures involving FTS5, native SQLite bindings, POSIX shell assumptions, symlink privileges, path expectations, and a timing threshold. Representative FTS5 and symlink failures reproduced on clean `upstream/main`.
- `npm ci --ignore-scripts` — blocked on clean `upstream/main` because `package.json` and `package-lock.json` are out of sync; dependencies were installed without lockfile updates for verification.

Conceived by Romuald Członkowski - https://aiadvisors.pl/en